### PR TITLE
chore: Refactor notifiers to re-use webhook notifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.6",
+ "winnow 0.7.7",
 ]
 
 [[package]]
@@ -921,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.6",
+ "winnow 0.7.7",
 ]
 
 [[package]]
@@ -1766,9 +1766,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -6324,7 +6324,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.6",
+ "winnow 0.7.7",
 ]
 
 [[package]]
@@ -7080,9 +7080,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]

--- a/src/services/notification/discord.rs
+++ b/src/services/notification/discord.rs
@@ -81,9 +81,6 @@ impl DiscordNotifier {
 		title: String,
 		body_template: String,
 	) -> Result<Self, Box<NotificationError>> {
-		let mut headers = HashMap::new();
-		headers.insert("Content-Type".to_string(), "application/json".to_string());
-
 		// Set default Discord payload fields
 		let mut payload_fields = HashMap::new();
 		payload_fields.insert("username".to_string(), serde_json::json!(null));
@@ -97,7 +94,7 @@ impl DiscordNotifier {
 				body_template,
 				method: Some("POST".to_string()),
 				secret: None,
-				headers: Some(headers),
+				headers: None,
 				payload_fields: Some(payload_fields),
 			})?,
 		})

--- a/src/services/notification/discord.rs
+++ b/src/services/notification/discord.rs
@@ -4,25 +4,18 @@
 //! via incoming webhooks, supporting message templates with variable substitution.
 
 use async_trait::async_trait;
-use reqwest::Client;
 use serde::Serialize;
+use serde_json;
 use std::collections::HashMap;
 
 use crate::{
 	models::TriggerTypeConfig,
-	services::notification::{NotificationError, Notifier},
+	services::notification::{NotificationError, Notifier, WebhookConfig, WebhookNotifier},
 };
 
 /// Implementation of Discord notifications via webhooks
 pub struct DiscordNotifier {
-	/// Discord webhook URL for message delivery
-	url: String,
-	/// Title to display in the message
-	title: String,
-	/// Message template with variable placeholders
-	body_template: String,
-	/// HTTP client for webhook requests
-	client: Client,
+	inner: WebhookNotifier,
 }
 
 /// Represents a field in a Discord embed message
@@ -88,11 +81,25 @@ impl DiscordNotifier {
 		title: String,
 		body_template: String,
 	) -> Result<Self, Box<NotificationError>> {
+		let mut headers = HashMap::new();
+		headers.insert("Content-Type".to_string(), "application/json".to_string());
+
+		// Set default Discord payload fields
+		let mut payload_fields = HashMap::new();
+		payload_fields.insert("username".to_string(), serde_json::json!(null));
+		payload_fields.insert("avatar_url".to_string(), serde_json::json!(null));
+
 		Ok(Self {
-			url,
-			title,
-			body_template,
-			client: Client::new(),
+			inner: WebhookNotifier::new(WebhookConfig {
+				url,
+				url_params: None,
+				title,
+				body_template,
+				method: Some("POST".to_string()),
+				secret: None,
+				headers: Some(headers),
+				payload_fields: Some(payload_fields),
+			})?,
 		})
 	}
 
@@ -104,11 +111,8 @@ impl DiscordNotifier {
 	/// # Returns
 	/// * `String` - Formatted message with variables replaced
 	pub fn format_message(&self, variables: &HashMap<String, String>) -> String {
-		let mut message = self.body_template.clone();
-		for (key, value) in variables {
-			message = message.replace(&format!("${{{}}}", key), value);
-		}
-		format!("*{}*\n\n{}", self.title, message)
+		let message = self.inner.format_message(variables);
+		format!("*{}*\n\n{}", self.inner.title, message)
 	}
 
 	/// Creates a Discord notifier from a trigger configuration
@@ -123,12 +127,18 @@ impl DiscordNotifier {
 			TriggerTypeConfig::Discord {
 				discord_url,
 				message,
-			} => Some(Self {
+			} => WebhookNotifier::new(WebhookConfig {
 				url: discord_url.clone(),
+				url_params: None,
 				title: message.title.clone(),
 				body_template: message.body.clone(),
-				client: Client::new(),
-			}),
+				method: Some("POST".to_string()),
+				secret: None,
+				headers: None,
+				payload_fields: None,
+			})
+			.ok()
+			.map(|inner| Self { inner }),
 			_ => None,
 		}
 	}
@@ -144,38 +154,22 @@ impl Notifier for DiscordNotifier {
 	/// # Returns
 	/// * `Result<(), anyhow::Error>` - Success or error
 	async fn notify(&self, message: &str) -> Result<(), anyhow::Error> {
-		let payload = DiscordMessage {
+		let mut payload_fields = HashMap::new();
+		let discord_message = DiscordMessage {
 			content: message.to_string(),
 			username: None,
 			avatar_url: None,
 			embeds: None,
 		};
 
-		let response = match self
-			.client
-			.post(&self.url)
-			.header("Content-Type", "application/json")
-			.json(&payload)
-			.send()
+		payload_fields.insert(
+			"content".to_string(),
+			serde_json::json!(discord_message.content),
+		);
+
+		self.inner
+			.notify_with_payload(message, payload_fields)
 			.await
-		{
-			Ok(resp) => resp,
-			Err(e) => {
-				return Err(anyhow::anyhow!(
-					"Failed to send Discord notification: {}",
-					e
-				));
-			}
-		};
-
-		if !response.status().is_success() {
-			return Err(anyhow::anyhow!(
-				"Discord webhook returned error status: {}",
-				response.status()
-			));
-		}
-
-		Ok(())
 	}
 }
 
@@ -253,9 +247,9 @@ mod tests {
 		assert!(notifier.is_some());
 
 		let notifier = notifier.unwrap();
-		assert_eq!(notifier.url, "https://discord.example.com");
-		assert_eq!(notifier.title, "Test Alert");
-		assert_eq!(notifier.body_template, "Test message ${value}");
+		assert_eq!(notifier.inner.url, "https://discord.example.com");
+		assert_eq!(notifier.inner.title, "Test Alert");
+		assert_eq!(notifier.inner.body_template, "Test message ${value}");
 	}
 
 	////////////////////////////////////////////////////////////
@@ -266,6 +260,15 @@ mod tests {
 	async fn test_notify_failure() {
 		let notifier = create_test_notifier("Test message");
 		let result = notifier.notify("Test message").await;
+		assert!(result.is_err());
+	}
+
+	#[tokio::test]
+	async fn test_notify_with_payload_failure() {
+		let notifier = create_test_notifier("Test message");
+		let result = notifier
+			.notify_with_payload("Test message", HashMap::new())
+			.await;
 		assert!(result.is_err());
 	}
 }

--- a/src/services/notification/mod.rs
+++ b/src/services/notification/mod.rs
@@ -24,7 +24,7 @@ pub use error::NotificationError;
 pub use script::ScriptNotifier;
 pub use slack::SlackNotifier;
 pub use telegram::TelegramNotifier;
-pub use webhook::WebhookNotifier;
+pub use webhook::{WebhookConfig, WebhookNotifier};
 
 /// Interface for notification implementations
 ///
@@ -40,6 +40,23 @@ pub trait Notifier {
 	/// # Returns
 	/// * `Result<(), anyhow::Error>` - Success or error
 	async fn notify(&self, message: &str) -> Result<(), anyhow::Error>;
+
+	/// Sends a notification with custom payload fields
+	///
+	/// # Arguments
+	/// * `message` - The formatted message to send
+	/// * `payload_fields` - Additional fields to include in the payload
+	///
+	/// # Returns
+	/// * `Result<(), anyhow::Error>` - Success or error
+	async fn notify_with_payload(
+		&self,
+		message: &str,
+		_payload_fields: HashMap<String, serde_json::Value>,
+	) -> Result<(), anyhow::Error> {
+		// Default implementation just calls notify
+		self.notify(message).await
+	}
 }
 
 /// Interface for executing scripts

--- a/src/services/notification/slack.rs
+++ b/src/services/notification/slack.rs
@@ -4,32 +4,16 @@
 //! via incoming webhooks, supporting message templates with variable substitution.
 
 use async_trait::async_trait;
-use reqwest::Client;
-use serde::Serialize;
 use std::collections::HashMap;
 
 use crate::{
 	models::TriggerTypeConfig,
-	services::notification::{NotificationError, Notifier},
+	services::notification::{NotificationError, Notifier, WebhookConfig, WebhookNotifier},
 };
 
 /// Implementation of Slack notifications via webhooks
 pub struct SlackNotifier {
-	/// Slack webhook URL for message delivery
-	url: String,
-	/// Title to display in the message
-	title: String,
-	/// Message template with variable placeholders
-	body_template: String,
-	/// HTTP client for webhook requests
-	client: Client,
-}
-
-/// Represents a formatted Slack message
-#[derive(Serialize)]
-struct SlackMessage {
-	/// The formatted text to send to Slack
-	text: String,
+	inner: WebhookNotifier,
 }
 
 impl SlackNotifier {
@@ -44,11 +28,24 @@ impl SlackNotifier {
 		title: String,
 		body_template: String,
 	) -> Result<Self, Box<NotificationError>> {
+		let mut headers = HashMap::new();
+		headers.insert("Content-Type".to_string(), "application/json".to_string());
+
+		// Set default Slack payload fields
+		let mut payload_fields = HashMap::new();
+		payload_fields.insert("text".to_string(), serde_json::json!(null));
+
 		Ok(Self {
-			url,
-			title,
-			body_template,
-			client: Client::new(),
+			inner: WebhookNotifier::new(WebhookConfig {
+				url,
+				url_params: None,
+				title,
+				body_template,
+				method: Some("POST".to_string()),
+				secret: None,
+				headers: Some(headers),
+				payload_fields: Some(payload_fields),
+			})?,
 		})
 	}
 
@@ -60,11 +57,8 @@ impl SlackNotifier {
 	/// # Returns
 	/// * `String` - Formatted message with variables replaced
 	pub fn format_message(&self, variables: &HashMap<String, String>) -> String {
-		let mut message = self.body_template.clone();
-		for (key, value) in variables {
-			message = message.replace(&format!("${{{}}}", key), value);
-		}
-		format!("*{}*\n\n{}", self.title, message)
+		let message = self.inner.format_message(variables);
+		format!("*{}*\n\n{}", self.inner.title, message)
 	}
 
 	/// Creates a Slack notifier from a trigger configuration
@@ -76,12 +70,26 @@ impl SlackNotifier {
 	/// * `Option<Self>` - Notifier instance if config is Slack type
 	pub fn from_config(config: &TriggerTypeConfig) -> Option<Self> {
 		match config {
-			TriggerTypeConfig::Slack { slack_url, message } => Some(Self {
-				url: slack_url.clone(),
-				title: message.title.clone(),
-				body_template: message.body.clone(),
-				client: Client::new(),
-			}),
+			TriggerTypeConfig::Slack { slack_url, message } => {
+				let mut headers = HashMap::new();
+				headers.insert("Content-Type".to_string(), "application/json".to_string());
+
+				let mut payload_fields = HashMap::new();
+				payload_fields.insert("text".to_string(), serde_json::json!(null));
+
+				WebhookNotifier::new(WebhookConfig {
+					url: slack_url.clone(),
+					url_params: None,
+					title: message.title.clone(),
+					body_template: message.body.clone(),
+					method: Some("POST".to_string()),
+					secret: None,
+					headers: Some(headers),
+					payload_fields: Some(payload_fields),
+				})
+				.ok()
+				.map(|inner| Self { inner })
+			}
 			_ => None,
 		}
 	}
@@ -97,26 +105,12 @@ impl Notifier for SlackNotifier {
 	/// # Returns
 	/// * `Result<(), anyhow::Error>` - Success or error
 	async fn notify(&self, message: &str) -> Result<(), anyhow::Error> {
-		let payload = SlackMessage {
-			text: message.to_string(),
-		};
+		let mut payload_fields = HashMap::new();
+		payload_fields.insert("text".to_string(), serde_json::json!(message));
 
-		let response = self
-			.client
-			.post(&self.url)
-			.json(&payload)
-			.send()
+		self.inner
+			.notify_with_payload(message, payload_fields)
 			.await
-			.map_err(|e| anyhow::anyhow!("Failed to send Slack notification: {}", e))?;
-
-		if !response.status().is_success() {
-			return Err(anyhow::anyhow!(
-				"Slack webhook returned error status: {}",
-				response.status()
-			));
-		}
-
-		Ok(())
 	}
 }
 
@@ -194,9 +188,9 @@ mod tests {
 		assert!(notifier.is_some());
 
 		let notifier = notifier.unwrap();
-		assert_eq!(notifier.url, "https://slack.example.com");
-		assert_eq!(notifier.title, "Test Alert");
-		assert_eq!(notifier.body_template, "Test message ${value}");
+		assert_eq!(notifier.inner.url, "https://slack.example.com");
+		assert_eq!(notifier.inner.title, "Test Alert");
+		assert_eq!(notifier.inner.body_template, "Test message ${value}");
 	}
 
 	////////////////////////////////////////////////////////////
@@ -207,6 +201,15 @@ mod tests {
 	async fn test_notify_failure() {
 		let notifier = create_test_notifier("Test message");
 		let result = notifier.notify("Test message").await;
+		assert!(result.is_err());
+	}
+
+	#[tokio::test]
+	async fn test_notify_with_payload_failure() {
+		let notifier = create_test_notifier("Test message");
+		let result = notifier
+			.notify_with_payload("Test message", HashMap::new())
+			.await;
 		assert!(result.is_err());
 	}
 }

--- a/src/services/notification/slack.rs
+++ b/src/services/notification/slack.rs
@@ -28,9 +28,6 @@ impl SlackNotifier {
 		title: String,
 		body_template: String,
 	) -> Result<Self, Box<NotificationError>> {
-		let mut headers = HashMap::new();
-		headers.insert("Content-Type".to_string(), "application/json".to_string());
-
 		// Set default Slack payload fields
 		let mut payload_fields = HashMap::new();
 		payload_fields.insert("text".to_string(), serde_json::json!(null));
@@ -43,7 +40,7 @@ impl SlackNotifier {
 				body_template,
 				method: Some("POST".to_string()),
 				secret: None,
-				headers: Some(headers),
+				headers: None,
 				payload_fields: Some(payload_fields),
 			})?,
 		})

--- a/src/services/notification/telegram.rs
+++ b/src/services/notification/telegram.rs
@@ -46,9 +46,6 @@ impl TelegramNotifier {
 		url_params.insert("chat_id".to_string(), chat_id);
 		url_params.insert("parse_mode".to_string(), "markdown".to_string());
 
-		let mut headers = HashMap::new();
-		headers.insert("Content-Type".to_string(), "application/json".to_string());
-
 		Ok(Self {
 			inner: WebhookNotifier::new(WebhookConfig {
 				url,
@@ -57,7 +54,7 @@ impl TelegramNotifier {
 				body_template,
 				method: Some("GET".to_string()),
 				secret: None,
-				headers: Some(headers),
+				headers: None,
 				payload_fields: None,
 			})?,
 			disable_web_preview: disable_web_preview.unwrap_or(false),

--- a/src/services/notification/telegram.rs
+++ b/src/services/notification/telegram.rs
@@ -4,30 +4,18 @@
 //! via incoming webhooks, supporting message templates with variable substitution.
 
 use async_trait::async_trait;
-use reqwest::Client;
 use std::collections::HashMap;
 
 use crate::{
 	models::TriggerTypeConfig,
-	services::notification::{NotificationError, Notifier},
+	services::notification::{NotificationError, Notifier, WebhookConfig, WebhookNotifier},
 };
 
 /// Implementation of Telegram notifications via webhooks
 pub struct TelegramNotifier {
-	/// Telegram bot token
-	token: String,
-	/// Telegram chat ID
-	chat_id: String,
+	inner: WebhookNotifier,
 	/// Disable web preview
 	disable_web_preview: bool,
-	/// Title to display in the message
-	title: String,
-	/// Message template with variable placeholders
-	body_template: String,
-	/// HTTP client for webhook requests
-	client: Client,
-	/// Base URL for the Telegram API
-	base_url: String,
 }
 
 impl TelegramNotifier {
@@ -47,14 +35,32 @@ impl TelegramNotifier {
 		title: String,
 		body_template: String,
 	) -> Result<Self, Box<NotificationError>> {
+		let url = format!(
+			"{}/bot{}/sendMessage",
+			base_url.unwrap_or("https://api.telegram.org".to_string()),
+			token
+		);
+
+		// Set up initial URL parameters
+		let mut url_params = HashMap::new();
+		url_params.insert("chat_id".to_string(), chat_id);
+		url_params.insert("parse_mode".to_string(), "markdown".to_string());
+
+		let mut headers = HashMap::new();
+		headers.insert("Content-Type".to_string(), "application/json".to_string());
+
 		Ok(Self {
-			base_url: base_url.unwrap_or("https://api.telegram.org".to_string()),
-			token,
-			chat_id,
+			inner: WebhookNotifier::new(WebhookConfig {
+				url,
+				url_params: Some(url_params),
+				title,
+				body_template,
+				method: Some("GET".to_string()),
+				secret: None,
+				headers: Some(headers),
+				payload_fields: None,
+			})?,
 			disable_web_preview: disable_web_preview.unwrap_or(false),
-			title,
-			body_template,
-			client: Client::new(),
 		})
 	}
 
@@ -66,14 +72,8 @@ impl TelegramNotifier {
 	/// # Returns
 	/// * `String` - Formatted message with variables replaced
 	pub fn format_message(&self, variables: &HashMap<String, String>) -> String {
-		let mut message = self.body_template.clone();
-		for (key, value) in variables {
-			message = message.replace(&format!("${{{}}}", key), value);
-		}
-		// Markdown formatting for Telegram
-		// Double asterisks for bold text
-		// Double whitespaces for new line
-		format!("*{}* \n\n{}", self.title, message)
+		let message = self.inner.format_message(variables);
+		format!("*{}* \n\n{}", self.inner.title, message)
 	}
 
 	/// Creates a Telegram notifier from a trigger configuration
@@ -90,29 +90,32 @@ impl TelegramNotifier {
 				chat_id,
 				message,
 				disable_web_preview,
-			} => Some(Self {
-				base_url: "https://api.telegram.org".to_string(),
-				token: token.clone(),
-				chat_id: chat_id.clone(),
-				disable_web_preview: disable_web_preview.unwrap_or(false),
-				title: message.title.clone(),
-				body_template: message.body.clone(),
-				client: Client::new(),
-			}),
+			} => {
+				let mut url_params = HashMap::new();
+				url_params.insert("chat_id".to_string(), chat_id.clone());
+				url_params.insert("parse_mode".to_string(), "markdown".to_string());
+
+				WebhookNotifier::new(WebhookConfig {
+					url: format!("https://api.telegram.org/bot{}/sendMessage", token),
+					url_params: Some(url_params),
+					title: message.title.clone(),
+					body_template: message.body.clone(),
+					method: Some("GET".to_string()),
+					secret: None,
+					headers: Some(HashMap::from([(
+						"Content-Type".to_string(),
+						"application/json".to_string(),
+					)])),
+					payload_fields: None,
+				})
+				.ok()
+				.map(|inner| Self {
+					inner,
+					disable_web_preview: disable_web_preview.unwrap_or(false),
+				})
+			}
 			_ => None,
 		}
-	}
-
-	pub fn construct_url(&self, message: &str) -> String {
-		format!(
-			"{}/bot{}/sendMessage?text={}&chat_id={}&parse_mode=markdown&\
-			 disable_web_page_preview={}",
-			self.base_url,
-			self.token,
-			urlencoding::encode(message),
-			self.chat_id,
-			self.disable_web_preview
-		)
 	}
 }
 
@@ -126,26 +129,27 @@ impl Notifier for TelegramNotifier {
 	/// # Returns
 	/// * `Result<(), anyhow::Error>` - Success or error
 	async fn notify(&self, message: &str) -> Result<(), anyhow::Error> {
-		let url = self.construct_url(message);
+		// Add message and disable_web_preview to URL parameters
+		let mut url_params = self.inner.url_params.clone().unwrap_or_default();
+		url_params.insert("text".to_string(), message.to_string());
+		url_params.insert(
+			"disable_web_page_preview".to_string(),
+			self.disable_web_preview.to_string(),
+		);
 
-		let response = match self.client.get(&url).send().await {
-			Ok(resp) => resp,
-			Err(e) => {
-				return Err(anyhow::anyhow!(
-					"Failed to send Telegram notification: {}",
-					e
-				));
-			}
-		};
+		// Create a new WebhookNotifier with updated URL parameters
+		let notifier = WebhookNotifier::new(WebhookConfig {
+			url: self.inner.url.clone(),
+			url_params: Some(url_params),
+			title: self.inner.title.clone(),
+			body_template: self.inner.body_template.clone(),
+			method: Some("GET".to_string()),
+			secret: None,
+			headers: self.inner.headers.clone(),
+			payload_fields: None,
+		})?;
 
-		if !response.status().is_success() {
-			return Err(anyhow::anyhow!(
-				"Telegram webhook returned error status: {}",
-				response.status()
-			));
-		}
-
-		Ok(())
+		notifier.notify_with_payload(message, HashMap::new()).await
 	}
 }
 
@@ -217,17 +221,6 @@ mod tests {
 	}
 
 	////////////////////////////////////////////////////////////
-	// construct_url tests
-	////////////////////////////////////////////////////////////
-
-	#[test]
-	fn test_construct_url() {
-		let notifier = create_test_notifier("Test message");
-		let url = notifier.construct_url("Test message");
-		assert_eq!(url, "https://api.telegram.org/bottest-token/sendMessage?text=Test%20message&chat_id=test-chat-id&parse_mode=markdown&disable_web_page_preview=true");
-	}
-
-	////////////////////////////////////////////////////////////
 	// from_config tests
 	////////////////////////////////////////////////////////////
 
@@ -239,10 +232,12 @@ mod tests {
 		assert!(notifier.is_some());
 
 		let notifier = notifier.unwrap();
-		assert_eq!(notifier.token, "test-token");
-		assert_eq!(notifier.chat_id, "test-chat-id");
+		assert_eq!(
+			notifier.inner.url,
+			"https://api.telegram.org/bottest-token/sendMessage"
+		);
 		assert!(notifier.disable_web_preview);
-		assert_eq!(notifier.body_template, "Test message ${value}");
+		assert_eq!(notifier.inner.body_template, "Test message ${value}");
 	}
 
 	////////////////////////////////////////////////////////////
@@ -253,6 +248,15 @@ mod tests {
 	async fn test_notify_failure() {
 		let notifier = create_test_notifier("Test message");
 		let result = notifier.notify("Test message").await;
+		assert!(result.is_err());
+	}
+
+	#[tokio::test]
+	async fn test_notify_with_payload_failure() {
+		let notifier = create_test_notifier("Test message");
+		let result = notifier
+			.notify_with_payload("Test message", HashMap::new())
+			.await;
 		assert!(result.is_err());
 	}
 }

--- a/src/services/notification/webhook.rs
+++ b/src/services/notification/webhook.rs
@@ -22,22 +22,46 @@ use crate::{
 /// HMAC SHA256 type alias
 type HmacSha256 = Hmac<Sha256>;
 
+/// Represents a webhook payload with additional fields
+#[derive(Serialize, Debug)]
+pub struct WebhookPayload {
+	#[serde(flatten)]
+	fields: HashMap<String, serde_json::Value>,
+}
+
+/// Represents a webhook configuration
+#[derive(Clone)]
+pub struct WebhookConfig {
+	pub url: String,
+	pub url_params: Option<HashMap<String, String>>,
+	pub title: String,
+	pub body_template: String,
+	pub method: Option<String>,
+	pub secret: Option<String>,
+	pub headers: Option<HashMap<String, String>>,
+	pub payload_fields: Option<HashMap<String, serde_json::Value>>,
+}
+
 /// Implementation of webhook notifications via webhooks
 pub struct WebhookNotifier {
 	/// Webhook URL for message delivery
-	url: String,
+	pub url: String,
+	/// URL parameters to use for the webhook request
+	pub url_params: Option<HashMap<String, String>>,
 	/// Title to display in the message
-	title: String,
+	pub title: String,
 	/// Message template with variable placeholders
-	body_template: String,
+	pub body_template: String,
 	/// HTTP client for webhook requests
-	client: Client,
+	pub client: Client,
 	/// HTTP method to use for the webhook request
-	method: Option<String>,
+	pub method: Option<String>,
 	/// Secret to use for the webhook request
-	secret: Option<String>,
+	pub secret: Option<String>,
 	/// Headers to use for the webhook request
-	headers: Option<HashMap<String, String>>,
+	pub headers: Option<HashMap<String, String>>,
+	/// Payload fields to use for the webhook request
+	pub payload_fields: Option<HashMap<String, serde_json::Value>>,
 }
 
 /// Represents a formatted webhook message
@@ -52,28 +76,21 @@ impl WebhookNotifier {
 	/// Creates a new Webhook notifier instance
 	///
 	/// # Arguments
-	/// * `url` - Webhook URL
-	/// * `title` - Message title
-	/// * `body_template` - Message template with variables
-	/// * `method` - HTTP method to use for the webhook request (optional, defaults to POST)
-	/// * `secret` - Secret to use for the webhook request (optional)
-	/// * `headers` - Headers to use for the webhook request (optional)
-	pub fn new(
-		url: String,
-		title: String,
-		body_template: String,
-		method: Option<String>,
-		secret: Option<String>,
-		headers: Option<HashMap<String, String>>,
-	) -> Result<Self, Box<NotificationError>> {
+	/// * `config` - Webhook configuration
+	///
+	/// # Returns
+	/// * `Result<Self, Box<NotificationError>>` - Notifier instance if config is valid
+	pub fn new(config: WebhookConfig) -> Result<Self, Box<NotificationError>> {
 		Ok(Self {
-			url,
-			title,
-			body_template,
+			url: config.url,
+			url_params: config.url_params,
+			title: config.title,
+			body_template: config.body_template,
 			client: Client::new(),
-			method: Some(method.unwrap_or("POST".to_string())),
-			secret: secret.map(|s| s.to_string()),
-			headers,
+			method: Some(config.method.unwrap_or("POST".to_string())),
+			secret: config.secret,
+			headers: config.headers,
+			payload_fields: config.payload_fields,
 		})
 	}
 
@@ -109,12 +126,14 @@ impl WebhookNotifier {
 				headers,
 			} => Some(Self {
 				url: url.clone(),
+				url_params: None,
 				title: message.title.clone(),
 				body_template: message.body.clone(),
 				client: Client::new(),
 				method: method.clone(),
 				secret: secret.clone(),
 				headers: headers.clone(),
+				payload_fields: None,
 			}),
 			_ => None,
 		}
@@ -153,85 +172,112 @@ impl Notifier for WebhookNotifier {
 	/// # Returns
 	/// * `Result<(), anyhow::Error>` - Success or error
 	async fn notify(&self, message: &str) -> Result<(), anyhow::Error> {
-		let payload = WebhookMessage {
-			title: self.title.clone(),
-			body: message.to_string(),
-		};
+		// Default payload with title and body
+		let mut payload_fields = HashMap::new();
+		payload_fields.insert("title".to_string(), serde_json::json!(self.title));
+		payload_fields.insert("body".to_string(), serde_json::json!(message));
+
+		self.notify_with_payload(message, payload_fields).await
+	}
+
+	/// Sends a formatted message to Webhook with custom payload fields
+	///
+	/// # Arguments
+	/// * `message` - The formatted message to send
+	/// * `payload_fields` - Additional fields to include in the payload
+	///
+	/// # Returns
+	/// * `Result<(), anyhow::Error>` - Success or error
+	async fn notify_with_payload(
+		&self,
+		message: &str,
+		mut payload_fields: HashMap<String, serde_json::Value>,
+	) -> Result<(), anyhow::Error> {
+		let mut url = self.url.clone();
+		// Add URL parameters if present
+		if let Some(params) = &self.url_params {
+			let params_str: Vec<String> = params
+				.iter()
+				.map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+				.collect();
+			if !params_str.is_empty() {
+				url = format!("{}?{}", url, params_str.join("&"));
+			}
+		}
+
+		// Merge with default payload fields if they exist
+		if let Some(default_fields) = &self.payload_fields {
+			for (key, value) in default_fields {
+				if !payload_fields.contains_key(key) {
+					payload_fields.insert(key.clone(), value.clone());
+				}
+			}
+		}
 
 		let method = if let Some(ref m) = self.method {
 			Method::from_bytes(m.as_bytes()).unwrap_or(Method::POST)
 		} else {
 			Method::POST
 		};
-
 		let mut headers = HeaderMap::new();
+		headers.insert(
+			HeaderName::from_static("content-type"),
+			HeaderValue::from_static("application/json"),
+		);
 
 		if let Some(secret) = &self.secret {
+			// Create a WebhookMessage for signing
+			let payload_for_signing = WebhookMessage {
+				title: self.title.clone(),
+				body: message.to_string(),
+			};
+
 			let (signature, timestamp) = self
-				.sign_request(secret, &payload)
+				.sign_request(secret, &payload_for_signing)
 				.map_err(|e| NotificationError::internal_error(e.to_string(), None, None))?;
 
-			// Handle X-Signature header
-			if let Ok(header_name) = HeaderName::from_bytes(b"X-Signature") {
-				if let Ok(header_value) = HeaderValue::from_str(&signature) {
-					headers.insert(header_name, header_value);
-				} else {
-					return Err(anyhow::anyhow!("Invalid signature value",));
-				}
-			} else {
-				return Err(anyhow::anyhow!("Invalid signature header name",));
-			}
-
-			// Handle X-Timestamp header
-			if let Ok(header_name) = HeaderName::from_bytes(b"X-Timestamp") {
-				if let Ok(header_value) = HeaderValue::from_str(&timestamp) {
-					headers.insert(header_name, header_value);
-				} else {
-					return Err(anyhow::anyhow!("Invalid timestamp value",));
-				}
-			} else {
-				return Err(anyhow::anyhow!("Invalid timestamp header name",));
-			}
+			// Add signature headers
+			headers.insert(
+				HeaderName::from_static("x-signature"),
+				HeaderValue::from_str(&signature)
+					.map_err(|_| anyhow::anyhow!("Invalid signature value"))?,
+			);
+			headers.insert(
+				HeaderName::from_static("x-timestamp"),
+				HeaderValue::from_str(&timestamp)
+					.map_err(|_| anyhow::anyhow!("Invalid timestamp value"))?,
+			);
 		}
 
+		// Add custom headers
 		if let Some(headers_map) = &self.headers {
 			for (key, value) in headers_map {
-				let Ok(header_name) = HeaderName::from_bytes(key.as_bytes()) else {
-					return Err(anyhow::anyhow!("Invalid header name: {}", key));
-				};
-				let Ok(header_value) = HeaderValue::from_str(value) else {
-					return Err(anyhow::anyhow!(format!(
-						"Invalid header value for key: {}",
-						key
-					),));
-				};
+				let header_name = HeaderName::from_bytes(key.as_bytes())
+					.map_err(|_| anyhow::anyhow!("Invalid header name: {}", key))?;
+				let header_value = HeaderValue::from_str(value)
+					.map_err(|_| anyhow::anyhow!("Invalid header value for key: {}", key))?;
 				headers.insert(header_name, header_value);
 			}
 		}
 
-		let response = match self
+		let payload = WebhookPayload {
+			fields: payload_fields,
+		};
+
+		// Send request with custom payload
+		let response = self
 			.client
-			.request(method, self.url.as_str())
+			.request(method, url.as_str())
 			.headers(headers)
 			.json(&payload)
 			.send()
 			.await
-		{
-			Ok(resp) => resp,
-			Err(e) => {
-				// Pass the original error as source instead of just its string representation
-				return Err(anyhow::anyhow!(
-					"Failed to send webhook notification: {}",
-					e
-				));
-			}
-		};
+			.map_err(|e| anyhow::anyhow!("Failed to send webhook notification: {}", e))?;
 
-		if !response.status().is_success() {
-			return Err(anyhow::anyhow!(
-				"Webhook returned error status: {}",
-				response.status()
-			));
+		let status = response.status();
+
+		if !status.is_success() {
+			return Err(anyhow::anyhow!("Webhook returned error status: {}", status));
 		}
 
 		Ok(())
@@ -244,6 +290,7 @@ mod tests {
 
 	use super::*;
 	use mockito::{Matcher, Mock};
+	use serde_json::json;
 
 	fn create_test_notifier(
 		url: &str,
@@ -251,14 +298,16 @@ mod tests {
 		secret: Option<&str>,
 		headers: Option<HashMap<String, String>>,
 	) -> WebhookNotifier {
-		WebhookNotifier::new(
-			url.to_string(),
-			"Alert".to_string(),
-			body_template.to_string(),
-			Some("POST".to_string()),
-			secret.map(|s| s.to_string()),
+		WebhookNotifier::new(WebhookConfig {
+			url: url.to_string(),
+			url_params: None,
+			title: "Alert".to_string(),
+			body_template: body_template.to_string(),
+			method: Some("POST".to_string()),
+			secret: secret.map(|s| s.to_string()),
 			headers,
-		)
+			payload_fields: None,
+		})
 		.unwrap()
 	}
 
@@ -525,5 +574,197 @@ mod tests {
 			timestamp.parse::<i64>().is_ok(),
 			"Timestamp should be valid i64"
 		);
+	}
+
+	////////////////////////////////////////////////////////////
+	// notify_with_payload tests
+	////////////////////////////////////////////////////////////
+
+	#[tokio::test]
+	async fn test_notify_with_payload_success() {
+		let mut server = mockito::Server::new_async().await;
+		let expected_payload = json!({
+			"title": "Alert",
+			"body": "Test message",
+			"custom_field": "custom_value"
+		});
+
+		let mock = server
+			.mock("POST", "/")
+			.match_header("content-type", "application/json")
+			.match_body(Matcher::Json(expected_payload))
+			.with_header("content-type", "application/json")
+			.with_body("{}")
+			.with_status(200)
+			.expect(1)  // Expect exactly one request
+			.create_async()
+			.await;
+
+		let notifier = create_test_notifier(server.url().as_str(), "Test message", None, None);
+		let mut payload = HashMap::new();
+		// Insert fields in the same order as they appear in expected_payload
+		payload.insert("title".to_string(), serde_json::json!("Alert"));
+		payload.insert("body".to_string(), serde_json::json!("Test message"));
+		payload.insert(
+			"custom_field".to_string(),
+			serde_json::json!("custom_value"),
+		);
+
+		let result = notifier.notify_with_payload("Test message", payload).await;
+		assert!(result.is_ok());
+		mock.assert();
+	}
+
+	#[tokio::test]
+	async fn test_notify_with_payload_and_url_params() {
+		let mut server = mockito::Server::new_async().await;
+		let mock = server
+			.mock("POST", "/")
+			.match_query(mockito::Matcher::AllOf(vec![
+				mockito::Matcher::UrlEncoded("param1".into(), "value1".into()),
+				mockito::Matcher::UrlEncoded("param2".into(), "value2".into()),
+			]))
+			.with_status(200)
+			.create_async()
+			.await;
+
+		let mut url_params = HashMap::new();
+		url_params.insert("param1".to_string(), "value1".to_string());
+		url_params.insert("param2".to_string(), "value2".to_string());
+
+		let notifier = WebhookNotifier::new(WebhookConfig {
+			url: server.url(),
+			url_params: Some(url_params),
+			title: "Alert".to_string(),
+			body_template: "Test message".to_string(),
+			method: None,
+			secret: None,
+			headers: None,
+			payload_fields: None,
+		})
+		.unwrap();
+
+		let result = notifier
+			.notify_with_payload("Test message", HashMap::new())
+			.await;
+		assert!(result.is_ok());
+		mock.assert();
+	}
+
+	#[tokio::test]
+	async fn test_notify_with_payload_and_method_override() {
+		let mut server = mockito::Server::new_async().await;
+		let mock = server
+			.mock("GET", "/")
+			.with_status(200)
+			.create_async()
+			.await;
+
+		let notifier = WebhookNotifier::new(WebhookConfig {
+			url: server.url(),
+			url_params: None,
+			title: "Alert".to_string(),
+			body_template: "Test message".to_string(),
+			method: Some("GET".to_string()),
+			secret: None,
+			headers: None,
+			payload_fields: None,
+		})
+		.unwrap();
+
+		let result = notifier
+			.notify_with_payload("Test message", HashMap::new())
+			.await;
+		assert!(result.is_ok());
+		mock.assert();
+	}
+
+	#[tokio::test]
+	async fn test_notify_with_payload_merges_default_fields() {
+		let mut server = mockito::Server::new_async().await;
+
+		let expected_payload = json!({
+			"default_field": "default_value",
+			"custom_field": "custom_value"
+		});
+
+		let mock = server
+			.mock("POST", "/")
+			.match_body(mockito::Matcher::Json(expected_payload))
+			.with_status(200)
+			.create_async()
+			.await;
+
+		let mut default_fields = HashMap::new();
+		default_fields.insert(
+			"default_field".to_string(),
+			serde_json::json!("default_value"),
+		);
+
+		let notifier = WebhookNotifier::new(WebhookConfig {
+			url: server.url(),
+			url_params: None,
+			title: "Alert".to_string(),
+			body_template: "Test message".to_string(),
+			method: None,
+			secret: None,
+			headers: None,
+			payload_fields: Some(default_fields),
+		})
+		.unwrap();
+
+		let mut payload = HashMap::new();
+		payload.insert(
+			"custom_field".to_string(),
+			serde_json::json!("custom_value"),
+		);
+
+		let result = notifier.notify_with_payload("Test message", payload).await;
+		assert!(result.is_ok());
+		mock.assert();
+	}
+
+	#[tokio::test]
+	async fn test_notify_with_payload_custom_fields_override_defaults() {
+		let mut server = mockito::Server::new_async().await;
+
+		let expected_payload = json!({
+			 "custom_field": "custom_value"
+		});
+
+		let mock = server
+			.mock("POST", "/")
+			.match_body(mockito::Matcher::Json(expected_payload))
+			.with_status(200)
+			.create_async()
+			.await;
+
+		let mut default_fields = HashMap::new();
+		default_fields.insert(
+			"custom_field".to_string(),
+			serde_json::json!("default_value"),
+		);
+
+		let notifier = WebhookNotifier::new(WebhookConfig {
+			url: server.url(),
+			url_params: None,
+			title: "Alert".to_string(),
+			body_template: "Test message".to_string(),
+			method: None,
+			secret: None,
+			headers: None,
+			payload_fields: Some(default_fields),
+		})
+		.unwrap();
+
+		let mut payload = HashMap::new();
+		payload.insert(
+			"custom_field".to_string(),
+			serde_json::json!("custom_value"),
+		);
+
+		let result = notifier.notify_with_payload("Test message", payload).await;
+		assert!(result.is_ok());
+		mock.assert();
 	}
 }

--- a/src/services/notification/webhook.rs
+++ b/src/services/notification/webhook.rs
@@ -81,6 +81,10 @@ impl WebhookNotifier {
 	/// # Returns
 	/// * `Result<Self, Box<NotificationError>>` - Notifier instance if config is valid
 	pub fn new(config: WebhookConfig) -> Result<Self, Box<NotificationError>> {
+		let mut headers = config.headers.unwrap_or_default();
+		if !headers.contains_key("Content-Type") {
+			headers.insert("Content-Type".to_string(), "application/json".to_string());
+		}
 		Ok(Self {
 			url: config.url,
 			url_params: config.url_params,
@@ -89,7 +93,7 @@ impl WebhookNotifier {
 			client: Client::new(),
 			method: Some(config.method.unwrap_or("POST".to_string())),
 			secret: config.secret,
-			headers: config.headers,
+			headers: Some(headers),
 			payload_fields: config.payload_fields,
 		})
 	}
@@ -219,6 +223,8 @@ impl Notifier for WebhookNotifier {
 		} else {
 			Method::POST
 		};
+
+		// Add default headers
 		let mut headers = HeaderMap::new();
 		headers.insert(
 			HeaderName::from_static("content-type"),

--- a/tests/integration/notifications/discord.rs
+++ b/tests/integration/notifications/discord.rs
@@ -40,14 +40,14 @@ fn create_test_evm_match(monitor: Monitor) -> MonitorMatch {
 async fn test_discord_notification_success() {
 	// Setup async mock server
 	let mut server = mockito::Server::new_async().await;
+	let expected_json_payload = json!({
+		"content": "*Test Alert*\n\nTest message with value 42",
+		"avatar_url": null,
+		"username": null,
+	});
 	let mock = server
 		.mock("POST", "/")
-		.match_body(mockito::Matcher::Json(json!({
-			"content": "*Test Alert*\n\nTest message with value 42",
-			"username": null,
-			"avatar_url": null,
-			"embeds": null,
-		})))
+		.match_body(mockito::Matcher::Json(expected_json_payload))
 		.with_status(200)
 		.create_async()
 		.await;

--- a/tests/integration/notifications/webhook.rs
+++ b/tests/integration/notifications/webhook.rs
@@ -3,7 +3,7 @@ use openzeppelin_monitor::{
 		BlockChainType, EVMMonitorMatch, MatchConditions, Monitor, MonitorMatch,
 		NotificationMessage, TransactionType, Trigger, TriggerType, TriggerTypeConfig,
 	},
-	services::notification::{NotificationService, Notifier, WebhookNotifier},
+	services::notification::{NotificationService, Notifier, WebhookConfig, WebhookNotifier},
 };
 use serde_json::json;
 use std::collections::HashMap;
@@ -50,14 +50,16 @@ async fn test_webhook_notification_success() {
 		.create_async()
 		.await;
 
-	let notifier = WebhookNotifier::new(
-		server.url(),
-		"Test Alert".to_string(),
-		"Test message with value ${value}".to_string(),
-		Some("GET".to_string()),
-		None,
-		None,
-	)
+	let notifier = WebhookNotifier::new(WebhookConfig {
+		url: server.url(),
+		url_params: None,
+		title: "Test Alert".to_string(),
+		body_template: "Test message with value ${value}".to_string(),
+		method: Some("GET".to_string()),
+		secret: None,
+		headers: None,
+		payload_fields: None,
+	})
 	.unwrap();
 
 	// Prepare and send test message
@@ -82,14 +84,16 @@ async fn test_webhook_notification_failure() {
 		.create_async()
 		.await;
 
-	let notifier = WebhookNotifier::new(
-		server.url(),
-		"Test Alert".to_string(),
-		"Test message".to_string(),
-		Some("GET".to_string()),
-		None,
-		None,
-	)
+	let notifier = WebhookNotifier::new(WebhookConfig {
+		url: server.url(),
+		url_params: None,
+		title: "Test Alert".to_string(),
+		body_template: "Test message".to_string(),
+		method: Some("GET".to_string()),
+		secret: None,
+		headers: None,
+		payload_fields: None,
+	})
 	.unwrap();
 
 	let result = notifier.notify("Test message").await;
@@ -205,4 +209,45 @@ async fn test_notification_service_webhook_execution_invalid_config() {
 		.unwrap_err()
 		.to_string()
 		.contains("Invalid webhook configuration"));
+}
+
+#[tokio::test]
+async fn test_notify_with_payload_merges_default_fields() {
+	let mut server = mockito::Server::new_async().await;
+	let expected_payload = json!({
+		"default_field": "default_value",
+		"custom_field": "custom_value"
+	});
+
+	let mock = server
+		.mock("POST", "/")
+		.match_body(mockito::Matcher::Json(expected_payload))
+		.with_status(200)
+		.create_async()
+		.await;
+
+	let notifier = WebhookNotifier::new(WebhookConfig {
+		url: server.url(),
+		url_params: None,
+		title: "Test".to_string(),
+		body_template: "Test message".to_string(),
+		method: None,
+		secret: None,
+		headers: None,
+		payload_fields: Some(HashMap::from([(
+			"default_field".to_string(),
+			serde_json::json!("default_value"),
+		)])),
+	})
+	.unwrap();
+
+	let mut payload = HashMap::new();
+	payload.insert(
+		"custom_field".to_string(),
+		serde_json::json!("custom_value"),
+	);
+
+	let result = notifier.notify_with_payload("Test message", payload).await;
+	assert!(result.is_ok());
+	mock.assert();
 }

--- a/tests/properties/notifications/webhook.rs
+++ b/tests/properties/notifications/webhook.rs
@@ -5,7 +5,7 @@
 //! The tests ensure that the Webhook notification system handles template variables correctly
 //! and produces consistent, well-formed output across various input combinations.
 
-use openzeppelin_monitor::services::notification::WebhookNotifier;
+use openzeppelin_monitor::services::notification::{WebhookConfig, WebhookNotifier};
 use proptest::{prelude::*, test_runner::Config};
 use std::collections::HashMap;
 
@@ -33,14 +33,17 @@ proptest! {
 		template in "[a-zA-Z0-9 ${}_]{1,100}",
 		vars in template_variables_strategy()
 	) {
-			let notifier = WebhookNotifier::new(
-			"https://webhook.com/test".to_string(),
-			"Test".to_string(),
-			template.clone(),
-			None,
-			None,
-			None,
-		).unwrap();
+		let notifier = WebhookNotifier::new(WebhookConfig {
+			url: "https://webhook.com/test".to_string(),
+			url_params: None,
+			title: "Test".to_string(),
+			body_template: template.clone(),
+			method: None,
+			secret: None,
+			headers: None,
+			payload_fields: None,
+		})
+		.unwrap();
 
 		let first_pass = notifier.format_message(&vars);
 		let second_pass = notifier.format_message(&vars);
@@ -59,14 +62,17 @@ proptest! {
 		template in "[a-zA-Z0-9 ]{0,50}\\$\\{[a-z_]+\\}[a-zA-Z0-9 ]{0,50}",
 		vars in template_variables_strategy()
 	) {
-		let notifier = WebhookNotifier::new(
-			"https://webhook.com/test".to_string(),
-			"Test".to_string(),
-			template.clone(),
-			None,
-			None,
-			None,
-		).unwrap();
+		let notifier = WebhookNotifier::new(WebhookConfig {
+			url: "https://webhook.com/test".to_string(),
+			url_params: None,
+			title: "Test".to_string(),
+			body_template: template.clone(),
+			method: None,
+			secret: None,
+			headers: None,
+			payload_fields: None,
+		})
+		.unwrap();
 
 		let formatted = notifier.format_message(&vars);
 
@@ -84,14 +90,17 @@ proptest! {
 	fn test_notification_empty_variables(
 		template in "[a-zA-Z0-9 ${}_]{1,100}"
 	) {
-		let notifier = WebhookNotifier::new(
-			"https://webhook.com/test".to_string(),
-			"Test".to_string(),
-			template.clone(),
-			None,
-			None,
-			None,
-		).unwrap();
+		let notifier = WebhookNotifier::new(WebhookConfig {
+			url: "https://webhook.com/test".to_string(),
+			url_params: None,
+			title: "Test".to_string(),
+			body_template: template.clone(),
+			method: None,
+			secret: None,
+			headers: None,
+			payload_fields: None,
+		})
+		.unwrap();
 
 		let empty_vars = HashMap::new();
 		let formatted = notifier.format_message(&empty_vars);


### PR DESCRIPTION
# Summary

- Reusing Webhook notifier for telegram, slack, discord

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
