### PR TITLE
fix: Add thread flag when running tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,8 +66,9 @@ jobs:
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
 
   msrv:
-    if: ${{ github.event.pull_request.draft == false && github.event_name != 'push' && (needs.changed_files.outputs.changed-rust-files
-      == 'true' || needs.changed_files.outputs.changed-lockfile-files == 'true') }}
+    if: ${{ github.event.pull_request.draft == false && github.event_name != 'push'
+      && (needs.changed_files.outputs.changed-rust-files == 'true' || needs.changed_files.outputs.changed-lockfile-files
+      == 'true') }}
     runs-on: ubuntu-latest
     needs: changed_files
     steps:
@@ -91,8 +92,8 @@ jobs:
         run: cargo hack check --feature-powerset --locked --rust-version --all-targets
 
   lockfile:
-    if: ${{ github.event.pull_request.draft == false && github.event_name != 'push' && needs.changed_files.outputs.changed-lockfile-files
-      == 'true' }}
+    if: ${{ github.event.pull_request.draft == false && github.event_name != 'push'
+      && needs.changed_files.outputs.changed-lockfile-files == 'true' }}
     needs: changed_files
     runs-on: ubuntu-latest
     steps:
@@ -113,8 +114,8 @@ jobs:
         run: cargo update --locked
 
   rustfmt:
-    if: ${{ github.event.pull_request.draft == false && github.event_name != 'push' && needs.changed_files.outputs.changed-rust-files
-      == 'true' }}
+    if: ${{ github.event.pull_request.draft == false && github.event_name != 'push'
+      && needs.changed_files.outputs.changed-rust-files == 'true' }}
     needs: changed_files
     runs-on: ubuntu-latest
     steps:
@@ -135,8 +136,8 @@ jobs:
         run: cargo fmt --all -- --check
 
   clippy:
-    if: ${{ github.event.pull_request.draft == false && github.event_name != 'push' && needs.changed_files.outputs.changed-rust-files
-      == 'true' }}
+    if: ${{ github.event.pull_request.draft == false && github.event_name != 'push'
+      && needs.changed_files.outputs.changed-rust-files == 'true' }}
     needs: changed_files
     runs-on: ubuntu-latest
     steps:
@@ -227,7 +228,7 @@ jobs:
         run: cargo hack llvm-cov --no-report --feature-powerset --locked --all-targets
 
       - name: Cargo llvm-cov
-        run: cargo llvm-cov --locked --lcov --output-path lcov.info
+        run: RUST_TEST_THREADS=1 cargo llvm-cov --locked --lcov --output-path lcov.info
 
       - name: Upload to CodeCov
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3  # v5.3.1
@@ -240,7 +241,8 @@ jobs:
   docker-scan:
     runs-on: ubuntu-latest
     needs: [changed_files, ci]
-    if: ${{ needs.changed_files.outputs.changed-docker-files == 'true' && github.event_name != 'push' }}
+    if: ${{ needs.changed_files.outputs.changed-docker-files == 'true' && github.event_name
+      != 'push' }}
     steps:
       # Checkout the repository
       - name: Checkout Code


### PR DESCRIPTION
# Summary

Tests may arbitrarily fail when running in parallel.

- Added a flag to ensure tests are running single-threaded.

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
