### PR TITLE
chore: Add  `--check` flag and improves cli opts readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -678,7 +678,7 @@ checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -891,7 +891,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -910,7 +910,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity",
 ]
 
@@ -1382,7 +1382,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1427,7 +1427,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1610,7 +1610,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1656,6 +1656,16 @@ name = "byte-slice-cast"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
+name = "byte-unit"
+version = "4.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
+dependencies = [
+ "serde",
+ "utf8-width",
+]
 
 [[package]]
 name = "bytecheck"
@@ -1852,7 +1862,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2152,7 +2162,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2163,7 +2173,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2243,7 +2253,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2254,7 +2264,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -2293,7 +2303,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2728,7 +2738,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3351,7 +3361,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3422,7 +3432,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3795,7 +3805,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3863,7 +3873,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3968,7 +3978,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4028,7 +4038,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4099,7 +4109,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4130,6 +4140,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "byte-unit",
  "cargo-llvm-cov",
  "chrono",
  "clap",
@@ -4227,7 +4238,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4334,7 +4345,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4414,7 +4425,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -4484,7 +4495,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4559,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -4594,9 +4605,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.4"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -5389,7 +5400,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5463,7 +5474,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5660,9 +5671,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601f9201feb9b09c00266478bf459952b9ef9a6b94edb2f21eba14ab681a60a9"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5869,7 +5880,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5891,9 +5902,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5909,7 +5920,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5929,7 +5940,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6054,7 +6065,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6065,7 +6076,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6231,7 +6242,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6307,18 +6318,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -6401,7 +6412,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6473,7 +6484,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6588,6 +6599,12 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8-width"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8_iter"
@@ -6711,7 +6728,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -6746,7 +6763,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6801,9 +6818,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6888,7 +6905,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6899,7 +6916,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6910,7 +6927,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6921,7 +6938,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7188,7 +7205,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7203,11 +7220,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -7218,18 +7235,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7249,7 +7266,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7270,7 +7287,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7292,7 +7309,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ alloy = { version = "0.12.4", features = ["full"] }
 anyhow = { version = "1.0.97", features = ["std"] }
 async-trait = "0.1"
 base64 = "0.22"
+byte-unit = "4.0"
 chrono = "0.4"
-clap = { version = "4.5", features = ["cargo"] }
+clap = { version = "4.5", features = ["cargo", "derive"] }
 cron = "0.15.0"
 dotenvy = "0.15.7"
 email_address = "0.2.9"

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -184,6 +184,9 @@ mv ./target/release/openzeppelin-monitor .
 
 # Enable metrics server
 ./openzeppelin-monitor --metrics
+
+# Validate configuration files without starting the service
+./openzeppelin-monitor --check
 ----
 
 === Run with Docker
@@ -342,10 +345,10 @@ This table lists the environment variables and their default values.
 | `<any file path>`
 | Persist monitor data between container restarts.
 
-| `LOG_MAX_SIZE (in bytes)`
+| `LOG_MAX_SIZE`
 | `1073741824`
-| `<any value in bytes>`
-| Size after which logs needs to be rolled.
+| `<size in bytes or human-readable format (e.g., "1GB", "500MB")>`
+| Size after which logs needs to be rolled. Accepts both raw bytes (e.g., "1073741824") or human-readable formats (e.g., "1GB", "500MB").
 
 | `METRICS_ENABLED`
 | `false`
@@ -378,6 +381,25 @@ cp examples/config/triggers/email_notifications.json config/triggers/email_notif
 cp examples/config/filters/evm_filter_block_number.sh config/filters/evm_filter_block_number.sh
 cp examples/config/filters/stellar_filter_block_number.sh config/filters/stellar_filter_block_number.sh
 ----
+
+=== Command Line Options
+
+The monitor supports several command-line options for configuration and control:
+
+[cols="1,1,2", options="header"]
+|===
+| Option | Default | Description
+| `--log-file` | `false` | Write logs to file instead of stdout
+| `--log-level` | `info` | Set log level (trace, debug, info, warn, error)
+| `--log-path` | `logs/` | Path to store log files
+| `--log-max-size` | `1GB` | Maximum log file size before rolling
+| `--metrics-address` | `127.0.0.1:8081` | Address to start the metrics server on
+| `--metrics` | `false` | Enable metrics server
+| `--monitor-path` | - | Path to the monitor to execute (for testing)
+| `--network` | - | Network to execute the monitor for (for testing)
+| `--block` | - | Block number to execute the monitor for (for testing)
+| `--check` | `false` | Validate configuration files without starting the service
+|===
 
 == Data Storage Configuration
 
@@ -1130,6 +1152,24 @@ The `validate_network_config.sh` script helps ensure your network configuration 
 
 TIP: Run this script when setting up new networks, before deploying configuration changes, or when troubleshooting connectivity issues.
 
+==== Validating Configuration Files
+
+Before starting the monitor service, you can validate your configuration files using the `--check` option:
+
+[source,bash]
+----
+./openzeppelin-monitor --check
+----
+
+This command will:
+
+* Parse and validate all configuration files
+* Check for syntax errors
+* Verify references between monitors, networks, and triggers
+* Report any issues without starting the service
+
+It's recommended to run this check after making changes to any configuration files.
+
 ==== Monitor Configuration
 The monitor can be tested in two modes:
 
@@ -1139,7 +1179,7 @@ This mode processes the most recent blocks across all configured networks.
 
 [source,bash]
 ----
-cargo run -- --monitorPath="config/monitors/evm_transfer_usdc.json"
+./openzeppelin-monitor --monitor-path="config/monitors/evm_transfer_usdc.json"
 ----
 
 What this does:
@@ -1154,8 +1194,8 @@ This mode allows you to analyze a particular block on a specific network, which 
 
 [source,bash]
 ----
-cargo run -- \
-    --monitorPath="config/monitors/evm_transfer_usdc.json" \
+./openzeppelin-monitor \
+    --monitor-path="config/monitors/evm_transfer_usdc.json" \
     --network=ethereum_mainnet \
     --block=12345678
 ----
@@ -1180,7 +1220,7 @@ Specific Block Mode requires both parameters:
 
 [source,bash]
 ----
-cargo run
+./openzeppelin-monitor
 ----
 
 === Docker Deployment

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -73,6 +73,9 @@ mv ./target/release/openzeppelin-monitor .
 
 # Enable metrics server
 ./openzeppelin-monitor --metrics
+
+# Validate configuration files without starting the service
+./openzeppelin-monitor --check
 ----
 
 === Run with Docker
@@ -327,7 +330,7 @@ Update the SMTP settings in the link:https://github.com/OpenZeppelin/openzeppeli
 
 [source,bash]
 ----
-cargo run
+./openzeppelin-monitor
 ----
 
 **Docker Deployment**
@@ -478,7 +481,7 @@ Update the webhook URL in the link:https://github.com/OpenZeppelin/openzeppelin-
 
 [source,bash]
 ----
-cargo run
+./openzeppelin-monitor
 ----
 
 **Docker Deployment**

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,6 +8,8 @@
 //! - expression: Utilities for working with cron expressions
 //! - logging: Logging utilities
 //! - metrics: Metrics utilities
+//! - monitor: Monitor utilities
+//! - parsing: Parsing utilities
 
 mod cron_utils;
 mod expression;
@@ -16,7 +18,9 @@ pub mod constants;
 pub mod logging;
 pub mod metrics;
 pub mod monitor;
+pub mod parsing;
 
 pub use constants::*;
 pub use cron_utils::*;
 pub use expression::*;
+pub use parsing::*;

--- a/src/utils/parsing.rs
+++ b/src/utils/parsing.rs
@@ -14,3 +14,49 @@ pub fn parse_string_to_bytes_size(s: &str) -> Result<u64, String> {
 		Err(e) => Err(format!("Invalid size format: '{}'. Error: {}", s, e)),
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_valid_size_formats() {
+		let test_cases = vec![
+			("1B", 1),
+			("1KB", 1000),
+			("1KiB", 1024),
+			("1MB", 1000 * 1000),
+			("1MiB", 1024 * 1024),
+			("1GB", 1000 * 1000 * 1000),
+			("1GiB", 1024 * 1024 * 1024),
+			("1.5GB", (1.5 * 1000.0 * 1000.0 * 1000.0) as u64),
+			("500MB", 500 * 1000 * 1000),
+			("0B", 0),
+		];
+
+		for (input, expected) in test_cases {
+			let result = parse_string_to_bytes_size(input);
+			assert!(result.is_ok(), "Failed to parse valid input: {}", input);
+			assert_eq!(
+				result.unwrap(),
+				expected,
+				"Incorrect parsing for input: {}",
+				input
+			);
+		}
+	}
+
+	#[test]
+	fn test_invalid_size_formats() {
+		let invalid_inputs = vec!["", "invalid", "GB", "-1GB", "1.5.5GB", "1GB2"];
+
+		for input in invalid_inputs {
+			let result = parse_string_to_bytes_size(input);
+			assert!(
+				result.is_err(),
+				"Expected error for invalid input: {}",
+				input
+			);
+		}
+	}
+}

--- a/src/utils/parsing.rs
+++ b/src/utils/parsing.rs
@@ -1,0 +1,16 @@
+//! Parsing utilities
+//!
+//! This module provides utilities for parsing various types of data.
+
+use byte_unit::Byte;
+
+/// Parses a string argument into a `u64` value representing a file size.
+///
+/// Accepts human-readable formats like "1GB", "500MB", "1024KB", etc.
+/// Returns an error if the format is invalid.
+pub fn parse_string_to_bytes_size(s: &str) -> Result<u64, String> {
+	match Byte::from_str(s) {
+		Ok(byte) => Ok(byte.get_bytes() as u64),
+		Err(e) => Err(format!("Invalid size format: '{}'. Error: {}", s, e)),
+	}
+}


### PR DESCRIPTION
# Summary

- Adds a `--check` flag which attempts to initialise services (reading configuration files) and logs any errors without starting the full monitor service.
- Improves readability for  CLI options by using `clap::Parser`
- Updates relevant documentation

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
