### PR TITLE
chore: Log warning when insecure protocols are used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -183,7 +183,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -678,7 +678,7 @@ checksum = "a40e1ef334153322fd878d07e86af7a529bcb86b2439525920a88eba87bcf943"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -891,7 +891,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -910,7 +910,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity",
 ]
 
@@ -1382,7 +1382,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1399,7 +1399,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1427,7 +1427,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1610,7 +1610,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1852,7 +1852,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2152,7 +2152,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2163,7 +2163,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2243,7 +2243,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2254,7 +2254,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -2293,7 +2293,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2728,7 +2728,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3351,7 +3351,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3422,7 +3422,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3795,7 +3795,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3863,7 +3863,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3968,7 +3968,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4028,7 +4028,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4099,7 +4099,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4227,7 +4227,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4334,7 +4334,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4414,7 +4414,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -4484,7 +4484,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4559,9 +4559,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -4594,9 +4594,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.4"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
 ]
@@ -5389,7 +5389,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5463,7 +5463,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5660,9 +5660,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "stacker"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601f9201feb9b09c00266478bf459952b9ef9a6b94edb2f21eba14ab681a60a9"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5869,7 +5869,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5891,9 +5891,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5909,7 +5909,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5929,7 +5929,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6054,7 +6054,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6065,7 +6065,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6231,7 +6231,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6307,18 +6307,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -6401,7 +6401,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6473,7 +6473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6711,7 +6711,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -6746,7 +6746,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6801,9 +6801,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "0.26.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6888,7 +6888,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6899,7 +6899,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6910,7 +6910,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6921,7 +6921,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7188,7 +7188,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7203,11 +7203,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -7218,18 +7218,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7249,7 +7249,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7270,7 +7270,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7292,7 +7292,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1267,14 +1267,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand 2.3.0",
  "futures-lite 2.6.0",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -1789,9 +1790,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -6316,9 +6317,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.25"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap 2.9.0",
  "serde",

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -305,6 +305,56 @@ docker compose logs -f
 Ensure all referenced slugs and trigger keys exist in their respective configuration files. The monitor will fail to start if it cannot resolve these references.
 ====
 
+==== Safe Protocol Guidelines
+
+The monitor implements protocol security validations across different components and will issue warnings when potentially insecure configurations are detected. While insecure protocols are not blocked, we strongly recommend following these security guidelines:
+
+===== Network Protocols
+
+====== RPC URLs
+* *HTTPS Recommended*: Using `https://` for RPC endpoints is strongly recommended
+* *WSS Recommended*: For WebSocket connections, `wss://` (secure WebSocket) is strongly recommended
+* *Warning*: Using `http://` or `ws://` will trigger security warnings as they transmit data unencrypted
+
+===== Notification Protocols
+
+====== Slack Notifications
+* *HTTPS Recommended*: Webhook URLs should start with `https://hooks.slack.com/`
+* *Warning*: Non-HTTPS URLs will trigger security warnings
+
+====== Discord Notifications
+* *HTTPS Recommended*: Webhook URLs should start with `https://discord.com/api/webhooks/`
+* *Warning*: Non-HTTPS URLs will trigger security warnings
+
+====== Email Notifications
+* *Secure Ports Recommended*: The following ports are considered secure:
+** 465: SMTPS (SMTP over SSL)
+** 587: SMTP with STARTTLS
+** 993: IMAPS (IMAP over SSL)
+* *Warning*: Using other ports will trigger security warnings
+* *Valid Format*: Email addresses must follow RFC 5322 format
+
+====== Webhook Notifications
+* *HTTPS Recommended*: URLs should use HTTPS protocol
+* *Authentication Recommended*: Including either:
+** `X-API-Key` header
+** `Authorization` header
+* *Optional Secret*: Can include a secret for HMAC authentication
+* *Warning*: Non-HTTPS URLs or missing authentication headers will trigger security warnings
+
+===== Script Security
+
+====== File Permissions (Unix Systems)
+* *Restricted Write Access*: Script files should not have overly permissive write permissions
+* *Recommended Permissions*: Use `644` (`rw-r--r--`) for script files
+* *Warning*: Files with mode `022` or more permissive will trigger security warnings
+
+.Example Setting Recommended Permissions
+[source,bash]
+----
+chmod 644 ./config/filters/my_script.sh
+----
+
 ==== Basic Configuration
 
 * Set up environment variables:

--- a/src/models/config/mod.rs
+++ b/src/models/config/mod.rs
@@ -30,6 +30,11 @@ pub trait ConfigLoader: Sized {
 	/// Returns Ok(()) if valid, or an error message if invalid.
 	fn validate(&self) -> Result<(), error::ConfigError>;
 
+	/// Validate safety of the protocol
+	///
+	/// Returns if safe, or logs a warning message if unsafe.
+	fn validate_protocol(&self);
+
 	/// Check if a file is a JSON file based on extension
 	fn is_json_file(path: &Path) -> bool {
 		path.extension()

--- a/src/models/config/monitor_config.rs
+++ b/src/models/config/monitor_config.rs
@@ -163,7 +163,32 @@ impl ConfigLoader for Monitor {
 			)?;
 		}
 
+		// Log a warning if the monitor uses an insecure protocol
+		self.validate_protocol();
+
 		Ok(())
+	}
+
+	/// Validate the safety of the protocols used in the monitor
+	///
+	/// Returns if safe, or logs a warning message if unsafe.
+	fn validate_protocol(&self) {
+		// Check script file permissions on Unix systems
+		#[cfg(unix)]
+		for condition in &self.trigger_conditions {
+			use std::os::unix::fs::PermissionsExt;
+			if let Ok(metadata) = std::fs::metadata(&condition.script_path) {
+				let permissions = metadata.permissions();
+				let mode = permissions.mode();
+				if mode & 0o022 != 0 {
+					tracing::warn!(
+						"Monitor '{}' trigger conditions script file has overly permissive write permissions: {}",
+						self.name,
+						condition.script_path
+					);
+				}
+			}
+		}
 	}
 }
 
@@ -176,6 +201,7 @@ mod tests {
 	};
 	use std::collections::HashMap;
 	use tempfile::TempDir;
+	use tracing_test::traced_test;
 
 	#[test]
 	fn test_load_valid_monitor() {
@@ -569,5 +595,48 @@ mod tests {
 		if let Err(ConfigError::FileError(err)) = result {
 			assert!(err.message.contains("monitors directory not found"));
 		}
+	}
+
+	#[cfg(unix)]
+	#[test]
+	#[traced_test]
+	fn test_validate_protocol_script_permissions() {
+		use std::fs::File;
+		use std::os::unix::fs::PermissionsExt;
+		use tempfile::TempDir;
+
+		let temp_dir = TempDir::new().unwrap();
+		let script_path = temp_dir.path().join("test_script.sh");
+		File::create(&script_path).unwrap();
+
+		// Set overly permissive permissions (777)
+		let metadata = std::fs::metadata(&script_path).unwrap();
+		let mut permissions = metadata.permissions();
+		permissions.set_mode(0o777);
+		std::fs::set_permissions(&script_path, permissions).unwrap();
+
+		let monitor = Monitor {
+			name: "TestMonitor".to_string(),
+			networks: vec!["ethereum_mainnet".to_string()],
+			paused: false,
+			addresses: vec![],
+			match_conditions: MatchConditions {
+				functions: vec![],
+				events: vec![],
+				transactions: vec![],
+			},
+			trigger_conditions: vec![TriggerConditions {
+				script_path: script_path.to_str().unwrap().to_string(),
+				timeout_ms: 1000,
+				arguments: None,
+				language: ScriptLanguage::Bash,
+			}],
+			triggers: vec![],
+		};
+
+		monitor.validate_protocol();
+		assert!(logs_contain(
+			"script file has overly permissive write permissions"
+		));
 	}
 }

--- a/src/models/config/monitor_config.rs
+++ b/src/models/config/monitor_config.rs
@@ -182,7 +182,7 @@ impl ConfigLoader for Monitor {
 				let mode = permissions.mode();
 				if mode & 0o022 != 0 {
 					tracing::warn!(
-						"Monitor '{}' trigger conditions script file has overly permissive write permissions: {}",
+						"Monitor '{}' trigger conditions script file has overly permissive write permissions: {}. The recommended permissions are `644` (`rw-r--r--`)",
 						self.name,
 						condition.script_path
 					);

--- a/src/models/config/trigger_config.rs
+++ b/src/models/config/trigger_config.rs
@@ -467,7 +467,73 @@ impl ConfigLoader for Trigger {
 				}
 			}
 		}
+
+		// Log a warning if the trigger uses an insecure protocol
+		self.validate_protocol();
+
 		Ok(())
+	}
+
+	/// Validate the safety of the protocols used in the trigger
+	///
+	/// Returns if safe, or logs a warning message if unsafe.
+	fn validate_protocol(&self) {
+		match &self.config {
+			TriggerTypeConfig::Slack { slack_url, .. } => {
+				if !slack_url.starts_with("https://") {
+					tracing::warn!("Slack URL uses an insecure protocol: {}", slack_url);
+				}
+			}
+			TriggerTypeConfig::Discord { discord_url, .. } => {
+				if !discord_url.starts_with("https://") {
+					tracing::warn!("Discord URL uses an insecure protocol: {}", discord_url);
+				}
+			}
+			TriggerTypeConfig::Telegram { .. } => {}
+			TriggerTypeConfig::Script { script_path, .. } => {
+				// Check script file permissions on Unix systems
+				#[cfg(unix)]
+				{
+					use std::os::unix::fs::PermissionsExt;
+					if let Ok(metadata) = std::fs::metadata(script_path) {
+						let permissions = metadata.permissions();
+						let mode = permissions.mode();
+						if mode & 0o022 != 0 {
+							tracing::warn!(
+								"Script file has overly permissive write permissions: {}",
+								script_path
+							);
+						}
+					}
+				}
+			}
+			TriggerTypeConfig::Email { port, .. } => {
+				let secure_ports = [993, 587, 465];
+				if let Some(port) = port {
+					if !secure_ports.contains(port) {
+						tracing::warn!("Email port is not using a secure protocol: {}", port);
+					}
+				}
+			}
+			TriggerTypeConfig::Webhook { url, headers, .. } => {
+				if !url.starts_with("https://") {
+					tracing::warn!("Webhook URL uses an insecure protocol: {}", url);
+				}
+				// Check for security headers
+				match headers {
+					Some(headers) => {
+						if !headers.contains_key("X-API-Key")
+							&& !headers.contains_key("Authorization")
+						{
+							tracing::warn!("Webhook lacks authentication headers");
+						}
+					}
+					None => {
+						tracing::warn!("Webhook lacks authentication headers");
+					}
+				}
+			}
+		};
 	}
 }
 
@@ -480,6 +546,7 @@ mod tests {
 	};
 	use std::{fs::File, io::Write, os::unix::fs::PermissionsExt};
 	use tempfile::TempDir;
+	use tracing_test::traced_test;
 
 	#[test]
 	fn test_slack_trigger_validation() {
@@ -1137,5 +1204,151 @@ mod tests {
 		let mut perms = std::fs::metadata(&file_path).unwrap().permissions();
 		perms.set_mode(0o644);
 		std::fs::set_permissions(&file_path, perms).unwrap();
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_validate_protocol_slack() {
+		let insecure_trigger = Trigger {
+			name: "test_slack".to_string(),
+			trigger_type: TriggerType::Slack,
+			config: TriggerTypeConfig::Slack {
+				slack_url: "http://hooks.slack.com/services/xxx".to_string(),
+				message: NotificationMessage {
+					title: "Alert".to_string(),
+					body: "Test message".to_string(),
+				},
+			},
+		};
+
+		insecure_trigger.validate_protocol();
+		assert!(logs_contain("Slack URL uses an insecure protocol"));
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_validate_protocol_discord() {
+		let insecure_trigger = Trigger {
+			name: "test_discord".to_string(),
+			trigger_type: TriggerType::Discord,
+			config: TriggerTypeConfig::Discord {
+				discord_url: "http://discord.com/api/webhooks/xxx".to_string(),
+				message: NotificationMessage {
+					title: "Alert".to_string(),
+					body: "Test message".to_string(),
+				},
+			},
+		};
+
+		insecure_trigger.validate_protocol();
+		assert!(logs_contain("Discord URL uses an insecure protocol"));
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_validate_protocol_webhook() {
+		let insecure_trigger = Trigger {
+			name: "test_webhook".to_string(),
+			trigger_type: TriggerType::Webhook,
+			config: TriggerTypeConfig::Webhook {
+				url: "http://api.example.com/webhook".to_string(),
+				method: Some("POST".to_string()),
+				headers: None,
+				secret: None,
+				message: NotificationMessage {
+					title: "Alert".to_string(),
+					body: "Test message".to_string(),
+				},
+			},
+		};
+
+		insecure_trigger.validate_protocol();
+		assert!(logs_contain("Webhook URL uses an insecure protocol"));
+		assert!(logs_contain("Webhook lacks authentication headers"));
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_validate_protocol_email() {
+		let insecure_trigger = Trigger {
+			name: "test_email".to_string(),
+			trigger_type: TriggerType::Email,
+			config: TriggerTypeConfig::Email {
+				host: "smtp.example.com".to_string(),
+				port: Some(25), // Insecure port
+				username: "user".to_string(),
+				password: "pass".to_string(),
+				message: NotificationMessage {
+					title: "Test".to_string(),
+					body: "Test message".to_string(),
+				},
+				sender: EmailAddress::new_unchecked("sender@example.com"),
+				recipients: vec![EmailAddress::new_unchecked("recipient@example.com")],
+			},
+		};
+
+		insecure_trigger.validate_protocol();
+		assert!(logs_contain("Email port is not using a secure protocol"));
+	}
+
+	#[cfg(unix)]
+	#[test]
+	#[traced_test]
+	fn test_validate_protocol_script() {
+		use std::fs::File;
+		use std::os::unix::fs::PermissionsExt;
+		use tempfile::TempDir;
+
+		let temp_dir = TempDir::new().unwrap();
+		let script_path = temp_dir.path().join("test_script.sh");
+		File::create(&script_path).unwrap();
+
+		// Set overly permissive permissions (777)
+		let metadata = std::fs::metadata(&script_path).unwrap();
+		let mut permissions = metadata.permissions();
+		permissions.set_mode(0o777);
+		std::fs::set_permissions(&script_path, permissions).unwrap();
+
+		let trigger = Trigger {
+			name: "test_script".to_string(),
+			trigger_type: TriggerType::Script,
+			config: TriggerTypeConfig::Script {
+				script_path: script_path.to_str().unwrap().to_string(),
+				language: ScriptLanguage::Bash,
+				timeout_ms: 1000,
+				arguments: None,
+			},
+		};
+
+		trigger.validate_protocol();
+		assert!(logs_contain(
+			"Script file has overly permissive write permissions"
+		));
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_validate_protocol_webhook_with_headers() {
+		let mut headers = HashMap::new();
+		headers.insert("Content-Type".to_string(), "application/json".to_string());
+
+		let insecure_trigger = Trigger {
+			name: "test_webhook".to_string(),
+			trigger_type: TriggerType::Webhook,
+			config: TriggerTypeConfig::Webhook {
+				url: "http://api.example.com/webhook".to_string(),
+				method: Some("POST".to_string()),
+				headers: Some(headers),
+				secret: None,
+				message: NotificationMessage {
+					title: "Alert".to_string(),
+					body: "Test message".to_string(),
+				},
+			},
+		};
+
+		insecure_trigger.validate_protocol();
+		assert!(logs_contain("Webhook URL uses an insecure protocol"));
+		assert!(logs_contain("Webhook lacks authentication headers"));
 	}
 }

--- a/src/models/config/trigger_config.rs
+++ b/src/models/config/trigger_config.rs
@@ -500,7 +500,7 @@ impl ConfigLoader for Trigger {
 						let mode = permissions.mode();
 						if mode & 0o022 != 0 {
 							tracing::warn!(
-								"Script file has overly permissive write permissions: {}",
+								"Script file has overly permissive write permissions: {}.The recommended permissions are `644` (`rw-r--r--`)",
 								script_path
 							);
 						}


### PR DESCRIPTION
# Summary

https://linear.app/openzeppelin-development/issue/PLAT-6247/add-productiondevelopment-flag-and-validate-unsafe-portprotocol-uses

- Logs a warning message when:
- - insecure protocol is used (HTTP)
- - insecure port is used (!= 465, 587, 993)
- - there is a lack of webhook auth headers
- - script files are overly permissive
- Updates documentation to reflect safe protocol guidelines

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
