### PR TITLE
feat: Add environment vars and Hashicorp cloud vault support (breaking)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3808,7 +3808,8 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "oz-keystore"
 version = "0.1.3"
-source = "git+https://github.com/OpenZeppelin/oz-keystore.git?branch=allow-overriding-base-urls#6400fe6736aac4a933cfbd754cd791be2b7fdad9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34912c1f66968ad8bde9dbad76fd7f5bf90c78df82c1ead387b8d8099207b337"
 dependencies = [
  "base64 0.22.1",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e556656901af91d214076fa93c34aeead783d37eb574b28711df108728e6c5"
+checksum = "94a59fc882d15edfd3c4e315d29e4521769d5c90d32eba8e4511599959d24bd9"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c103f18381c4f17b5691cbea7baa3bafa7da3bf9c9b7d90f94f48715c6cc054"
+checksum = "e95f195ff89abc65469bb141b8ac73d69ea0c3589331f1ad10573f5e05beb168"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c13988a8d23dfd00a49dc6702bc704000d34853951f23b9c125a342ee537443"
+checksum = "c5eb741241cd0a6c59eb2d75221ae1530de821781d9a32d532ed010c1dec277a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1179cffcb18617a3f8119faa9fc18c3a10f4d192efed51e28f3c66cfd0aff392"
+checksum = "c3ea02cfa0b71757693251af6fae7052cf4011dfb0f8d1c59f94ae634f7355ae"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86eba345a4e6ff5684cb98c0aedc69eca4db77cbca3a456e7930ab7d086febdd"
+checksum = "3c763c3a7c99d3eb61c8383a0c54264372f2ef13353cbb8fa0769c601c102a0a"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e126d004937fd347ec65ed5b27ff39d82dd3c500dc91be6cd3d4fa4b004f63da"
+checksum = "b373f9795eb86bc3e043d50d4102e3623e2a5652ae628a478035ddb9d12d80c1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b3429d59feb5c72e1e5f92efd6f67def0f6a8de5cb610aea56c35eff1cf60d"
+checksum = "b1abf511974854b470e0e45588c2a06cceb38fa1ab2066d4cb61581e82687b76"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb5acf3ae77e8e9775673d9f81f96c1f5596824c35b4f158c5f8eb30e4d565f"
+checksum = "adf68d6a8664c89847905b63fef561c54fd9ecb42ef92053e7935a61b8ec453e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d770bdcca12fe2b3e973de3f17290065b42c6d9a10cbd9728877bbbbfb050b6"
+checksum = "a83c70f1509416f905f809a27006d3b8e2005d9d1e4aeee994882ae0397477c5"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bdea7fbe75f25cfcaf6aebf27205c975af9fb789a2ff1699431654139585afa"
+checksum = "64578f486297b27de47434f45659d3648e3326e195dab596e8a4161e91723bd5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c35ff3212bb01dc0e3456e685a022cd880776954752628714b2867fc6aa5ef"
+checksum = "7622a767f5db7bb0165895e821a643c9903e6422f9986663b754cce6b9e972d7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f5f4e5340ae70163848eaf22d55125254a2b4362daa3d774fd8c5519c59a39f"
+checksum = "00bb8eb6eeeb6ba57a49e77cc73169ba099081daedb9596f61d91e27cfb8a012"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4feb6dd2776f88f10e189bda1b9c25a7ae812bce37a195542a9a2ed9389cc33"
+checksum = "815e430440eadcf61d7ea90dab5642bcf72056a8eacaffb97820d3a41fcdc0da"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b7326d4bec9bf410a69306a6ac489451c882bf250041400e35fa297d8fc7dd9"
+checksum = "329177b79cc1db6a82477cb470fe5fa1a07d06a13425392edc254c664536caed"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d1a67b833618d34929f343c764cd84b88fb76af48fe3f4581ac6919e453822f"
+checksum = "a148344212e34b213a9e3516ace482df74f4146b43bd898f2e8c655707851ec3"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8619f59234d17a2055d8eb3f5fe46b2a8e3f9fe9ad99d96adfe5ce042392aba"
+checksum = "e2838ef592345b46b4aeffbb8dd4c857a84d4d7e6f14a8edef34197d74bc1d39"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177843a59f906433720d42a89c4f3d1ef628032ccb15f9230d72621b00c7cd6e"
+checksum = "3e228902dd802e9af385ca9d511f1556b647bf651d65574ae5e198447db96eaf"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d08bc32276225c44bdc14b34ed244a1b4ccab0b4e39025bfc3dd60be5203af43"
+checksum = "6f2530ba812172a7749b7af9bfbcb94cd555109e0a97458716b4543c36b81339"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e38344e1639385d79fe092bc25d3074fa7356c92d331be0992bb56753bdccc"
+checksum = "4bc246ec9df92018d7be5bb3da2be87a2b9e35d076afa7c0f4dbeaefd2ba9ac0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9a5dbb3a8ba53d732c6396a63fabff3d5ec0433a2ecc0702b7fe09c30d921d"
+checksum = "f66c7991d20ac2dfbf2fe1aeb303e20abbdb1ee85b3eaf0cf8512deef2f2e5f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f448b0d9ee32ef23565ac4dfb0ea7544b03c01571ee187c471337a6f1b3cb203"
+checksum = "57fd26c861032c1e91f430ef534e70a806d4486d3382d1e2e28033570b20fe43"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07abd80b2db2606a4d4566b8d71440534c46160f6bd34cf029be145ecc20fd46"
+checksum = "c37f6e07803121bd9597058f83726f7dc316fc630a0dad61c3c7a1fb784303c5"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9031fac651c1d62ae27afaa2b5083121f5c46e610564935b0b6f7909b484e0c"
+checksum = "c7ae7b607365e02bd879679dd295809d73391510ab21b917973317fb8b90228b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a81e6e2030ca40ffa5613e8193339c341eec0c34f2dc4eb9d9071cf968a2d98c"
+checksum = "c30aa026c88924cfa89ddfa77ad77aec05d2153c6838422dcdaf559a6e9e3175"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0a4428116e2305bd36692bf2664ea28ff927897a0dc183555efbccf7707fba"
+checksum = "3259b177d89bb02599bddb4cd3c11ec5a1ffdaaa01a2706e8298e08433f205f0"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7534710fab1c9221805afd8af9595db862f6c3ecbc810ed47fe663ce5b0c49d3"
+checksum = "e8722fa30fc71c11f7626b35712ffba266497f304ede4fe09fc2a3c130c1eee5"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.15.8"
+version = "0.15.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30c1ef1fc3a4a6b17c9aeec9aa171504e806b50ac9c5099eb4aba60e4d24030c"
+checksum = "fadcf1dc3105a51ac24070fed1a696334c7f77f639501e580c243490d0ba3d18"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3808,8 +3808,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "oz-keystore"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34912c1f66968ad8bde9dbad76fd7f5bf90c78df82c1ead387b8d8099207b337"
+source = "git+https://github.com/OpenZeppelin/oz-keystore.git?branch=allow-overriding-base-urls#6400fe6736aac4a933cfbd754cd791be2b7fdad9"
 dependencies = [
  "base64 0.22.1",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,7 +34,7 @@ dependencies = [
  "brotli",
  "bytes",
  "bytestring",
- "derive_more 2.0.1",
+ "derive_more",
  "encoding_rs",
  "flate2",
  "foldhash",
@@ -50,7 +50,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rand 0.9.1",
- "sha1 0.10.6",
+ "sha1",
  "smallvec",
  "tokio",
  "tokio-util",
@@ -149,8 +149,8 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie 0.16.2",
- "derive_more 2.0.1",
+ "cookie",
+ "derive_more",
  "encoding_rs",
  "foldhash",
  "futures-core",
@@ -169,7 +169,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec",
  "socket2",
- "time 0.3.41",
+ "time",
  "tracing",
  "url",
 ]
@@ -202,57 +202,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "aead"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "aes"
-version = "0.6.0"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "aes-soft",
- "aesni",
+ "cfg-if",
  "cipher",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
-name = "aes-soft"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
-dependencies = [
- "cipher",
- "opaque-debug",
-]
-
-[[package]]
-name = "aesni"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
-dependencies = [
- "cipher",
- "opaque-debug",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -310,9 +267,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b4ae82946772d69f868b9ef81fc66acb1b149ef9b4601849bec4bcf5da6552e"
+checksum = "3287a60462d933cbc753a1a87439016d4eb717401f3052ff72742c6dd0dbce3f"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -335,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.69"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28e2652684758b0d9b389d248b209ed9fd9989ef489a550265fe4bb8454fe7eb"
+checksum = "7734aecfc58a597dde036e4c5cace2ae43e2f8bf3d406b022a1ef34da178dd49"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -346,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fbf458101ed6c389e9bb70a34ebc56039868ad10472540614816cdedc8f5265"
+checksum = "94ee204a7795e56b8e78013f5824d6ea6e4da457a4aaf6c72e4800c4d4987fce"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -357,7 +314,7 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more",
  "either",
  "k256",
  "once_cell",
@@ -369,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc982af629e511292310fe85b433427fd38cb3105147632b574abc997db44c91"
+checksum = "a16df75c656be4465ab411b88c5ec6bae4931ce806834efbf375ca85b8db6f9a"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -383,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0a0c1ddee20ecc14308aae21c2438c994df7b39010c26d70f86e1d8fdb8db0"
+checksum = "258feff52f1e3be58b4d235ef85f5c0224905e371fb023dfbf758d5a7e027672"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -405,9 +362,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d8bcce99ad10fe02640cfaec1c6bc809b837c783c1d52906aa5af66e2a196f6"
+checksum = "9d020a85ae8cf79b9c897a86d617357817bbc9a7d159dd7e6fedf1bc90f64d35"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -418,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
+checksum = "884a5d4560f7e5e34ec3c5e54a60223c56352677dd049b495fbb59384cf72a90"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -435,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2124"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
+checksum = "741bdd7499908b3aa0b159bba11e71c8cddd009a2c2eb7a06e825f1ec87900a5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -448,9 +405,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
+checksum = "dbe3e16484669964c26ac48390245d84c410b1a5f968976076c17184725ef235"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -459,9 +416,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b15b13d38b366d01e818fe8e710d4d702ef7499eacd44926a06171dd9585d0c"
+checksum = "804cefe429015b4244966c006d25bda5545fa9db5990e9c9079faf255052f50a"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -472,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e86967eb559920e4b9102e4cb825fe30f2e9467988353ce4809f0d3f2c90cd4"
+checksum = "fd8ce6197b2cc38968c80c676372f383ed46051fb8600a421b5259f3f2d13a15"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -484,18 +441,17 @@ dependencies = [
  "alloy-serde",
  "auto_impl",
  "c-kzg",
- "derive_more 2.0.1",
+ "derive_more",
  "either",
- "once_cell",
  "serde",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40de6f5b53ecf5fd7756072942f41335426d9a3704cd961f77d854739933bcf"
+checksum = "bc13f76f34587a9d5efd1d141dd6a596983be715922ccc488209e58dc643ec65"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -506,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
+checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -518,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27434beae2514d4a2aa90f53832cbdf6f23e4b5e2656d95eaf15f9276e2418b6"
+checksum = "3593ce03c82601517eee458f67bb5dc642b9baff7016063f03a4ccbcfb52a387"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -532,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a33a38c7486b1945f8d093ff027add2f3a8f83c7300dbad6165cc49150085e"
+checksum = "36be8015a205bf2e6784b0367c0f29e87f901f5f9b80b0a9bb4e1411c65242fd"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -549,7 +505,7 @@ dependencies = [
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
- "derive_more 2.0.1",
+ "derive_more",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -558,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db973a7a23cbe96f2958e5687c51ce2d304b5c6d0dc5ccb3de8667ad8476f50b"
+checksum = "3449fdd0908f50fb68eef8c43201d73d4ff51882b36e2adaadab277a7539ce4f"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -571,15 +527,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c77490fe91a0ce933a1f219029521f20fc28c2c0ca95d53fa4da9c00b8d9d4e"
+checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 2.0.1",
+ "derive_more",
  "foldhash",
  "hashbrown 0.15.2",
  "indexmap 2.9.0",
@@ -588,7 +544,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.8.5",
+ "rand 0.9.1",
  "ruint",
  "rustc-hash",
  "serde",
@@ -598,9 +554,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b03bde77ad73feae14aa593bcabb932c8098c0f0750ead973331cfc0003a4e1"
+checksum = "16db7e6c225828a4540b1cce6047f06777c057df58386db9641827a2d1afb4f5"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -616,6 +572,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
+ "alloy-signer",
  "alloy-sol-types",
  "alloy-transport",
  "alloy-transport-http",
@@ -625,6 +582,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "dashmap",
+ "either",
  "futures",
  "futures-utils-wasm",
  "lru",
@@ -642,21 +600,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721aca709a9231815ad5903a2d284042cc77e7d9d382696451b30c9ee0950001"
+checksum = "2fbf7f3b22f7d34eb9aedf637bcdc5d4f47f5e028d3f7520f6ecc7fc75a7a027"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
  "alloy-transport",
  "bimap",
  "futures",
+ "parking_lot 0.12.3",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
  "tower 0.5.2",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -683,9 +643,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445a3298c14fae7afb5b9f2f735dead989f3dd83020c2ab8e48ed95d7b6d1acb"
+checksum = "821fca097f02720cd2a53e785776e265f36288f8210aa9177c9de05e2c2724c3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -711,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157deaec6ba2ad7854f16146e4cd60280e76593eed79fdcb06e0fa8b6c60f77"
+checksum = "30890a9856721a376e989283a17b2698acc3e1a612415abbca980aa4d29d7367"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -727,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a80ee83ef97e7ffd667a81ebdb6154558dfd5e8f20d8249a10a12a1671a04b3"
+checksum = "8702ccf7d241cb52fc6730561f7429c15158dacffe68c9127d2ab79d1657b862"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -739,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604dea1f00fd646debe8033abe8e767c732868bf8a5ae9df6321909ccbc99c56"
+checksum = "93017fb350fe2c0cccda41f9be45352012696a5fbd08c5fef4be0df838999bfa"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -750,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08b113a0087d226291b9768ed331818fa0b0744cc1207ae7c150687cf3fde1bd"
+checksum = "ec0b7976ba2e770e085389c8f9ffa81812700254c36e5cc35bca496e9491d1e3"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -760,16 +720,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874ac9d1249ece0453e262d9ba72da9dbb3b7a2866220ded5940c2e47f1aa04d"
+checksum = "4f09bac3a6651e3e9e292e946a1fc393128aa1a572254e2ff641e9911f024f61"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 2.0.1",
+ "derive_more",
  "rand 0.8.5",
  "serde",
  "strum",
@@ -777,9 +737,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e13d71eac04513a71af4b3df580f52f2b4dcbff9d971cc9a52519acf55514cb"
+checksum = "d9f96bc409dee49f68d70bf1303c3b34d7153e185dda75caa8b72919a28cd6ac"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -797,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4747763aee39c1b0f5face79bde9be8932be05b2db7d8bdcebb93490f32c889c"
+checksum = "1c24a733a999bbfa706d03f54332ad03697e745ed27c25bdeebac39586f184d8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -811,9 +771,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70132ebdbea1eaa68c4d6f7a62c2fadf0bdce83b904f895ab90ca4ec96f63468"
+checksum = "ac6d62259b6e1469042a21807d5f24002a7a0f30f69e945ded82ed6009fd1e50"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -823,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a1cd73fc054de6353c7f22ff9b846b0f0f145cd0112da07d4119e41e9959207"
+checksum = "3fa2fc7f82a9884ff1632d2a2137d35fef4db9270c85668634a603be5948fcdc"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -834,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96fbde54bee943cd94ebacc8a62c50b38c7dfd2552dcd79ff61aea778b1bfcc"
+checksum = "44eaf520bbb527ba90a3dd963aadf0c339595932169fb10f7330fe779336436e"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -849,9 +809,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6e72002cc1801d8b41e9892165e3a6551b7bd382bd9d0414b21e90c0c62551"
+checksum = "1f8d1f2edc446b52985a5af71cdbce86e8646865b889e38410594eea97804380"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -865,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
+checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -879,9 +839,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
+checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -898,9 +858,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3d30f0d3f9ba3b7686f3ff1de9ee312647aac705604417a2f40c604f409a9e"
+checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -916,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
+checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
 dependencies = [
  "serde",
  "winnow 0.7.7",
@@ -926,9 +886,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
+checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -939,13 +899,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec325c2af8562ef355c02aeb527c755a07e9d8cf6a1e65dda8d0bf23e29b2c"
+checksum = "609f69c9153df716e7e6ef002cba69f94b7635eb2c603fff69b664aa6acea93a"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
- "derive_more 2.0.1",
+ "derive_more",
  "futures",
  "futures-utils-wasm",
  "parking_lot 0.12.3",
@@ -961,9 +921,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a082c9473c6642cce8b02405a979496126a03b096997888e86229afad05db06c"
+checksum = "c2e60987afbc49b8719578355726059579a1a197741a2adae52f860d5d7464cc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -976,9 +936,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a78cfda2cac16fa83f6b5dd8b4643caec6161433b25b67e484ce05d2194513"
+checksum = "0a0cad5f19f718b83d4a52ebc12f3b691b245111e50403d2adfd46674bc73da8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -996,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.12.6"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae865917bdabaae21f418010fe7e8837c6daa6611fde25f8d78a1778d6ecb523"
+checksum = "f48cc4f88d59463992251b89381760be901c4789a4721c657b832994331aff05"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1014,14 +974,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.7.9"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a94854e420f07e962f7807485856cde359ab99ab6413883e15235ad996e8b"
+checksum = "983d99aa81f586cef9dae38443245e585840fcf0fc58b09aee0b1f27aed1d500"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "arrayvec",
- "derive_more 1.0.0",
+ "derive_more",
  "nybbles",
  "serde",
  "smallvec",
@@ -1098,6 +1058,15 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "ark-ff"
@@ -1243,128 +1212,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
-dependencies = [
- "concurrent-queue",
- "event-listener 2.5.3",
- "futures-core",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand 2.3.0",
- "futures-lite 2.6.0",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
-dependencies = [
- "async-channel 2.3.1",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite 2.6.0",
- "once_cell",
-]
-
-[[package]]
-name = "async-io"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
-dependencies = [
- "async-lock",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite 2.6.0",
- "parking",
- "polling",
- "rustix 0.38.44",
- "slab",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
-dependencies = [
- "event-listener 5.4.0",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-sse"
-version = "5.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e6fa871e4334a622afd6bb2f611635e8083a6f5e2936c0f90f37c7ef9856298"
-dependencies = [
- "async-channel 1.9.0",
- "futures-lite 1.13.0",
- "http-types",
- "log",
- "memchr",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-std"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
-dependencies = [
- "async-channel 1.9.0",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite 2.6.0",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,12 +1232,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -1449,26 +1290,14 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
-name = "base32"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ce669cd6c8588f79e15cf450314f9638f967fc5770ff1c7c1deb0925ea7cfa"
 
 [[package]]
 name = "base64"
@@ -1550,33 +1379,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
-dependencies = [
- "async-channel 2.3.1",
- "async-task",
- "futures-io",
- "futures-lite 2.6.0",
- "piper",
 ]
 
 [[package]]
@@ -1636,6 +1443,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1660,10 +1476,11 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byte-unit"
-version = "4.0.19"
+version = "5.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da78b32057b8fdfc352504708feeba7216dcd65a2c9ab02978cbd288d1279b6c"
+checksum = "e1cd29c3c585209b0cbc7309bfe3ed7efd8c84c21b7af29c8bfae908f8777174"
 dependencies = [
+ "rust_decimal",
  "serde",
  "utf8-width",
 ]
@@ -1716,10 +1533,11 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.3"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
+checksum = "4e7e3c397401eb76228c89561cf22f85f41c95aa799ee9d860de3ea1cbc728fc"
 dependencies = [
+ "arbitrary",
  "blst",
  "cc",
  "glob",
@@ -1825,11 +1643,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.2.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "generic-array",
+ "crypto-common",
+ "inout",
 ]
 
 [[package]]
@@ -1888,15 +1707,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "const-hex"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,12 +1724,6 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
-name = "const_fn"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
 
 [[package]]
 name = "const_format"
@@ -1943,29 +1747,12 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a5d7b21829bc7b4bf4754a978a241ae54ea55a40f92bb20216e54096f4b951"
-dependencies = [
- "aes-gcm",
- "base64 0.13.1",
- "hkdf",
- "hmac 0.10.1",
- "percent-encoding",
- "rand 0.8.5",
- "sha2 0.9.9",
- "time 0.2.27",
- "version_check",
-]
-
-[[package]]
-name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
  "percent-encoding",
- "time 0.3.41",
+ "time",
  "version_check",
 ]
 
@@ -1995,12 +1782,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
-
-[[package]]
 name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2025,12 +1806,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "crc16"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
@@ -2071,25 +1846,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2124,20 +1880,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "ctr"
-version = "0.6.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
 dependencies = [
  "cipher",
 ]
@@ -2229,12 +1975,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "1.0.0"
+name = "derive_arbitrary"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
- "derive_more-impl 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2243,18 +1991,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
 dependencies = [
- "derive_more-impl 2.0.1",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "derive_more-impl",
 ]
 
 [[package]]
@@ -2284,17 +2021,11 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
  "crypto-common",
  "subtle",
 ]
-
-[[package]]
-name = "discard"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "displaydoc"
@@ -2312,6 +2043,12 @@ name = "doctest-file"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aac81fa3e28d21450aa4d2ac065992ba96a1d7303efbce51a95f4fd175b67562"
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dotenvy"
@@ -2354,17 +2091,8 @@ dependencies = [
  "elliptic-curve",
  "rfc6979",
  "serdect",
- "signature 2.2.0",
+ "signature",
  "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "1.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
-dependencies = [
- "signature 1.6.4",
 ]
 
 [[package]]
@@ -2447,6 +2175,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
+name = "eth-keystore"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fda3bf123be441da5260717e0661c25a2fd9cb2b2c1d20bf2e05580047158ab"
+dependencies = [
+ "aes",
+ "ctr",
+ "digest 0.10.7",
+ "hex",
+ "hmac",
+ "pbkdf2",
+ "rand 0.8.5",
+ "scrypt",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sha3",
+ "thiserror 1.0.69",
+ "uuid 0.8.2",
+]
+
+[[package]]
 name = "ethabi"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2488,42 +2238,6 @@ dependencies = [
  "impl-serde",
  "primitive-types",
  "uint",
-]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
-version = "5.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener 5.4.0",
- "pin-project-lite",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -2704,34 +2418,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
-name = "futures-lite"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49a9d51ce47660b1e808d3c990b4709f2f415d928835a17dfd16991515c46bce"
-dependencies = [
- "fastrand 1.9.0",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
-
-[[package]]
-name = "futures-lite"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
-dependencies = [
- "fastrand 2.3.0",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
 name = "futures-macro"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,17 +2477,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
@@ -2826,16 +2501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghash"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
-
-[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,18 +2511,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "group"
@@ -2952,38 +2605,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
-name = "hermit-abi"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "hkdf"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
-dependencies = [
- "digest 0.9.0",
- "hmac 0.10.1",
-]
-
-[[package]]
-name = "hmac"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
 ]
 
 [[package]]
@@ -3060,28 +2687,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
-]
-
-[[package]]
-name = "http-types"
-version = "2.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9b187a72d63adbfba487f48095306ac823049cb504ee195541e91c7775f5ad"
-dependencies = [
- "anyhow",
- "async-channel 1.9.0",
- "async-std",
- "base64 0.13.1",
- "cookie 0.14.4",
- "futures-lite 1.13.0",
- "infer",
- "pin-project-lite",
- "rand 0.7.3",
- "serde",
- "serde_json",
- "serde_qs",
- "serde_urlencoded",
- "url",
 ]
 
 [[package]]
@@ -3172,19 +2777,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
 ]
 
 [[package]]
@@ -3459,10 +3051,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "infer"
-version = "0.2.3"
+name = "inout"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e9829a50b42bb782c1df523f78d332fe371b10c661e78b7a3c34b0198e9fac"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "instant"
@@ -3557,12 +3152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
-
-[[package]]
 name = "jsonrpsee-core"
 version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3626,7 +3215,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.8",
+ "sha2",
 ]
 
 [[package]]
@@ -3646,15 +3235,6 @@ checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
-]
-
-[[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
 ]
 
 [[package]]
@@ -3691,7 +3271,7 @@ dependencies = [
  "chumsky",
  "email-encoding",
  "email_address",
- "fastrand 2.3.0",
+ "fastrand",
  "futures-util",
  "hostname",
  "httpdate",
@@ -3737,12 +3317,6 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
@@ -3785,9 +3359,6 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
-dependencies = [
- "value-bag",
-]
 
 [[package]]
 name = "lru"
@@ -3992,17 +3563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-rational"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4018,7 +3578,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4056,6 +3616,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.0",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,12 +3638,6 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opener"
@@ -4152,7 +3715,7 @@ dependencies = [
  "futures",
  "glob",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "lazy_static",
  "lettre",
  "libc",
@@ -4160,6 +3723,7 @@ dependencies = [
  "mockall",
  "mockito",
  "once_cell",
+ "oz-keystore",
  "prometheus",
  "proptest",
  "rand 0.9.1",
@@ -4169,10 +3733,9 @@ dependencies = [
  "reqwest-retry",
  "serde",
  "serde_json",
- "sha2 0.10.8",
- "stellar-horizon",
+ "sha2",
  "stellar-rpc-client",
- "stellar-strkey 0.0.12",
+ "stellar-strkey 0.0.13",
  "stellar-xdr",
  "sysinfo",
  "tempfile",
@@ -4186,7 +3749,8 @@ dependencies = [
  "tracing-test",
  "url",
  "urlencoding",
- "uuid",
+ "uuid 1.16.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -4215,6 +3779,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "oz-keystore"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb691c7845692a1c33f6e57a7fbfe53f2156d032744f17919a4c4e1d102dd63"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "dotenv",
+ "eth-keystore",
+ "hex",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "stellar-strkey 0.0.9",
+ "tokio",
+]
+
+[[package]]
 name = "parity-scale-codec"
 version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4241,12 +3823,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4293,7 +3869,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.11",
  "smallvec",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4301,6 +3877,15 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4362,17 +3947,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand 2.3.0",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4387,32 +3961,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "polling"
-version = "3.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi 0.4.0",
- "pin-project-lite",
- "rustix 0.38.44",
- "tracing",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "polyval"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
-dependencies = [
- "cpuid-bool",
- "opaque-debug",
- "universal-hash",
-]
 
 [[package]]
 name = "powerfmt"
@@ -4498,12 +4046,6 @@ dependencies = [
  "quote",
  "syn 2.0.101",
 ]
-
-[[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
@@ -4642,19 +4184,6 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -4673,16 +4202,7 @@ checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "serde",
 ]
 
 [[package]]
@@ -4707,15 +4227,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -4730,15 +4241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "serde",
 ]
 
 [[package]]
@@ -4748,26 +4251,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -4855,9 +4338,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4870,7 +4353,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -4949,7 +4432,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac 0.12.1",
+ "hmac",
  "subtle",
 ]
 
@@ -4982,7 +4465,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -5075,15 +4558,6 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -5102,19 +4576,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
@@ -5122,7 +4583,7 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
 ]
 
@@ -5240,6 +4701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5262,6 +4732,18 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f9e24d2b632954ded8ab2ef9fea0a0c769ea56ea98bddbafbad22caeeadf45d"
+dependencies = [
+ "hmac",
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "sct"
@@ -5319,20 +4801,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.3",
+ "semver-parser",
 ]
 
 [[package]]
@@ -5340,12 +4813,6 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -5417,17 +4884,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_qs"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
-dependencies = [
- "percent-encoding",
- "serde",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5463,7 +4919,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time 0.3.41",
+ "time",
 ]
 
 [[package]]
@@ -5490,15 +4946,6 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
-dependencies = [
- "sha1_smol",
-]
-
-[[package]]
-name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
@@ -5509,29 +4956,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sha2"
-version = "0.9.9"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5597,12 +5025,6 @@ checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "signature"
-version = "1.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
 name = "signature"
@@ -5684,116 +5106,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "standback"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e113fb6f3de07a243d434a56ec6f186dfd51cb08448239fe7bcae73f87ff28ff"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stdweb"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
-dependencies = [
- "discard",
- "rustc_version 0.2.3",
- "stdweb-derive",
- "stdweb-internal-macros",
- "stdweb-internal-runtime",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "stdweb-derive"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stdweb-internal-macros"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
-dependencies = [
- "base-x",
- "proc-macro2",
- "quote",
- "serde",
- "serde_derive",
- "serde_json",
- "sha1 0.6.1",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stdweb-internal-runtime"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
-
-[[package]]
-name = "stellar-base"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608ee81eeba2f8ab2375f7b6d8fd2a5665a42b090dde37fa36e9856f7acc254b"
-dependencies = [
- "base32",
- "base64 0.21.7",
- "bitflags 2.9.0",
- "byteorder",
- "chrono",
- "crc16",
- "ed25519",
- "json",
- "num-bigint",
- "num-rational",
- "num-traits",
- "rust_decimal",
- "serde",
- "serde_json",
- "sha2 0.10.8",
- "thiserror 1.0.69",
- "xdr-rs-serialize",
- "xdr-rs-serialize-derive",
-]
-
-[[package]]
-name = "stellar-horizon"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48eb6fc456fb683d94e35549f7efcb3258d520bbabde4c6b24b0e6e573cdd4fe"
-dependencies = [
- "async-sse",
- "chrono",
- "futures",
- "http 0.2.12",
- "http-types",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "stellar-base",
- "thiserror 1.0.69",
- "url",
-]
 
 [[package]]
 name = "stellar-rpc-client"
@@ -5811,7 +5127,7 @@ dependencies = [
  "serde-aux",
  "serde_json",
  "serde_with",
- "sha2 0.10.8",
+ "sha2",
  "stellar-strkey 0.0.9",
  "stellar-xdr",
  "termcolor",
@@ -5833,9 +5149,9 @@ dependencies = [
 
 [[package]]
 name = "stellar-strkey"
-version = "0.0.12"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e27545061c1c74d595a18bfd885f1dda489d079e6316db98b4867525510ea3e"
+checksum = "ee1832fb50c651ad10f734aaf5d31ca5acdfb197a6ecda64d93fcdb8885af913"
 dependencies = [
  "crate-git-revision",
  "data-encoding",
@@ -5914,9 +5230,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.25"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
+checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -5946,15 +5262,14 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "a4b93974b3d3aeaa036504b8eefd4c039dced109171c1ae973f1dc63b2c7e4b2"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
+ "objc2-core-foundation",
  "windows",
 ]
 
@@ -6002,10 +5317,10 @@ version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix",
  "windows-sys 0.59.0",
 ]
 
@@ -6101,21 +5416,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.2.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4752a97f8eebd6854ff91f1c1824cd6160626ac4bd44287f7f4ea2035a02a242"
-dependencies = [
- "const_fn",
- "libc",
- "standback",
- "stdweb",
- "time-macros 0.1.1",
- "version_check",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
@@ -6126,7 +5426,7 @@ dependencies = [
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.22",
+ "time-macros",
 ]
 
 [[package]]
@@ -6137,35 +5437,12 @@ checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
-dependencies = [
- "proc-macro-hack",
- "time-macros-impl",
-]
-
-[[package]]
-name = "time-macros"
 version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
-]
-
-[[package]]
-name = "time-macros-impl"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c141a1b43194f3f56a1411225df8646c55781d5f26db825b3d98507eb482f"
-dependencies = [
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "standback",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6232,7 +5509,7 @@ dependencies = [
  "num-traits",
  "tokio",
  "tracing",
- "uuid",
+ "uuid 1.16.0",
 ]
 
 [[package]]
@@ -6401,7 +5678,7 @@ checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
  "thiserror 1.0.69",
- "time 0.3.41",
+ "time",
  "tracing-subscriber",
 ]
 
@@ -6508,7 +5785,7 @@ dependencies = [
  "rand 0.9.1",
  "rustls 0.23.26",
  "rustls-pki-types",
- "sha1 0.10.6",
+ "sha1",
  "thiserror 2.0.12",
  "utf-8",
 ]
@@ -6556,16 +5833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "universal-hash"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6580,7 +5847,6 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
- "serde",
 ]
 
 [[package]]
@@ -6621,6 +5887,16 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.16",
+ "serde",
+]
+
+[[package]]
+name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
@@ -6633,12 +5909,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-bag"
-version = "1.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -6662,12 +5932,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "waker-fn"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6685,12 +5949,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
@@ -6819,9 +6077,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.9"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29aad86cec885cafd03e8305fd727c418e970a521322c91688414d5b8efba16b"
+checksum = "37493cadf42a2a939ed404698ded7fb378bf301b5011f973361779a3a74f8c93"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6870,7 +6128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
 dependencies = [
  "windows-core 0.57.0",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6882,7 +6140,7 @@ dependencies = [
  "windows-implement 0.57.0",
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6950,13 +6208,13 @@ checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings 0.1.0",
- "windows-targets",
+ "windows-result 0.3.2",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -6965,16 +6223,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -6988,12 +6237,11 @@ dependencies = [
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -7011,7 +6259,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7020,7 +6268,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7029,14 +6277,30 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -7046,10 +6310,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7058,10 +6334,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7070,10 +6358,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7082,10 +6382,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -7161,29 +6473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.5",
-]
-
-[[package]]
-name = "xdr-rs-serialize"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b0d68af0b22a8be627a13d392e9d378f8f7f1f79543a09fddb5c97030a3749"
-dependencies = [
- "base64 0.13.1",
- "hex",
- "json",
-]
-
-[[package]]
-name = "xdr-rs-serialize-derive"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abcd23270af2d44e3172a86a57aafee2c7b89f19513fefd86ade1433c75b286"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3807,9 +3807,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "oz-keystore"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34912c1f66968ad8bde9dbad76fd7f5bf90c78df82c1ead387b8d8099207b337"
+checksum = "827d7f806953487d6b49ba11138209ad5290c0e9fbe464cc49760c4ef234cad7"
 dependencies = [
  "base64 0.22.1",
  "bs58",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.7",
+ "winnow 0.7.8",
 ]
 
 [[package]]
@@ -882,7 +882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "251273c5aa1abb590852f795c938730fa641832fc8fa77b5478ed1bf11b6097e"
 dependencies = [
  "serde",
- "winnow 0.7.7",
+ "winnow 0.7.8",
 ]
 
 [[package]]
@@ -1613,9 +1613,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -5661,7 +5661,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.7",
+ "winnow 0.7.8",
 ]
 
 [[package]]
@@ -6458,9 +6458,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3287a60462d933cbc753a1a87439016d4eb717401f3052ff72742c6dd0dbce3f"
+checksum = "52090b759230093c607803da793b494aff03f32bd6c142590c846db356e5a743"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94ee204a7795e56b8e78013f5824d6ea6e4da457a4aaf6c72e4800c4d4987fce"
+checksum = "c2931374f0e80fc031f61f3f48a23c671d78ad5e15fe9a2e405eff5a45383d2e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -319,6 +319,7 @@ dependencies = [
  "k256",
  "once_cell",
  "rand 0.8.5",
+ "secp256k1",
  "serde",
  "serde_with",
  "thiserror 2.0.12",
@@ -326,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16df75c656be4465ab411b88c5ec6bae4931ce806834efbf375ca85b8db6f9a"
+checksum = "649a1a61d692c5c765fbd6356c3694dd19b53bda6b13765f6085e1c119724f45"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -340,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258feff52f1e3be58b4d235ef85f5c0224905e371fb023dfbf758d5a7e027672"
+checksum = "e1d42161d813270b26fb100b4b7f8336da35d55af4f0fb01b5f9ebe79074c541"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -362,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d020a85ae8cf79b9c897a86d617357817bbc9a7d159dd7e6fedf1bc90f64d35"
+checksum = "24b2817489e4391d8c0bdf043c842164855e3d697de7a8e9edf24aa30b153ac5"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -375,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "884a5d4560f7e5e34ec3c5e54a60223c56352677dd049b495fbb59384cf72a90"
+checksum = "4f90b63261b7744642f6075ed17db6de118eecbe9516ea6c6ffd444b80180b75"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -429,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8ce6197b2cc38968c80c676372f383ed46051fb8600a421b5259f3f2d13a15"
+checksum = "9260d6932d9e8df00bd8b40a0ea15f16502e479a1bb5758e4a948d9a93462846"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -449,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc13f76f34587a9d5efd1d141dd6a596983be715922ccc488209e58dc643ec65"
+checksum = "6dd1ffced3576dd04fcfbd8baf3f58af791f2fa1428513b497040db551a0e0df"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -462,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
+checksum = "0068ae277f5ee3153a95eaea8ff10e188ed8ccde9b7f9926305415a2c0ab2442"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -474,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3593ce03c82601517eee458f67bb5dc642b9baff7016063f03a4ccbcfb52a387"
+checksum = "e4bc7b1036d3f62b74098054f94c9ee5a55bda7bbff74875facce9daac197749"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -488,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36be8015a205bf2e6784b0367c0f29e87f901f5f9b80b0a9bb4e1411c65242fd"
+checksum = "8caffce5f40ad5ab9ec06139a3083e34d9764b4a7d3d2f18cf1bb6e1eb215cc5"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -514,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3449fdd0908f50fb68eef8c43201d73d4ff51882b36e2adaadab277a7539ce4f"
+checksum = "02543b3dfaeaace2b583c8350020d0a99def063f23eedfbb3fdd173f1929dedc"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -527,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+checksum = "6a12fe11d0b8118e551c29e1a67ccb6d01cc07ef08086df30f07487146de6fa1"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -537,7 +538,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "indexmap 2.9.0",
  "itoa",
  "k256",
@@ -554,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16db7e6c225828a4540b1cce6047f06777c057df58386db9641827a2d1afb4f5"
+checksum = "e54d190317767b103c269ccfdb5fc4d6ae95227137466a85e80bf5f90d6130ed"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -600,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fbf7f3b22f7d34eb9aedf637bcdc5d4f47f5e028d3f7520f6ecc7fc75a7a027"
+checksum = "7b0b272577b3e8bf7f7225935e3c80911b76f7f3d096f0aff457cf72270d9160"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -643,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "821fca097f02720cd2a53e785776e265f36288f8210aa9177c9de05e2c2724c3"
+checksum = "c7786f4e1b82b39721545f81cf759749e0cb37c85b8d12ab5cf8d8ffe81939cf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -671,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30890a9856721a376e989283a17b2698acc3e1a612415abbca980aa4d29d7367"
+checksum = "e8b0862c17853965fd8b4e4e14d883775b4a4c01b8ea695d9f4f9d9b0b996205"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -687,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8702ccf7d241cb52fc6730561f7429c15158dacffe68c9127d2ab79d1657b862"
+checksum = "0a932f32e86bd3e52b2dea1b6f235a3555e239c77f5a6b04a31dd71cc0a7d331"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -699,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93017fb350fe2c0cccda41f9be45352012696a5fbd08c5fef4be0df838999bfa"
+checksum = "78adea3fffb8dd117b11269b35a6f0300996d8724a771f335dc667b1ce20a28b"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -710,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0b7976ba2e770e085389c8f9ffa81812700254c36e5cc35bca496e9491d1e3"
+checksum = "7e66b0c42c09c916ae04102f3418bba75e4b0cc05afb8ef930e1ef21024e2af3"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -720,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f09bac3a6651e3e9e292e946a1fc393128aa1a572254e2ff641e9911f024f61"
+checksum = "12a40093884c5c7243c061a0abf9fdd36cecb75880299de9b0e886a847275bde"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -737,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9f96bc409dee49f68d70bf1303c3b34d7153e185dda75caa8b72919a28cd6ac"
+checksum = "a7f5bd2f031c061a47721870cab4573aa6c50578204173b0648176aa811c73be"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -757,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c24a733a999bbfa706d03f54332ad03697e745ed27c25bdeebac39586f184d8"
+checksum = "3129b98dad969d0863020bf2ca3538aa5afbaf4f109a7c4196eb08850c99b990"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -771,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6d62259b6e1469042a21807d5f24002a7a0f30f69e945ded82ed6009fd1e50"
+checksum = "a9fea51138e9486896bb551d326515deb19fcf8e60e6fbf375a0a437333f1bf4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -783,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa2fc7f82a9884ff1632d2a2137d35fef4db9270c85668634a603be5948fcdc"
+checksum = "4d7176ff080b8c729375c129410cb6268fea4372aa1e0d20951a5af5be176477"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -794,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44eaf520bbb527ba90a3dd963aadf0c339595932169fb10f7330fe779336436e"
+checksum = "8c20b8766d2143f49b4f578889b51336f001624ed9cb37ee09ff23ab29635530"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -809,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f8d1f2edc446b52985a5af71cdbce86e8646865b889e38410594eea97804380"
+checksum = "4b148084b1384b6920c0c2320f69c7a75e18556bd61f783e3dfe3b398595a200"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -825,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
+checksum = "5d3ef8e0d622453d969ba3cded54cf6800efdc85cb929fe22c5bdf8335666757"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -839,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
+checksum = "f0e84bd0693c69a8fbe3ec0008465e029c6293494df7cb07580bf4a33eff52e1"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -858,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
+checksum = "f3de663412dadf9b64f4f92f507f78deebcc92339d12cf15f88ded65d41c7935"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -876,9 +877,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
+checksum = "251273c5aa1abb590852f795c938730fa641832fc8fa77b5478ed1bf11b6097e"
 dependencies = [
  "serde",
  "winnow 0.7.7",
@@ -886,9 +887,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
+checksum = "5460a975434ae594fe2b91586253c1beb404353b78f0a55bf124abcd79557b15"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -899,11 +900,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "609f69c9153df716e7e6ef002cba69f94b7635eb2c603fff69b664aa6acea93a"
+checksum = "4ccbaf33414918255037aaf75aa564819a148940d82465e75c27688793ed07fa"
 dependencies = [
  "alloy-json-rpc",
+ "alloy-primitives",
  "base64 0.22.1",
  "derive_more",
  "futures",
@@ -921,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e60987afbc49b8719578355726059579a1a197741a2adae52f860d5d7464cc"
+checksum = "21238d7ce1425bdb42269624b59a4fcc1c744bcfcb3cc762cbb251761c45d488"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -936,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0cad5f19f718b83d4a52ebc12f3b691b245111e50403d2adfd46674bc73da8"
+checksum = "76c038f8ebfa4963b925944901adacc02b6d8667585f9f9b5100843ee5fe29cc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -956,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.15.6"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f48cc4f88d59463992251b89381760be901c4789a4721c657b832994331aff05"
+checksum = "4135a469b959e82cf7c7a5b4afc51308e72663aafd6cb5df3e22492671cabf18"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -1352,6 +1354,22 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative",
+]
 
 [[package]]
 name = "bitflags"
@@ -2582,9 +2600,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2611,6 +2629,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
 ]
 
 [[package]]
@@ -3046,7 +3073,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -3366,7 +3393,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -3684,9 +3711,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -3780,9 +3807,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "oz-keystore"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb691c7845692a1c33f6e57a7fbfe53f2156d032744f17919a4c4e1d102dd63"
+checksum = "34912c1f66968ad8bde9dbad76fd7f5bf90c78df82c1ead387b8d8099207b337"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -4576,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -4774,6 +4801,27 @@ dependencies = [
  "serdect",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.8.5",
+ "secp256k1-sys",
+ "serde",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4997,9 +5045,9 @@ dependencies = [
 
 [[package]]
 name = "shared_child"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
+checksum = "7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -5230,9 +5278,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
+checksum = "3d0f0d4760f4c2a0823063b2c70e97aa2ad185f57be195172ccc0e23c4b787c4"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -5251,9 +5299,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = "1.5"
 lettre = "0.11.11"
 libc = "0.2"
 log = "0.4"
-oz-keystore = { git = "https://github.com/OpenZeppelin/oz-keystore.git", branch = "allow-overriding-base-urls" }
+oz-keystore = "0.1.3"
 prometheus = "0.14"
 regex = "1.11.0"
 reqwest = { version = "=0.12.15", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = "1.5"
 lettre = "0.11.11"
 libc = "0.2"
 log = "0.4"
-oz-keystore = "0.1.3"
+oz-keystore = "0.1.4"
 prometheus = "0.14"
 regex = "1.11.0"
 reqwest = { version = "=0.12.15", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ lazy_static = "1.5"
 lettre = "0.11.11"
 libc = "0.2"
 log = "0.4"
-oz-keystore = "0.1.2"
+oz-keystore = { git = "https://github.com/OpenZeppelin/oz-keystore.git", branch = "allow-overriding-base-urls" }
 prometheus = "0.14"
 regex = "1.11.0"
 reqwest = { version = "=0.12.15", features = ["json"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,11 +18,11 @@ panic = 'unwind'
 [dependencies]
 actix-rt = "2.0.0"
 actix-web = "4"
-alloy = { version = "0.12.4", features = ["full"] }
+alloy = { version = "0.15.6", features = ["full"] }
 anyhow = { version = "1.0.97", features = ["std"] }
 async-trait = "0.1"
 base64 = "0.22"
-byte-unit = "4.0"
+byte-unit = "5.1.6"
 chrono = "0.4"
 clap = { version = "4.5", features = ["cargo", "derive"] }
 cron = "0.15.0"
@@ -37,19 +37,19 @@ lazy_static = "1.5"
 lettre = "0.11.11"
 libc = "0.2"
 log = "0.4"
+oz-keystore = "0.1.2"
 prometheus = "0.14"
 regex = "1.11.0"
-reqwest = { version = "=0.12.12", features = ["json"] }
+reqwest = { version = "=0.12.15", features = ["json"] }
 reqwest-middleware = "0.4.1"
 reqwest-retry = "0.7.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10.0"
-stellar-horizon = "0.7.1"
 stellar-rpc-client = "22.0.0"
-stellar-strkey = "0.0.12"
+stellar-strkey = "0.0.13"
 stellar-xdr = "22.1.0"
-sysinfo = "0.33"
+sysinfo = "0.34.2"
 thiserror = "2.0.12"
 tokio = { version = "1.0", features = ["full"] }
 tokio-cron-scheduler = "0.13.0"
@@ -60,6 +60,7 @@ tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 url = "2.5"
 urlencoding = "2.1.3"
 uuid = "1.15.0"
+zeroize = { version = "1.8.1", features = ["derive"] }
 
 [dev-dependencies]
 cargo-llvm-cov = "0.6"

--- a/docs/modules/ROOT/pages/error.adoc
+++ b/docs/modules/ROOT/pages/error.adoc
@@ -105,6 +105,13 @@ a|* `ValidationError` - Configuration validation failures
 * `FileError` - File system related errors
 * `Other` - Unclassified errors
 
+|Security
+|`SecurityError`
+a|* `ValidationError` - Security validation failures
+* `ParseError` - Security data parsing issues
+* `NetworkError` - Security service connectivity issues
+* `Other` - Unclassified security-related errors
+
 |Blockchain Service
 |`BlockChainError`
 a|* `ConnectionError` - Network connectivity issues

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1120,11 +1120,11 @@ Slack, Discord, Telegram, Email and Webhook support Markdown formatting in their
     "config": {
       "host": "smtp.example.com",
       "port": 465,
-      "username": "alerts@example.com",
-      "password": "password",
+      "username": {"type": "plain", "value": "alerts@example.com"},
+      "password": {"type": "plain", "value": "password"},
       "message": {
         "title": "**High Value Transfer Alert**",
-        "body": "### Transaction Details\n\n* **Amount:** ${event_0_value} USDC\n* **From:** `${event_0_from}`\n* **To:** `${event_0_to}`\n\n> Transaction Hash: ${transaction_hash}\n\n[View on Explorer](https://etherscan.io/tx/${transaction_hash})"
+        "body": "### Transaction Details\n\n* **Amount:** ${events.0.args.value} USDC\n* **From:** `${events.0.args.from}`\n* **To:** `${events.0.args.to}`\n\n> Transaction Hash: ${transaction.hash}\n\n[View on Explorer](https://etherscan.io/tx/${transaction.hash})"
       },
       "sender": "alerts@example.com",
       "recipients": ["recipient@example.com"]
@@ -1141,10 +1141,10 @@ Slack, Discord, Telegram, Email and Webhook support Markdown formatting in their
     "name": "Formatted Alert",
     "trigger_type": "slack",
     "config": {
-      "slack_url": "https://hooks.slack.com/services/XXX/YYY/ZZZ",
+      "slack_url": {"type": "plain", "value": "https://hooks.slack.com/services/XXX/YYY/ZZZ"},
       "message": {
         "title": "*🚨 High Value Transfer Alert*",
-        "body": "*Transaction Details*\n\n• *Amount:* `${event_0_value}` USDC\n• *From:* `${event_0_from}`\n• *To:* `${event_0_to}`\n\n>Transaction Hash: `${transaction_hash}`\n\n<https://etherscan.io/tx/${transaction_hash}|View on Explorer>"
+        "body": "*Transaction Details*\n\n• *Amount:* `${events.0.args.value}` USDC\n• *From:* `${events.0.args.from}`\n• *To:* `${events.0.args.to}`\n\n>Transaction Hash: `${transaction.hash}`\n\n<https://etherscan.io/tx/${transaction.hash}|View on Explorer>"
       }
     }
   }
@@ -1159,10 +1159,10 @@ Slack, Discord, Telegram, Email and Webhook support Markdown formatting in their
     "name": "Formatted Alert",
     "trigger_type": "discord",
     "config": {
-      "discord_url": "https://discord.com/api/webhooks/XXX/YYY",
+      "discord_url": {"type": "plain", "value": "https://discord.com/api/webhooks/XXX/YYY"},
       "message": {
         "title": "**🚨 High Value Transfer Alert**",
-        "body": "# Transaction Details\n\n* **Amount:** `${event_0_value}` USDC\n* **From:** `${event_0_from}`\n* **To:** `${event_0_to}`\n\n>>> Transaction Hash: `${transaction_hash}`\n\n**[View on Explorer](https://etherscan.io/tx/${transaction_hash})"
+        "body": "# Transaction Details\n\n* **Amount:** `${events.0.args.value}` USDC\n* **From:** `${events.0.args.from}`\n* **To:** `${events.0.args.to}`\n\n>>> Transaction Hash: `${transaction.hash}`\n\n**[View on Explorer](https://etherscan.io/tx/${transaction.hash})"
       }
     }
   }
@@ -1177,11 +1177,11 @@ Slack, Discord, Telegram, Email and Webhook support Markdown formatting in their
     "name": "Formatted Alert",
     "trigger_type": "telegram",
     "config": {
-      "token": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      "token": {"type": "plain", "value": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ"},
       "chat_id": "9876543210",
       "message": {
         "title": "*🚨 High Value Transfer Alert*",
-        "body": "*Transaction Details*\n\n• *Amount:* `${event_0_value}` USDC\n• *From:* `${event_0_from}`\n• *To:* `${event_0_to}`\n\n`Transaction Hash: ${transaction_hash}`\n\n[View on Explorer](https://etherscan.io/tx/${transaction_hash})"
+        "body": "*Transaction Details*\n\n• *Amount:* `${events.0.args.value}` USDC\n• *From:* `${events.0.args.from}`\n• *To:* `${events.0.args.to}`\n\n`Transaction Hash: ${transaction.hash}`\n\n[View on Explorer](https://etherscan.io/tx/${transaction.hash})"
       }
     }
   }

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -343,6 +343,12 @@ The monitor implements protocol security validations across different components
 ** `X-API-Key` header
 ** `Authorization` header
 * *Optional Secret*: Can include a secret for HMAC authentication
+** When a secret is provided, the monitor will:
+*** Generate a timestamp in milliseconds
+*** Create an HMAC-SHA256 signature of the payload and timestamp
+*** Add the signature in the `X-Signature` header
+*** Add the timestamp in the `X-Timestamp` header
+** The signature is computed as: `HMAC-SHA256(secret, payload + timestamp)`
 * *Warning*: Non-HTTPS URLs or missing authentication headers will trigger security warnings
 
 ===== Script Security
@@ -357,6 +363,83 @@ The monitor implements protocol security validations across different components
 ----
 chmod 644 ./config/filters/my_script.sh
 ----
+
+==== Secret Management
+
+The monitor implements a secure secret management system with support for multiple secret sources and automatic memory zeroization.
+
+===== Secret Sources
+
+The monitor supports three types of secret sources:
+
+* *Plain Text*: Direct secret values (wrapped in `SecretString` for secure memory handling)
+* *Environment Variables*: Secrets stored in environment variables
+* *Hashicorp Cloud Vault*: Secrets stored in Hashicorp Cloud Vault
+
+===== Security Features
+
+* *Automatic Zeroization*: Secrets are automatically zeroized from memory when no longer needed
+* *Type-Safe Resolution*: Secure handling of secret resolution with proper error handling
+* *Configuration Support*: Serde support for configuration files
+
+===== Configuration
+
+Secrets can be configured in the JSON files using the following format:
+
+[source,json]
+----
+{
+  "type": "Plain",
+  "value": "my-secret-value"
+}
+----
+
+[source,json]
+----
+{
+  "type": "Environment",
+  "value": "MY_SECRET_ENV_VAR"
+}
+----
+
+[source,json]
+----
+{
+  "type": "HashicorpCloudVault",
+  "value": "my-secret-name"
+}
+----
+
+===== Hashicorp Cloud Vault Integration
+
+To use Hashicorp Cloud Vault, configure the following environment variables:
+
+[cols="1,2", options="header"]
+|===
+| Environment Variable | Description
+
+| `HCP_CLIENT_ID`
+| Hashicorp Cloud Vault client ID
+
+| `HCP_CLIENT_SECRET`
+| Hashicorp Cloud Vault client secret
+
+| `HCP_ORG_ID`
+| Hashicorp Cloud Vault organization ID
+
+| `HCP_PROJECT_ID`
+| Hashicorp Cloud Vault project ID
+
+| `HCP_APP_NAME`
+| Hashicorp Cloud Vault application name
+|===
+
+===== Best Practices
+
+* Use environment variables or vault for production secrets
+* Avoid storing plain text secrets in configuration files
+* Use appropriate access controls for vault secrets
+* Monitor vault access patterns for suspicious activity
 
 ==== Basic Configuration
 
@@ -409,6 +492,31 @@ This table lists the environment variables and their default values.
 | `8081`
 | `<any tcp port (preferably choose non-privileged ports i.e. (1024-65535))>`
 | Port to use for metrics server.
+
+| `HCP_CLIENT_ID`
+| -
+| `<string>`
+| Hashicorp Cloud Vault client ID for secret management.
+
+| `HCP_CLIENT_SECRET`
+| -
+| `<string>`
+| Hashicorp Cloud Vault client secret for secret management.
+
+| `HCP_ORG_ID`
+| -
+| `<string>`
+| Hashicorp Cloud Vault organization ID for secret management.
+
+| `HCP_PROJECT_ID`
+| -
+| `<string>`
+| Hashicorp Cloud Vault project ID for secret management.
+
+| `HCP_APP_NAME`
+| -
+| `<string>`
+| Hashicorp Cloud Vault application name for secret management.
 |===
 
 * Copy and configure some example files:
@@ -484,7 +592,10 @@ A Network configuration defines connection details and operational parameters fo
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://soroban.stellar.org",
+      "url": {
+        "type": "Plain",
+        "value": "https://soroban.stellar.org"
+      },
       "weight": 100
     }
   ],
@@ -564,7 +675,10 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
     "name": "Large Transfer Slack Notification",
     "trigger_type": "slack",
     "config": {
-      "slack_url": "https://hooks.slack.com/services/A/B/C",
+      "slack_url": {
+        "type": "Plain",
+        "value": "https://hooks.slack.com/services/A/B/C"
+      },
       "message": {
         "title": "large_transfer_slack triggered",
         "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
@@ -575,7 +689,10 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
     "name": "Large Transfer Slack Notification",
     "trigger_type": "slack",
     "config": {
-      "slack_url": "https://hooks.slack.com/services/A/B/C",
+      "slack_url": {
+        "type": "Environment",
+        "value": "SLACK_WEBHOOK_URL"
+      },
       "message": {
         "title": "large_transfer_usdc_slack triggered",
         "body": "${monitor_name} triggered because of a large transfer of ${function_0_2} USDC to ${function_0_1} | https://stellar.expert/explorer/testnet/tx/${transaction_hash}"
@@ -591,7 +708,10 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 [source,json]
 ----
 {
-  "slack_url": "https://hooks.slack.com/...",
+  "slack_url": {
+    "type": "HashicorpCloudVault",
+    "value": "slack-webhook-url"
+  },
   "message": {
     "title": "Alert Title",
     "body": "Alert message for ${transaction_hash}"
@@ -612,9 +732,13 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 |String
 |Must be "slack" for Slack notifications
 
-|config.slack_url
+|config.slack_url.type
 |String
-|Slack webhook URL for sending notifications
+|Secret type ("Plain", "Environment", or "HashicorpCloudVault")
+
+|config.slack_url.value
+|String
+|Secret value (URL, environment variable name, or vault secret name)
 
 |config.message.title
 |String
@@ -631,8 +755,14 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 {
   "host": "smtp.gmail.com",
   "port": 465,
-  "username": "sender@example.com",
-  "password": "smtp_password",
+  "username": {
+    "type": "Plain",
+    "value": "sender@example.com"
+  },
+  "password": {
+    "type": "Environment",
+    "value": "SMTP_PASSWORD"
+  },
   "message": {
     "title": "Alert Subject",
     "body": "Alert message for ${transaction_hash}",
@@ -663,13 +793,21 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 |Number
 |SMTP port (defaults to 465)
 
-|config.username
+|config.username.type
 |String
-|SMTP authentication username
+|Secret type ("Plain", "Environment", or "HashicorpCloudVault")
 
-|config.password
+|config.username.value
 |String
-|SMTP authentication password
+|Secret value (username, environment variable name, or vault secret name)
+
+|config.password.type
+|String
+|Secret type ("Plain", "Environment", or "HashicorpCloudVault")
+
+|config.password.value
+|String
+|Secret value (password, environment variable name, or vault secret name)
 
 |config.message.title
 |String
@@ -692,9 +830,15 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 [source,json]
 ----
 {
-  "url": "https://webhook.site/123-456-789",
+  "url": {
+    "type": "HashicorpCloudVault",
+    "value": "webhook-url"
+  },
   "method": "POST",
-  "secret": "some-secret",
+  "secret": {
+    "type": "Environment",
+    "value": "WEBHOOK_SECRET"
+  },
   "headers": {
     "Content-Type": "application/json"
   },
@@ -718,17 +862,25 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 |String
 |Must be "webhook" for webhook notifications
 
-|config.url
+|config.url.type
 |String
-|Webhook URL
+|Secret type ("Plain", "Environment", or "HashicorpCloudVault")
+
+|config.url.value
+|String
+|Secret value (URL, environment variable name, or vault secret name)
 
 |config.method
 |String
 |HTTP method (POST, GET, etc.) defaults to POST
 
-|config.secret
+|config.secret.type
 |String
-|Optional secret for HMAC authentication
+|Secret type ("Plain", "Environment", or "HashicorpCloudVault")
+
+|config.secret.value
+|String
+|Secret value (HMAC secret, environment variable name, or vault secret name)
 
 |config.headers
 |Object
@@ -747,7 +899,10 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 [source,json]
 ----
 {
-  "discord_url": "https://discord.com/api/webhooks/123-456-789",
+  "discord_url": {
+    "type": "Plain",
+    "value": "https://discord.com/api/webhooks/123-456-789"
+  },
   "message": {
     "title": "Alert Title",
     "body": "Alert message for ${transaction_hash}"
@@ -768,9 +923,13 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 |String
 |Must be "discord" for Discord notifications
 
-|config.discord_url
+|config.discord_url.type
 |String
-|Discord webhook URL must start with https://discord.com/api/webhooks/
+|Secret type ("Plain", "Environment", or "HashicorpCloudVault")
+
+|config.discord_url.value
+|String
+|Secret value (URL, environment variable name, or vault secret name)
 
 |config.message.title
 |String
@@ -785,7 +944,10 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 [source,json]
 ----
 {
-  "token": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  "token": {
+    "type": "HashicorpCloudVault",
+    "value": "telegram-bot-token"
+  },
   "chat_id": "9876543210",
   "message": {
     "title": "Alert Title",
@@ -807,9 +969,13 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 |String
 |Must be "telegram" for Telegram notifications
 
-|config.token
+|config.token.type
 |String
-|Telegram bot token
+|Secret type ("Plain", "Environment", or "HashicorpCloudVault")
+
+|config.token.value
+|String
+|Secret value (bot token, environment variable name, or vault secret name)
 
 |config.chat_id
 |String

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -593,7 +593,7 @@ A Network configuration defines connection details and operational parameters fo
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://soroban.stellar.org"
       },
       "weight": 100
@@ -676,7 +676,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
     "trigger_type": "slack",
     "config": {
       "slack_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://hooks.slack.com/services/A/B/C"
       },
       "message": {
@@ -690,7 +690,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
     "trigger_type": "slack",
     "config": {
       "slack_url": {
-        "type": "Environment",
+        "type": "environment",
         "value": "SLACK_WEBHOOK_URL"
       },
       "message": {
@@ -756,11 +756,11 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
   "host": "smtp.gmail.com",
   "port": 465,
   "username": {
-    "type": "Plain",
+    "type": "plain",
     "value": "sender@example.com"
   },
   "password": {
-    "type": "Environment",
+    "type": "environment",
     "value": "SMTP_PASSWORD"
   },
   "message": {
@@ -836,7 +836,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
   },
   "method": "POST",
   "secret": {
-    "type": "Environment",
+    "type": "environment",
     "value": "WEBHOOK_SECRET"
   },
   "headers": {
@@ -900,7 +900,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 ----
 {
   "discord_url": {
-    "type": "Plain",
+    "type": "plain",
     "value": "https://discord.com/api/webhooks/123-456-789"
   },
   "message": {

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -168,7 +168,7 @@ The link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/examples
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "YOUR_RPC_URL_HERE"
       },
       "weight": 100
@@ -284,7 +284,7 @@ Update the webhook URL in the link:https://github.com/OpenZeppelin/openzeppelin-
         "trigger_type": "slack",
         "config": {
             "slack_url": {
-                "type": "Plain",
+                "type": "plain",
                 "value": "SLACK_WEBHOOK_URL"
             },
             "message": {
@@ -315,11 +315,11 @@ Update the SMTP settings in the link:https://github.com/OpenZeppelin/openzeppeli
             "host": "smtp.gmail.com",
             "port": 465,
             "username": {
-                "type": "Plain",
+                "type": "plain",
                 "value": "your_email@gmail.com"
             },
             "password": {
-                "type": "Plain",
+                "type": "plain",
                 "value": "SMTP_PASSWORD"
             },
             "message": {
@@ -389,7 +389,7 @@ The link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/examples
      {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "YOUR_RPC_URL_HERE"
       },
       "weight": 100
@@ -482,7 +482,7 @@ Update the webhook URL in the link:https://github.com/OpenZeppelin/openzeppelin-
     "trigger_type": "slack",
     "config": {
       "slack_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "slack-webhook-url"
       },
       "message": {

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -167,7 +167,10 @@ The link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/examples
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "YOUR_RPC_URL_HERE",
+      "url": {
+        "type": "Plain",
+        "value": "YOUR_RPC_URL_HERE"
+      },
       "weight": 100
     }
   ],
@@ -280,7 +283,10 @@ Update the webhook URL in the link:https://github.com/OpenZeppelin/openzeppelin-
         "name": "Large Transfer Slack Notification",
         "trigger_type": "slack",
         "config": {
-            "slack_url": "https://hooks.slack.com/services/A/B/C",
+            "slack_url": {
+                "type": "Plain",
+                "value": "SLACK_WEBHOOK_URL"
+            },
             "message": {
                 "title": "large_transfer_slack triggered",
                 "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
@@ -308,8 +314,14 @@ Update the SMTP settings in the link:https://github.com/OpenZeppelin/openzeppeli
         "config": {
             "host": "smtp.gmail.com",
             "port": 465,
-            "username": "your_email@gmail.com",
-            "password": "your_password",
+            "username": {
+                "type": "Plain",
+                "value": "your_email@gmail.com"
+            },
+            "password": {
+                "type": "Plain",
+                "value": "SMTP_PASSWORD"
+            },
             "message": {
                 "title": "large_transfer_usdc_email triggered",
                 "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
@@ -351,6 +363,7 @@ The monitor will now:
 * Adjust the transfer threshold by modifying the `expression` value.
 * Monitor additional ERC20 tokens by creating new monitor configurations.
 * xref:index.adoc#testing_your_configuration[Test the Monitor] configuration against a block number
+* xref:index.adoc#secret_management[Configure secure secret management] for sensitive data using environment variables or Hashicorp Cloud Vault
 * Explore other examples in the link:https://github.com/OpenZeppelin/openzeppelin-monitor/tree/main/examples/config/monitors[`examples/config/monitors` directory].
 
 === Monitoring Dex Swaps (Stellar):
@@ -375,7 +388,10 @@ The link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/examples
   "rpc_urls": [
      {
       "type_": "rpc",
-      "url": "YOUR_RPC_URL_HERE",
+      "url": {
+        "type": "Plain",
+        "value": "YOUR_RPC_URL_HERE"
+      },
       "weight": 100
     }
   ],
@@ -465,7 +481,10 @@ Update the webhook URL in the link:https://github.com/OpenZeppelin/openzeppelin-
     "name": "Large Swap By Dex Slack Notification",
     "trigger_type": "slack",
     "config": {
-      "slack_url": "https://hooks.slack.com/services/A/B/C",
+      "slack_url": {
+        "type": "Plain",
+        "value": "slack-webhook-url"
+      },
       "message": {
         "title": "large_swap_by_dex_slack triggered",
         "body": "${monitor_name} triggered because of a large swap of ${function_0_4} tokens | https://stellar.expert/explorer/public/tx/${transaction_hash}"
@@ -502,4 +521,5 @@ The monitor will now:
 * Adjust the swap threshold by modifying the `expression` value.
 * Monitor additional dex swaps by creating new monitor configurations.
 * xref:index.adoc#testing_your_configuration[Test the Monitor] configuration against a block number
+* xref:index.adoc#secret_management[Configure secure secret management] for sensitive data using environment variables or Hashicorp Cloud Vault
 * Explore other examples in the link:https://github.com/OpenZeppelin/openzeppelin-monitor/tree/main/examples/config/monitors[`examples/config/monitors` directory].

--- a/docs/modules/ROOT/pages/structure.adoc
+++ b/docs/modules/ROOT/pages/structure.adoc
@@ -46,6 +46,7 @@ The main source code directory contains the core implementation files organized 
 ** `cron_utils`: Cron schedule utilities
 ** `expression`: Expression evaluation
 ** `logging/`: Logging utilities
+** `macros/`: Macros for common functionality
 ** `metrics/`: Metrics utilities
 ** `monitor/`: Monitor configuration test utilities
 ** `tests/`: Contains test utilities and helper functions

--- a/docs/modules/ROOT/pages/structure.adoc
+++ b/docs/modules/ROOT/pages/structure.adoc
@@ -17,6 +17,7 @@ The main source code directory contains the core implementation files organized 
 *** `stellar/`: Stellar blockchain specific types
 ** `config/`: Configuration loading and validation
 ** `core/`: Core domain models
+** `security/`: Security and secret management
 
 * `repositories/`: Configuration storage
 ** Handles loading and validating configuration files

--- a/examples/config/networks/arbitrum_nova.json
+++ b/examples/config/networks/arbitrum_nova.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://nova.arbitrum.io/rpc",
+      "url": {
+        "type": "Plain",
+        "value": "https://nova.arbitrum.io/rpc"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/arbitrum_nova.json
+++ b/examples/config/networks/arbitrum_nova.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://nova.arbitrum.io/rpc"
       },
       "weight": 100

--- a/examples/config/networks/arbitrum_one.json
+++ b/examples/config/networks/arbitrum_one.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://arb1.arbitrum.io/rpc"
       },
       "weight": 100

--- a/examples/config/networks/arbitrum_one.json
+++ b/examples/config/networks/arbitrum_one.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://arb1.arbitrum.io/rpc",
+      "url": {
+        "type": "Plain",
+        "value": "https://arb1.arbitrum.io/rpc"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/arbitrum_sepolia.json
+++ b/examples/config/networks/arbitrum_sepolia.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://sepolia-rollup.arbitrum.io/rpc"
       },
       "weight": 100

--- a/examples/config/networks/arbitrum_sepolia.json
+++ b/examples/config/networks/arbitrum_sepolia.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://sepolia-rollup.arbitrum.io/rpc",
+      "url": {
+        "type": "Plain",
+        "value": "https://sepolia-rollup.arbitrum.io/rpc"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/ethereum_mainnet.json
+++ b/examples/config/networks/ethereum_mainnet.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://eth.drpc.org"
       },
       "weight": 100

--- a/examples/config/networks/ethereum_mainnet.json
+++ b/examples/config/networks/ethereum_mainnet.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://eth.drpc.org",
+      "url": {
+        "type": "Plain",
+        "value": "https://eth.drpc.org"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/ethereum_sepolia.json
+++ b/examples/config/networks/ethereum_sepolia.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://sepolia.drpc.org"
       },
       "weight": 100

--- a/examples/config/networks/ethereum_sepolia.json
+++ b/examples/config/networks/ethereum_sepolia.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://sepolia.drpc.org",
+      "url": {
+        "type": "Plain",
+        "value": "https://sepolia.drpc.org"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/optimism_mainnet.json
+++ b/examples/config/networks/optimism_mainnet.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://mainnet.optimism.io"
       },
       "weight": 100

--- a/examples/config/networks/optimism_mainnet.json
+++ b/examples/config/networks/optimism_mainnet.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://mainnet.optimism.io",
+      "url": {
+        "type": "Plain",
+        "value": "https://mainnet.optimism.io"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/optimism_sepolia.json
+++ b/examples/config/networks/optimism_sepolia.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://sepolia.optimism.io"
       },
       "weight": 100

--- a/examples/config/networks/optimism_sepolia.json
+++ b/examples/config/networks/optimism_sepolia.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://sepolia.optimism.io",
+      "url": {
+        "type": "Plain",
+        "value": "https://sepolia.optimism.io"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/polygon_amoy.json
+++ b/examples/config/networks/polygon_amoy.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://rpc-amoy.polygon.technology/",
+      "url": {
+        "type": "Plain",
+        "value": "https://rpc-amoy.polygon.technology/"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/polygon_amoy.json
+++ b/examples/config/networks/polygon_amoy.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://rpc-amoy.polygon.technology/"
       },
       "weight": 100

--- a/examples/config/networks/polygon_mainnet.json
+++ b/examples/config/networks/polygon_mainnet.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://polygon-rpc.com/",
+      "url": {
+        "type": "Plain",
+        "value": "https://polygon-rpc.com/"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/polygon_mainnet.json
+++ b/examples/config/networks/polygon_mainnet.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://polygon-rpc.com/"
       },
       "weight": 100

--- a/examples/config/networks/stellar_mainnet.json
+++ b/examples/config/networks/stellar_mainnet.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://mainnet.sorobanrpc.com"
       },
       "weight": 100

--- a/examples/config/networks/stellar_mainnet.json
+++ b/examples/config/networks/stellar_mainnet.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://mainnet.sorobanrpc.com",
+      "url": {
+        "type": "Plain",
+        "value": "https://mainnet.sorobanrpc.com"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/stellar_testnet.json
+++ b/examples/config/networks/stellar_testnet.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://soroban-testnet.stellar.org",
+      "url": {
+        "type": "Plain",
+        "value": "https://soroban-testnet.stellar.org"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/stellar_testnet.json
+++ b/examples/config/networks/stellar_testnet.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://soroban-testnet.stellar.org"
       },
       "weight": 100

--- a/examples/config/networks/unichain_sepolia.json
+++ b/examples/config/networks/unichain_sepolia.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://sepolia.unichain.org",
+      "url": {
+        "type": "Plain",
+        "value": "https://sepolia.unichain.org"
+      },
       "weight": 90
     }
   ],

--- a/examples/config/networks/unichain_sepolia.json
+++ b/examples/config/networks/unichain_sepolia.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://sepolia.unichain.org"
       },
       "weight": 90

--- a/examples/config/networks/zksync_era_mainnet.json
+++ b/examples/config/networks/zksync_era_mainnet.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://mainnet.era.zksync.io",
+      "url": {
+        "type": "Plain",
+        "value": "https://mainnet.era.zksync.io"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/zksync_era_mainnet.json
+++ b/examples/config/networks/zksync_era_mainnet.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://mainnet.era.zksync.io"
       },
       "weight": 100

--- a/examples/config/networks/zksync_era_sepolia.json
+++ b/examples/config/networks/zksync_era_sepolia.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://sepolia.era.zksync.dev",
+      "url": {
+        "type": "Plain",
+        "value": "https://sepolia.era.zksync.dev"
+      },
       "weight": 100
     }
   ],

--- a/examples/config/networks/zksync_era_sepolia.json
+++ b/examples/config/networks/zksync_era_sepolia.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://sepolia.era.zksync.dev"
       },
       "weight": 100

--- a/examples/config/triggers/discord_notifications.json
+++ b/examples/config/triggers/discord_notifications.json
@@ -3,7 +3,10 @@
     "name": "Large Transfer Discord Notification",
     "trigger_type": "discord",
     "config": {
-      "discord_url": "https://discord.com/api/webhooks/123-456-789",
+      "discord_url": {
+        "type": "Plain",
+        "value": "https://discord.com/api/webhooks/123-456-789"
+      },
       "message": {
         "title": "large_transfer_discord triggered",
         "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
@@ -14,7 +17,10 @@
     "name": "Large Swap By Dex Discord Notification",
     "trigger_type": "discord",
     "config": {
-      "discord_url": "https://discord.com/api/webhooks/123-456-789",
+      "discord_url": {
+        "type": "Plain",
+        "value": "https://discord.com/api/webhooks/123-456-789"
+      },
       "message": {
         "title": "large_swap_by_dex_discord triggered",
         "body": "${monitor_name} triggered because of a large swap of ${function_0_4} tokens | https://stellar.expert/explorer/public/tx/${transaction_hash}"

--- a/examples/config/triggers/discord_notifications.json
+++ b/examples/config/triggers/discord_notifications.json
@@ -4,7 +4,7 @@
     "trigger_type": "discord",
     "config": {
       "discord_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://discord.com/api/webhooks/123-456-789"
       },
       "message": {
@@ -18,7 +18,7 @@
     "trigger_type": "discord",
     "config": {
       "discord_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://discord.com/api/webhooks/123-456-789"
       },
       "message": {

--- a/examples/config/triggers/email_notifications.json
+++ b/examples/config/triggers/email_notifications.json
@@ -5,8 +5,14 @@
         "config": {
             "host": "smtp.gmail.com",
             "port": 465,
-            "username": "your_email@gmail.com",
-            "password": "your_password",
+            "username": {
+                "type": "Plain",
+                "value": "your_email@gmail.com"
+            },
+            "password": {
+                "type": "Plain",
+                "value": "your_password"
+            },
             "message": {
                 "title": "large_transfer_usdc_email triggered",
                 "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"

--- a/examples/config/triggers/email_notifications.json
+++ b/examples/config/triggers/email_notifications.json
@@ -6,11 +6,11 @@
             "host": "smtp.gmail.com",
             "port": 465,
             "username": {
-                "type": "Plain",
+                "type": "plain",
                 "value": "your_email@gmail.com"
             },
             "password": {
-                "type": "Plain",
+                "type": "plain",
                 "value": "your_password"
             },
             "message": {

--- a/examples/config/triggers/slack_notifications.json
+++ b/examples/config/triggers/slack_notifications.json
@@ -4,7 +4,7 @@
     "trigger_type": "slack",
     "config": {
       "slack_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://hooks.slack.com/services/A/B/C"
       },
       "message": {
@@ -18,7 +18,7 @@
     "trigger_type": "slack",
     "config": {
       "slack_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://hooks.slack.com/services/A/B/C"
       },
       "message": {

--- a/examples/config/triggers/slack_notifications.json
+++ b/examples/config/triggers/slack_notifications.json
@@ -3,7 +3,10 @@
     "name": "Large Transfer Slack Notification",
     "trigger_type": "slack",
     "config": {
-      "slack_url": "https://hooks.slack.com/services/A/B/C",
+      "slack_url": {
+        "type": "Plain",
+        "value": "https://hooks.slack.com/services/A/B/C"
+      },
       "message": {
         "title": "large_transfer_slack triggered",
         "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
@@ -14,7 +17,10 @@
     "name": "Large Swap By Dex Slack Notification",
     "trigger_type": "slack",
     "config": {
-      "slack_url": "https://hooks.slack.com/services/A/B/C",
+      "slack_url": {
+        "type": "Plain",
+        "value": "https://hooks.slack.com/services/A/B/C"
+      },
       "message": {
         "title": "large_swap_by_dex_slack triggered",
         "body": "${monitor_name} triggered because of a large swap of ${function_0_4} tokens | https://stellar.expert/explorer/public/tx/${transaction_hash}"

--- a/examples/config/triggers/telegram_notifications.json
+++ b/examples/config/triggers/telegram_notifications.json
@@ -4,7 +4,7 @@
     "trigger_type": "telegram",
     "config": {
       "token": {
-        "type": "Plain",
+        "type": "plain",
         "value": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       },
       "chat_id": "9876543210",
@@ -20,7 +20,7 @@
     "trigger_type": "telegram",
     "config": {
       "token": {
-        "type": "Plain",
+        "type": "plain",
         "value": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       },
       "chat_id": "9876543210",

--- a/examples/config/triggers/telegram_notifications.json
+++ b/examples/config/triggers/telegram_notifications.json
@@ -3,7 +3,10 @@
     "name": "Large Transfer Telegram Notification",
     "trigger_type": "telegram",
     "config": {
-      "token": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      "token": {
+        "type": "Plain",
+        "value": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      },
       "chat_id": "9876543210",
       "disable_web_preview": true,
       "message": {
@@ -16,7 +19,10 @@
     "name": "Large Swap By Dex Telegram Notification",
     "trigger_type": "telegram",
     "config": {
-      "token": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      "token": {
+        "type": "Plain",
+        "value": "1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+      },
       "chat_id": "9876543210",
       "disable_web_preview": true,
       "message": {

--- a/examples/config/triggers/webhook_notifications.json
+++ b/examples/config/triggers/webhook_notifications.json
@@ -4,12 +4,12 @@
     "trigger_type": "webhook",
     "config": {
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://webhook.site/123-456-789"
       },
       "method": "POST",
       "secret": {
-        "type": "Plain",
+        "type": "plain",
         "value": "some-secret"
       },
       "headers": {
@@ -26,12 +26,12 @@
     "trigger_type": "webhook",
     "config": {
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://webhook.site/123-456-789"
       },
       "method": "POST",
       "secret": {
-        "type": "Plain",
+        "type": "plain",
         "value": "some-secret"
       },
       "headers": {

--- a/examples/config/triggers/webhook_notifications.json
+++ b/examples/config/triggers/webhook_notifications.json
@@ -3,9 +3,15 @@
     "name": "Large Transfer Webhook Notification",
     "trigger_type": "webhook",
     "config": {
-      "url": "https://webhook.site/123-456-789",
+      "url": {
+        "type": "Plain",
+        "value": "https://webhook.site/123-456-789"
+      },
       "method": "POST",
-      "secret": "some-secret",
+      "secret": {
+        "type": "Plain",
+        "value": "some-secret"
+      },
       "headers": {
         "Content-Type": "application/json"
       },
@@ -19,9 +25,15 @@
     "name": "Large Swap By Dex Webhook Notification",
     "trigger_type": "webhook",
     "config": {
-      "url": "https://webhook.site/123-456-789",
+      "url": {
+        "type": "Plain",
+        "value": "https://webhook.site/123-456-789"
+      },
       "method": "POST",
-      "secret": "some-secret",
+      "secret": {
+        "type": "Plain",
+        "value": "some-secret"
+      },
       "headers": {
         "Content-Type": "application/json"
       },

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,7 @@ async fn main() -> Result<()> {
 		NetworkRepository,
 		TriggerRepository,
 	>(None, None, None)
+	.await
 	.map_err(|e| anyhow::anyhow!("Failed to initialize services: {}. Please refer to the documentation quickstart ({}) on how to configure the service.", e, DOCUMENTATION_URL))?;
 
 	// Read CLI arguments to determine if we should test monitor execution
@@ -627,6 +628,7 @@ async fn validate_configuration() {
 		NetworkRepository,
 		TriggerRepository,
 	>(None, None, None)
+	.await
 	{
 		Ok((_, _, active_monitors, networks, _, _, _)) => {
 			info!("✓ Core services initialized successfully");
@@ -673,6 +675,7 @@ mod tests {
 			NetworkRepository,
 			TriggerRepository,
 		>(None, None, None)
+		.await
 		.unwrap();
 
 		let path = "test_monitor.json".to_string();
@@ -707,6 +710,7 @@ mod tests {
 			NetworkRepository,
 			TriggerRepository,
 		>(None, None, None)
+		.await
 		.unwrap();
 
 		// Test parameters

--- a/src/models/config/mod.rs
+++ b/src/models/config/mod.rs
@@ -5,6 +5,7 @@
 
 #![allow(clippy::result_large_err)]
 
+use async_trait::async_trait;
 use std::path::Path;
 
 mod error;
@@ -14,6 +15,7 @@ mod trigger_config;
 
 pub use error::ConfigError;
 /// Common interface for loading configuration files
+#[async_trait]
 pub trait ConfigLoader: Sized {
 	/// Load all configuration files from a directory
 	///
@@ -41,4 +43,7 @@ pub trait ConfigLoader: Sized {
 			.map(|ext| ext.to_string_lossy().to_lowercase() == "json")
 			.unwrap_or(false)
 	}
+
+	/// Resolve all secrets in the configuration
+	async fn resolve_secrets(&self) -> Result<Self, ConfigError>;
 }

--- a/src/models/config/mod.rs
+++ b/src/models/config/mod.rs
@@ -20,12 +20,12 @@ pub trait ConfigLoader: Sized {
 	/// Load all configuration files from a directory
 	///
 	/// If no path is provided, uses the default config directory.
-	fn load_all<T>(path: Option<&Path>) -> Result<T, error::ConfigError>
+	async fn load_all<T>(path: Option<&Path>) -> Result<T, error::ConfigError>
 	where
 		T: FromIterator<(String, Self)>;
 
 	/// Load configuration from a specific file path
-	fn load_from_path(path: &Path) -> Result<Self, error::ConfigError>;
+	async fn load_from_path(path: &Path) -> Result<Self, error::ConfigError>;
 
 	/// Validate the configuration
 	///

--- a/src/models/config/monitor_config.rs
+++ b/src/models/config/monitor_config.rs
@@ -3,6 +3,7 @@
 //! This module implements the ConfigLoader trait for Monitor configurations,
 //! allowing monitors to be loaded from JSON files.
 
+use async_trait::async_trait;
 use std::{collections::HashMap, fs, path::Path};
 
 use crate::{
@@ -10,7 +11,13 @@ use crate::{
 	services::trigger::validate_script_config,
 };
 
+#[async_trait]
 impl ConfigLoader for Monitor {
+	/// Resolve all secrets in the monitor configuration
+	async fn resolve_secrets(&self) -> Result<Self, ConfigError> {
+		Ok(self.clone())
+	}
+
 	/// Load all monitor configurations from a directory
 	///
 	/// Reads and parses all JSON files in the specified directory (or default

--- a/src/models/config/network_config.rs
+++ b/src/models/config/network_config.rs
@@ -315,7 +315,6 @@ impl ConfigLoader for Network {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::models::{RpcUrl, SecretString};
 	use crate::utils::tests::builders::network::NetworkBuilder;
 	use tracing_test::traced_test;
 
@@ -492,30 +491,15 @@ mod tests {
 	#[test]
 	#[traced_test]
 	fn test_validate_protocol_insecure_rpc() {
-		let network = Network {
-			name: "Test Network".to_string(),
-			slug: "test_network".to_string(),
-			network_type: BlockChainType::EVM,
-			chain_id: Some(1),
-			network_passphrase: None,
-			store_blocks: Some(true),
-			rpc_urls: vec![
-				RpcUrl {
-					type_: "rpc".to_string(),
-					url: SecretValue::Plain(SecretString::new("http://test.network".to_string())),
-					weight: 100,
-				},
-				RpcUrl {
-					type_: "rpc".to_string(),
-					url: SecretValue::Plain(SecretString::new("ws://test.network".to_string())),
-					weight: 50,
-				},
-			],
-			block_time_ms: 1000,
-			confirmation_blocks: 1,
-			cron_schedule: "0 */5 * * * *".to_string(),
-			max_past_blocks: Some(10),
-		};
+		let network = NetworkBuilder::new()
+			.name("Test Network")
+			.slug("test_network")
+			.network_type(BlockChainType::EVM)
+			.chain_id(1)
+			.store_blocks(true)
+			.add_rpc_url("http://test.network", "rpc", 100)
+			.add_rpc_url("ws://test.network", "rpc", 100)
+			.build();
 
 		network.validate_protocol();
 		assert!(logs_contain(
@@ -529,30 +513,15 @@ mod tests {
 	#[test]
 	#[traced_test]
 	fn test_validate_protocol_secure_rpc() {
-		let network = Network {
-			name: "Test Network".to_string(),
-			slug: "test_network".to_string(),
-			network_type: BlockChainType::EVM,
-			chain_id: Some(1),
-			network_passphrase: None,
-			store_blocks: Some(true),
-			rpc_urls: vec![
-				RpcUrl {
-					type_: "rpc".to_string(),
-					url: SecretValue::Plain(SecretString::new("https://test.network".to_string())),
-					weight: 100,
-				},
-				RpcUrl {
-					type_: "rpc".to_string(),
-					url: SecretValue::Plain(SecretString::new("wss://test.network".to_string())),
-					weight: 50,
-				},
-			],
-			block_time_ms: 1000,
-			confirmation_blocks: 1,
-			cron_schedule: "0 */5 * * * *".to_string(),
-			max_past_blocks: Some(10),
-		};
+		let network = NetworkBuilder::new()
+			.name("Test Network")
+			.slug("test_network")
+			.network_type(BlockChainType::EVM)
+			.chain_id(1)
+			.store_blocks(true)
+			.add_rpc_url("https://test.network", "rpc", 100)
+			.add_rpc_url("wss://test.network", "rpc", 100)
+			.build();
 
 		network.validate_protocol();
 		assert!(!logs_contain("uses an insecure RPC URL"));
@@ -562,48 +531,17 @@ mod tests {
 	#[test]
 	#[traced_test]
 	fn test_validate_protocol_mixed_security() {
-		let network = Network {
-			name: "Test Network".to_string(),
-			slug: "test_network".to_string(),
-			network_type: BlockChainType::EVM,
-			chain_id: Some(1),
-			network_passphrase: None,
-			store_blocks: Some(true),
-			rpc_urls: vec![
-				RpcUrl {
-					type_: "rpc".to_string(),
-					url: SecretValue::Plain(SecretString::new(
-						"https://secure.network".to_string(),
-					)),
-					weight: 100,
-				},
-				RpcUrl {
-					type_: "rpc".to_string(),
-					url: SecretValue::Plain(SecretString::new(
-						"http://insecure.network".to_string(),
-					)),
-					weight: 50,
-				},
-				RpcUrl {
-					type_: "rpc".to_string(),
-					url: SecretValue::Plain(SecretString::new(
-						"wss://secure.ws.network".to_string(),
-					)),
-					weight: 25,
-				},
-				RpcUrl {
-					type_: "rpc".to_string(),
-					url: SecretValue::Plain(SecretString::new(
-						"ws://insecure.ws.network".to_string(),
-					)),
-					weight: 25,
-				},
-			],
-			block_time_ms: 1000,
-			confirmation_blocks: 1,
-			cron_schedule: "0 */5 * * * *".to_string(),
-			max_past_blocks: Some(10),
-		};
+		let network = NetworkBuilder::new()
+			.name("Test Network")
+			.slug("test_network")
+			.network_type(BlockChainType::EVM)
+			.chain_id(1)
+			.store_blocks(true)
+			.add_rpc_url("https://secure.network", "rpc", 100)
+			.add_rpc_url("http://insecure.network", "rpc", 50)
+			.add_rpc_url("wss://secure.ws.network", "rpc", 25)
+			.add_rpc_url("ws://insecure.ws.network", "rpc", 25)
+			.build();
 
 		network.validate_protocol();
 		assert!(logs_contain(

--- a/src/models/core/network.rs
+++ b/src/models/core/network.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::models::BlockChainType;
+use crate::models::{BlockChainType, SecretValue};
 
 /// Configuration for connecting to and interacting with a blockchain network.
 ///
@@ -48,8 +48,8 @@ pub struct RpcUrl {
 	/// Type of RPC endpoint (e.g. "rpc")
 	pub type_: String,
 
-	/// URL of the RPC endpoint
-	pub url: String,
+	/// URL of the RPC endpoint (can be a secret value)
+	pub url: SecretValue,
 
 	/// Weight for load balancing (0-100)
 	pub weight: u32,

--- a/src/models/core/trigger.rs
+++ b/src/models/core/trigger.rs
@@ -1,4 +1,4 @@
-use crate::models::core::ScriptLanguage;
+use crate::models::{core::ScriptLanguage, SecretValue};
 use email_address::EmailAddress;
 use serde::{Deserialize, Serialize};
 
@@ -49,7 +49,7 @@ pub enum TriggerTypeConfig {
 	/// Slack notification configuration
 	Slack {
 		/// Slack webhook URL
-		slack_url: String,
+		slack_url: SecretValue,
 		/// Notification message
 		message: NotificationMessage,
 	},
@@ -60,9 +60,9 @@ pub enum TriggerTypeConfig {
 		/// SMTP port (default 465)
 		port: Option<u16>,
 		/// SMTP username
-		username: String,
+		username: SecretValue,
 		/// SMTP password
-		password: String,
+		password: SecretValue,
 		/// Notification message
 		message: NotificationMessage,
 		/// Email sender
@@ -73,11 +73,11 @@ pub enum TriggerTypeConfig {
 	/// Webhook configuration
 	Webhook {
 		/// Webhook endpoint URL
-		url: String,
+		url: SecretValue,
 		/// HTTP method to use
 		method: Option<String>,
 		/// Secret
-		secret: Option<String>,
+		secret: Option<SecretValue>,
 		/// Optional HTTP headers
 		headers: Option<std::collections::HashMap<String, String>>,
 		/// Notification message
@@ -86,7 +86,7 @@ pub enum TriggerTypeConfig {
 	/// Telegram notification configuration
 	Telegram {
 		/// Telegram bot token
-		token: String,
+		token: SecretValue,
 		/// Telegram chat ID
 		chat_id: String,
 		/// Disable web preview
@@ -97,7 +97,7 @@ pub enum TriggerTypeConfig {
 	/// Discord notification configuration
 	Discord {
 		/// Discord webhook URL
-		discord_url: String,
+		discord_url: SecretValue,
 		/// Notification message
 		message: NotificationMessage,
 	},

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,10 +5,12 @@
 //! - `blockchain`: Platform-specific implementations for different blockchains (EVM, Stellar)
 //! - `config`: Configuration loading and validation
 //! - `core`: Core domain models (Monitor, Network, Trigger)
+//! - `security`: Security models (Secret)
 
 mod blockchain;
 mod config;
 mod core;
+mod security;
 
 // Re-export blockchain types
 pub use blockchain::{BlockChainType, BlockType, MonitorMatch, ProcessedBlock, TransactionType};
@@ -33,3 +35,6 @@ pub use core::{
 
 // Re-export config types
 pub use config::{ConfigError, ConfigLoader};
+
+// Re-export security types
+pub use security::{SecretString, SecretValue, SecurityError};

--- a/src/models/security/error.rs
+++ b/src/models/security/error.rs
@@ -1,16 +1,15 @@
-//! Configuration error types.
+//! Security error types and error handling utilities.
 //!
-//! This module defines the error types that can occur during configuration
-//! loading and validation.
+//! This module defines error types for handling security-related operations.
 
 use crate::utils::logging::error::{ErrorContext, TraceableError};
 use std::collections::HashMap;
 use thiserror::Error as ThisError;
 use uuid::Uuid;
 
-/// Represents errors that can occur during configuration operations
+/// Represents errors that can occur during security operations
 #[derive(ThisError, Debug)]
-pub enum ConfigError {
+pub enum SecurityError {
 	/// Errors related to validation failures
 	#[error("Validation error: {0}")]
 	ValidationError(ErrorContext),
@@ -19,25 +18,23 @@ pub enum ConfigError {
 	#[error("Parse error: {0}")]
 	ParseError(ErrorContext),
 
-	/// Errors related to file system errors
-	#[error("File error: {0}")]
-	FileError(ErrorContext),
+	/// Errors related to network failures
+	#[error("Network error: {0}")]
+	NetworkError(ErrorContext),
 
 	/// Other errors that don't fit into the categories above
 	#[error(transparent)]
 	Other(#[from] anyhow::Error),
 }
 
-impl ConfigError {
+impl SecurityError {
 	// Validation error
 	pub fn validation_error(
 		msg: impl Into<String>,
 		source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 		metadata: Option<HashMap<String, String>>,
 	) -> Self {
-		// We explicitly do not use new_with_log here because we want to log the error
-		// at from the context of the repository
-		Self::ValidationError(ErrorContext::new(msg, source, metadata))
+		Self::ValidationError(ErrorContext::new_with_log(msg, source, metadata))
 	}
 
 	// Parse error
@@ -46,41 +43,37 @@ impl ConfigError {
 		source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 		metadata: Option<HashMap<String, String>>,
 	) -> Self {
-		// We explicitly do not use new_with_log here because we want to log the error
-		// at from the context of the repository
-		Self::ParseError(ErrorContext::new(msg, source, metadata))
+		Self::ParseError(ErrorContext::new_with_log(msg, source, metadata))
 	}
 
-	// File error
-	pub fn file_error(
+	// Network error
+	pub fn network_error(
 		msg: impl Into<String>,
 		source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 		metadata: Option<HashMap<String, String>>,
 	) -> Self {
-		// We explicitly do not use new_with_log here because we want to log the error
-		// at from the context of the repository
-		Self::FileError(ErrorContext::new(msg, source, metadata))
+		Self::NetworkError(ErrorContext::new_with_log(msg, source, metadata))
 	}
 }
 
-impl TraceableError for ConfigError {
+impl TraceableError for SecurityError {
 	fn trace_id(&self) -> String {
 		match self {
 			Self::ValidationError(ctx) => ctx.trace_id.clone(),
 			Self::ParseError(ctx) => ctx.trace_id.clone(),
-			Self::FileError(ctx) => ctx.trace_id.clone(),
+			Self::NetworkError(ctx) => ctx.trace_id.clone(),
 			Self::Other(_) => Uuid::new_v4().to_string(),
 		}
 	}
 }
 
-impl From<std::io::Error> for ConfigError {
+impl From<std::io::Error> for SecurityError {
 	fn from(err: std::io::Error) -> Self {
-		Self::file_error(err.to_string(), None, None)
+		Self::parse_error(err.to_string(), None, None)
 	}
 }
 
-impl From<serde_json::Error> for ConfigError {
+impl From<serde_json::Error> for SecurityError {
 	fn from(err: serde_json::Error) -> Self {
 		Self::parse_error(err.to_string(), None, None)
 	}
@@ -93,11 +86,11 @@ mod tests {
 
 	#[test]
 	fn test_validation_error_formatting() {
-		let error = ConfigError::validation_error("test error", None, None);
+		let error = SecurityError::validation_error("test error", None, None);
 		assert_eq!(error.to_string(), "Validation error: test error");
 
 		let source_error = IoError::new(ErrorKind::NotFound, "test source");
-		let error = ConfigError::validation_error(
+		let error = SecurityError::validation_error(
 			"test error",
 			Some(Box::new(source_error)),
 			Some(HashMap::from([("key1".to_string(), "value1".to_string())])),
@@ -110,11 +103,11 @@ mod tests {
 
 	#[test]
 	fn test_parse_error_formatting() {
-		let error = ConfigError::parse_error("test error", None, None);
+		let error = SecurityError::parse_error("test error", None, None);
 		assert_eq!(error.to_string(), "Parse error: test error");
 
 		let source_error = IoError::new(ErrorKind::NotFound, "test source");
-		let error = ConfigError::parse_error(
+		let error = SecurityError::parse_error(
 			"test error",
 			Some(Box::new(source_error)),
 			Some(HashMap::from([("key1".to_string(), "value1".to_string())])),
@@ -123,26 +116,25 @@ mod tests {
 	}
 
 	#[test]
-	fn test_file_error_formatting() {
-		let error = ConfigError::file_error("test error", None, None);
-		assert_eq!(error.to_string(), "File error: test error");
+	fn test_network_error_formatting() {
+		let error = SecurityError::network_error("test error", None, None);
+		assert_eq!(error.to_string(), "Network error: test error");
 
 		let source_error = IoError::new(ErrorKind::NotFound, "test source");
-		let error = ConfigError::file_error(
+		let error = SecurityError::network_error(
 			"test error",
 			Some(Box::new(source_error)),
 			Some(HashMap::from([("key1".to_string(), "value1".to_string())])),
 		);
-
-		assert_eq!(error.to_string(), "File error: test error [key1=value1]");
+		assert_eq!(error.to_string(), "Network error: test error [key1=value1]");
 	}
 
 	#[test]
 	fn test_from_anyhow_error() {
 		let anyhow_error = anyhow::anyhow!("test anyhow error");
-		let config_error: ConfigError = anyhow_error.into();
-		assert!(matches!(config_error, ConfigError::Other(_)));
-		assert_eq!(config_error.to_string(), "test anyhow error");
+		let security_error: SecurityError = anyhow_error.into();
+		assert!(matches!(security_error, SecurityError::Other(_)));
+		assert_eq!(security_error.to_string(), "test anyhow error");
 	}
 
 	#[test]
@@ -150,13 +142,13 @@ mod tests {
 		let io_error = std::io::Error::new(std::io::ErrorKind::Other, "while reading config");
 
 		let outer_error =
-			ConfigError::file_error("Failed to initialize", Some(Box::new(io_error)), None);
+			SecurityError::parse_error("Failed to initialize", Some(Box::new(io_error)), None);
 
 		// Just test the string representation instead of the source chain
 		assert!(outer_error.to_string().contains("Failed to initialize"));
 
-		// For ConfigError::FileError, we know the implementation details
-		if let ConfigError::FileError(ctx) = &outer_error {
+		// For SecurityError::ParseError, we know the implementation details
+		if let SecurityError::ParseError(ctx) = &outer_error {
 			// Check that the context has the right message
 			assert_eq!(ctx.message, "Failed to initialize");
 
@@ -167,23 +159,23 @@ mod tests {
 				assert_eq!(src.to_string(), "while reading config");
 			}
 		} else {
-			panic!("Expected FileError variant");
+			panic!("Expected ParseError variant");
 		}
 	}
 
 	#[test]
 	fn test_io_error_conversion() {
 		let io_error = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found");
-		let config_error: ConfigError = io_error.into();
-		assert!(matches!(config_error, ConfigError::FileError(_)));
+		let security_error: SecurityError = io_error.into();
+		assert!(matches!(security_error, SecurityError::ParseError(_)));
 	}
 
 	#[test]
 	fn test_serde_error_conversion() {
 		let json = "invalid json";
 		let serde_error = serde_json::from_str::<serde_json::Value>(json).unwrap_err();
-		let config_error: ConfigError = serde_error.into();
-		assert!(matches!(config_error, ConfigError::ParseError(_)));
+		let security_error: SecurityError = serde_error.into();
+		assert!(matches!(security_error, SecurityError::ParseError(_)));
 	}
 
 	#[test]
@@ -192,25 +184,25 @@ mod tests {
 		let error_context = ErrorContext::new("Inner error", None, None);
 		let original_trace_id = error_context.trace_id.clone();
 
-		// Wrap it in a ConfigError
-		let config_error = ConfigError::FileError(error_context);
+		// Wrap it in a SecurityError
+		let security_error = SecurityError::ParseError(error_context);
 
 		// Verify the trace ID is preserved
-		assert_eq!(config_error.trace_id(), original_trace_id);
+		assert_eq!(security_error.trace_id(), original_trace_id);
 
 		// Test trace ID propagation through error chain
 		let source_error = IoError::new(ErrorKind::Other, "Source error");
 		let error_context = ErrorContext::new("Middle error", Some(Box::new(source_error)), None);
 		let original_trace_id = error_context.trace_id.clone();
 
-		let config_error = ConfigError::FileError(error_context);
-		assert_eq!(config_error.trace_id(), original_trace_id);
+		let security_error = SecurityError::ParseError(error_context);
+		assert_eq!(security_error.trace_id(), original_trace_id);
 
 		// Test Other variant
 		let anyhow_error = anyhow::anyhow!("Test anyhow error");
-		let config_error: ConfigError = anyhow_error.into();
+		let security_error: SecurityError = anyhow_error.into();
 
 		// Other variant should generate a new UUID
-		assert!(!config_error.trace_id().is_empty());
+		assert!(!security_error.trace_id().is_empty());
 	}
 }

--- a/src/models/security/error.rs
+++ b/src/models/security/error.rs
@@ -1,28 +1,38 @@
 //! Security error types and error handling utilities.
 //!
 //! This module defines error types for handling security-related operations.
+//! The `SecurityError` type provides a structured way to handle and propagate security-related errors
+//! with rich context and tracing capabilities.
 
 use crate::utils::logging::error::{ErrorContext, TraceableError};
 use std::collections::HashMap;
 use thiserror::Error as ThisError;
 use uuid::Uuid;
 
-/// Represents errors that can occur during security operations
+/// Result type alias for security operations
+pub type SecurityResult<T> = Result<T, Box<SecurityError>>;
+
+/// Represents errors that can occur during security operations.
+///
+/// This error type is used throughout the security module to provide consistent error handling
+/// with rich context and tracing capabilities. Each variant includes an `ErrorContext` that
+/// contains detailed information about the error, including a trace ID for distributed tracing.
+
 #[derive(ThisError, Debug)]
 pub enum SecurityError {
-	/// Errors related to validation failures
+	/// Errors related to validation failures.
 	#[error("Validation error: {0}")]
 	ValidationError(ErrorContext),
 
-	/// Errors related to parsing failures
+	/// Errors related to parsing failures.
 	#[error("Parse error: {0}")]
 	ParseError(ErrorContext),
 
-	/// Errors related to network failures
+	/// Errors related to network failures.
 	#[error("Network error: {0}")]
 	NetworkError(ErrorContext),
 
-	/// Other errors that don't fit into the categories above
+	/// Other errors that don't fit into the categories above.
 	#[error(transparent)]
 	Other(#[from] anyhow::Error),
 }

--- a/src/models/security/mod.rs
+++ b/src/models/security/mod.rs
@@ -1,0 +1,12 @@
+//! Security models
+//!
+//! This module contains the security models for the application.
+//!
+//! - `error`: Error types for security operations
+//! - `secret`: Secret management and zeroization
+
+mod error;
+mod secret;
+
+pub use error::SecurityError;
+pub use secret::{SecretString, SecretValue};

--- a/src/models/security/mod.rs
+++ b/src/models/security/mod.rs
@@ -8,5 +8,43 @@
 mod error;
 mod secret;
 
-pub use error::SecurityError;
+use std::env;
+
+pub use error::{SecurityError, SecurityResult};
 pub use secret::{SecretString, SecretValue};
+
+pub fn get_env_var(key: &str) -> SecurityResult<String> {
+	env::var(key).map_err(|e| {
+		Box::new(SecurityError::parse_error(
+			format!("Missing {} environment variable", key),
+			Some(e.into()),
+			None,
+		))
+	})
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use std::env;
+
+	#[test]
+	fn test_get_env_var_success() {
+		env::set_var("TEST_ENV_VAR", "test_value");
+		let result = get_env_var("TEST_ENV_VAR");
+		assert!(result.is_ok());
+		assert_eq!(result.unwrap(), "test_value".to_string());
+		env::remove_var("TEST_ENV_VAR");
+	}
+
+	#[test]
+	fn test_get_env_var_missing() {
+		let result = get_env_var("NON_EXISTING_ENV_VAR");
+		assert!(result.is_err());
+		assert!(result
+			.err()
+			.unwrap()
+			.to_string()
+			.contains("Missing NON_EXISTING_ENV_VAR environment variable"));
+	}
+}

--- a/src/models/security/secret.rs
+++ b/src/models/security/secret.rs
@@ -795,6 +795,21 @@ mod tests {
 			.contains("Failed to get environment variable"));
 	}
 
+	#[tokio::test]
+	async fn test_secret_value_resolve_hashicorp_cloud_vault_error() {
+		with_test_env(|| async {
+			let secret = SecretValue::HashicorpCloudVault("NON_EXISTENT_VAULT_SECRET".to_string());
+			let result = secret.resolve().await;
+			assert!(result.is_err());
+			assert!(result
+				.err()
+				.unwrap()
+				.to_string()
+				.contains("Failed to get secret from Hashicorp Cloud Vault"));
+		})
+		.await;
+	}
+
 	#[test]
 	fn test_secret_value_starts_with() {
 		let plain = SecretValue::Plain(SecretString::new("PREFIX_value".to_string()));

--- a/src/models/security/secret.rs
+++ b/src/models/security/secret.rs
@@ -1,0 +1,580 @@
+//! Secret management module for handling sensitive data securely.
+//!
+//! This module provides types and utilities for managing secrets in a secure manner,
+//! with automatic memory zeroization and support for multiple secret sources.
+//!
+//! # Features
+//!
+//! - Secure memory handling with automatic zeroization
+//! - Multiple secret sources (plain text, environment variables, Hashicorp Cloud Vault, etc.)
+//! - Type-safe secret resolution
+//! - Serde support for configuration files
+
+use oz_keystore::HashicorpCloudClient;
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::fmt;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::models::security::error::SecurityError;
+
+/// Trait for vault clients that can retrieve secrets
+#[async_trait::async_trait]
+pub trait VaultClient: Send + Sync {
+	async fn get_secret(&self, name: &str) -> Result<SecretString, SecurityError>;
+}
+
+/// Cloud Vault client implementation
+#[derive(Clone)]
+pub struct CloudVaultClient {
+	client: Arc<HashicorpCloudClient>,
+}
+
+impl CloudVaultClient {
+	#[allow(dead_code)] // TODO: Remove this after testing
+	/// Creates a new CloudVaultClient from a HashicorpCloudClient
+	pub fn new(client: HashicorpCloudClient) -> Self {
+		Self {
+			client: Arc::new(client),
+		}
+	}
+
+	/// Creates a new CloudVaultClient from environment variables
+	pub fn from_env() -> Result<Self, Box<SecurityError>> {
+		let addr = env::var("VAULT_ADDR").map_err(|e| {
+			Box::new(SecurityError::parse_error(
+				format!("Missing VAULT_ADDR environment variable: {}", e),
+				None,
+				None,
+			))
+		})?;
+		let token = env::var("VAULT_TOKEN").map_err(|e| {
+			Box::new(SecurityError::parse_error(
+				format!("Missing VAULT_TOKEN environment variable: {}", e),
+				None,
+				None,
+			))
+		})?;
+		let org_id = env::var("VAULT_ORG_ID").map_err(|e| {
+			Box::new(SecurityError::parse_error(
+				format!("Missing VAULT_ORG_ID environment variable: {}", e),
+				None,
+				None,
+			))
+		})?;
+		let project_id = env::var("VAULT_PROJECT_ID").map_err(|e| {
+			Box::new(SecurityError::parse_error(
+				format!("Missing VAULT_PROJECT_ID environment variable: {}", e),
+				None,
+				None,
+			))
+		})?;
+		let app_name = env::var("VAULT_APP_NAME").map_err(|e| {
+			Box::new(SecurityError::parse_error(
+				format!("Missing VAULT_APP_NAME environment variable: {}", e),
+				None,
+				None,
+			))
+		})?;
+
+		let client = HashicorpCloudClient::new(addr, token, org_id, project_id, app_name);
+		Ok(Self {
+			client: Arc::new(client),
+		})
+	}
+}
+
+#[async_trait::async_trait]
+impl VaultClient for CloudVaultClient {
+	async fn get_secret(&self, name: &str) -> Result<SecretString, SecurityError> {
+		let secret = self.client.get_secret(name).await.map_err(|e| {
+			SecurityError::network_error(
+				format!("Failed to get secret from Hashicorp Cloud Vault: {}", e),
+				None,
+				None,
+			)
+		})?;
+		Ok(SecretString::new(secret.secret.static_version.value))
+	}
+}
+
+/// Enum representing different vault types
+#[derive(Clone)]
+pub enum VaultType {
+	Cloud(CloudVaultClient),
+}
+
+impl VaultType {
+	/// Creates a new VaultType from environment variables
+	pub fn from_env() -> Result<Self, Box<SecurityError>> {
+		// Default to cloud vault for now
+		Ok(Self::Cloud(CloudVaultClient::from_env()?))
+	}
+}
+
+#[async_trait::async_trait]
+impl VaultClient for VaultType {
+	async fn get_secret(&self, name: &str) -> Result<SecretString, SecurityError> {
+		match self {
+			Self::Cloud(client) => client.get_secret(name).await,
+		}
+	}
+}
+
+// Global vault client instance
+static VAULT_CLIENT: OnceCell<VaultType> = OnceCell::const_new();
+
+/// Gets the global vault client instance, initializing it if necessary
+pub async fn get_vault_client() -> Result<&'static VaultType, Box<SecurityError>> {
+	VAULT_CLIENT
+		.get_or_try_init(|| async { VaultType::from_env() })
+		.await
+}
+
+/// A type that represents a secret value that can be sourced from different places
+/// and ensures proper zeroization of sensitive data.
+///
+/// This enum provides different ways to store and retrieve secrets:
+/// - `Plain`: Direct secret value (wrapped in `SecretString` for secure memory handling)
+/// - `Environment`: Environment variable reference
+/// - `HashicorpCloudVault`: Hashicorp Cloud Vault reference
+///
+/// All variants implement `ZeroizeOnDrop` to ensure secure memory cleanup.
+#[derive(Debug, Clone, Serialize, Deserialize, ZeroizeOnDrop)]
+#[serde(tag = "type", content = "value")]
+pub enum SecretValue {
+	/// A plain text secret value
+	Plain(SecretString),
+	/// A secret stored in an environment variable
+	Environment(String),
+	/// A secret stored in Hashicorp Cloud Vault
+	HashicorpCloudVault { name: String },
+}
+
+impl PartialEq for SecretValue {
+	fn eq(&self, other: &Self) -> bool {
+		match (self, other) {
+			(Self::Plain(l0), Self::Plain(r0)) => l0.as_str() == r0.as_str(),
+			(Self::Environment(l0), Self::Environment(r0)) => l0 == r0,
+			(Self::HashicorpCloudVault { name: l0 }, Self::HashicorpCloudVault { name: r0 }) => {
+				l0 == r0
+			}
+			_ => false,
+		}
+	}
+}
+
+/// A string type that automatically zeroizes its contents when dropped.
+///
+/// This type ensures that sensitive data like passwords and API keys are securely
+/// erased from memory as soon as they're no longer needed. It implements both
+/// `Zeroize` and `ZeroizeOnDrop` to guarantee secure memory cleanup.
+///
+/// # Security
+///
+/// The underlying string is automatically zeroized when:
+/// - The value is dropped
+/// - `zeroize()` is called explicitly
+/// - The value is moved
+#[derive(Debug, Clone, Serialize, Deserialize, Zeroize, ZeroizeOnDrop)]
+pub struct SecretString(String);
+
+impl PartialEq for SecretString {
+	fn eq(&self, other: &Self) -> bool {
+		self.0 == other.0
+	}
+}
+
+impl SecretValue {
+	/// Resolves the secret value based on its type.
+	///
+	/// This method retrieves the actual secret value from its source:
+	/// - For `Plain`, returns the wrapped `SecretString`
+	/// - For `Environment`, reads the environment variable
+	/// - For `HashicorpCloudVault`, fetches the secret from the vault
+	///
+	/// # Errors
+	///
+	/// Returns a `SecurityError` if:
+	/// - Environment variable is not set
+	/// - Vault access fails
+	/// - Any other security-related error occurs
+	pub async fn resolve(&self) -> Result<SecretString, Box<SecurityError>> {
+		match self {
+			SecretValue::Plain(secret) => Ok(secret.clone()),
+			SecretValue::Environment(env_var) => {
+				env::var(env_var).map(SecretString::new).map_err(|e| {
+					Box::new(SecurityError::parse_error(
+						format!("Failed to get environment variable {}: {}", env_var, e),
+						None,
+						None,
+					))
+				})
+			}
+			SecretValue::HashicorpCloudVault { name } => {
+				let client = get_vault_client().await?;
+				client.get_secret(name).await.map_err(Box::new)
+			}
+		}
+	}
+
+	/// Checks if the secret value starts with a given prefix
+	pub fn starts_with(&self, prefix: &str) -> bool {
+		match self {
+			SecretValue::Plain(secret) => secret.as_str().starts_with(prefix),
+			SecretValue::Environment(env_var) => env_var.starts_with(prefix),
+			SecretValue::HashicorpCloudVault { name } => name.starts_with(prefix),
+		}
+	}
+
+	/// Checks if the secret value is empty
+	pub fn is_empty(&self) -> bool {
+		match self {
+			SecretValue::Plain(secret) => secret.as_str().is_empty(),
+			SecretValue::Environment(env_var) => env_var.is_empty(),
+			SecretValue::HashicorpCloudVault { name } => name.is_empty(),
+		}
+	}
+
+	/// Trims the secret value
+	pub fn trim(&self) -> &str {
+		match self {
+			SecretValue::Plain(secret) => secret.as_str().trim(),
+			SecretValue::Environment(env_var) => env_var.trim(),
+			SecretValue::HashicorpCloudVault { name } => name.trim(),
+		}
+	}
+
+	/// Returns the secret value as a string
+	pub fn as_str(&self) -> &str {
+		match self {
+			SecretValue::Plain(secret) => secret.as_str(),
+			SecretValue::Environment(env_var) => env_var,
+			SecretValue::HashicorpCloudVault { name } => name,
+		}
+	}
+}
+
+impl Zeroize for SecretValue {
+	/// Securely zeroizes the secret value.
+	///
+	/// This implementation ensures that all sensitive data is properly cleared:
+	/// - For `Plain`, zeroizes the underlying `SecretString`
+	/// - For `Environment`, clears the environment variable name
+	/// - For `HashicorpCloudVault`, clears the secret name
+	fn zeroize(&mut self) {
+		match self {
+			SecretValue::Plain(secret) => secret.zeroize(),
+			SecretValue::Environment(env_var) => {
+				// Clear the environment variable name
+				env_var.clear();
+			}
+			SecretValue::HashicorpCloudVault { name } => {
+				name.clear();
+			}
+		}
+	}
+}
+
+impl SecretString {
+	/// Creates a new `SecretString` with the given value.
+	///
+	/// The value will be automatically zeroized when the `SecretString` is dropped.
+	pub fn new(value: String) -> Self {
+		Self(value)
+	}
+
+	/// Gets a reference to the underlying string.
+	///
+	/// # Security Note
+	///
+	/// Be careful with this method as it exposes the secret value.
+	/// The reference should be used immediately and not stored.
+	pub fn as_str(&self) -> &str {
+		&self.0
+	}
+}
+
+impl From<String> for SecretString {
+	fn from(value: String) -> Self {
+		Self::new(value)
+	}
+}
+
+impl AsRef<str> for SecretString {
+	fn as_ref(&self) -> &str {
+		self.as_str()
+	}
+}
+
+impl fmt::Display for SecretValue {
+	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+		match self {
+			SecretValue::Plain(secret) => write!(f, "{}", secret.as_str()),
+			SecretValue::Environment(env_var) => write!(f, "{}", env_var),
+			SecretValue::HashicorpCloudVault { name } => write!(f, "{}", name),
+		}
+	}
+}
+
+impl AsRef<str> for SecretValue {
+	fn as_ref(&self) -> &str {
+		match self {
+			SecretValue::Plain(secret) => secret.as_ref(),
+			SecretValue::Environment(env_var) => env_var,
+			SecretValue::HashicorpCloudVault { name } => name,
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use once_cell::sync::Lazy;
+	use std::collections::HashMap;
+	use std::sync::Mutex;
+
+	// Mock environment variables for testing
+	static ENV_LOCK: Mutex<()> = Mutex::new(());
+	static MOCK_VAULT_VARS: Lazy<HashMap<&'static str, &'static str>> = Lazy::new(|| {
+		let mut map = HashMap::new();
+		map.insert("VAULT_ADDR", "https://vault.example.com");
+		map.insert("VAULT_TOKEN", "test-token");
+		map.insert("VAULT_ORG_ID", "test-org");
+		map.insert("VAULT_PROJECT_ID", "test-project");
+		map.insert("VAULT_APP_NAME", "test-app");
+		map
+	});
+
+	// Helper function to set up mock environment
+	fn setup_mock_env() {
+		for (key, value) in MOCK_VAULT_VARS.iter() {
+			std::env::set_var(key, value);
+		}
+	}
+
+	// Helper function to clean up mock environment
+	fn cleanup_mock_env() {
+		for key in MOCK_VAULT_VARS.keys() {
+			std::env::remove_var(key);
+		}
+	}
+
+	/// Tests environment variable secret resolution
+	#[tokio::test]
+	async fn test_environment_secret() {
+		const TEST_ENV_VAR: &str = "TEST_SECRET_ENV_VAR";
+		const TEST_SECRET: &str = "test_secret_value";
+
+		env::set_var(TEST_ENV_VAR, TEST_SECRET);
+
+		let secret = SecretValue::Environment(TEST_ENV_VAR.to_string());
+		let resolved = secret.resolve().await.unwrap();
+
+		assert_eq!(resolved.as_str(), TEST_SECRET);
+
+		env::remove_var(TEST_ENV_VAR);
+	}
+
+	/// Tests manual zeroization of SecretString
+	#[test]
+	fn test_secret_string_zeroize() {
+		let secret = "sensitive_data".to_string();
+		let mut secret_string = SecretString::new(secret.clone());
+
+		assert_eq!(secret_string.as_str(), secret);
+
+		// Manually zeroize
+		secret_string.zeroize();
+		assert_eq!(secret_string.as_str(), "");
+	}
+
+	/// Tests zeroization of all SecretValue variants
+	#[test]
+	fn test_secret_value_zeroize() {
+		let mut plain_secret = SecretValue::Plain(SecretString::new("plain_secret".to_string()));
+		let mut env_secret = SecretValue::Environment("ENV_VAR".to_string());
+		let mut cloud_vault_secret = SecretValue::HashicorpCloudVault {
+			name: "secret_name".to_string(),
+		};
+
+		plain_secret.zeroize();
+		env_secret.zeroize();
+		cloud_vault_secret.zeroize();
+
+		// After zeroize, the values should be cleared
+		if let SecretValue::Plain(ref secret) = plain_secret {
+			assert_eq!(secret.as_str(), "");
+		}
+
+		if let SecretValue::Environment(ref env_var) = env_secret {
+			assert_eq!(env_var, "");
+		}
+		if let SecretValue::HashicorpCloudVault { ref name } = cloud_vault_secret {
+			assert_eq!(name, "");
+		}
+	}
+
+	#[test]
+	fn test_cloud_vault_client_from_env_success() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		setup_mock_env();
+
+		let result = CloudVaultClient::from_env();
+		assert!(result.is_ok());
+
+		cleanup_mock_env();
+	}
+
+	#[test]
+	fn test_cloud_vault_client_from_env_missing_vars() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		setup_mock_env();
+
+		// Test missing VAULT_ADDR
+		std::env::remove_var("VAULT_ADDR");
+		let result = CloudVaultClient::from_env();
+		assert!(result.is_err());
+		assert!(result.err().unwrap().to_string().contains("VAULT_ADDR"));
+
+		// Test missing VAULT_TOKEN
+		setup_mock_env();
+		std::env::remove_var("VAULT_TOKEN");
+		let result = CloudVaultClient::from_env();
+		assert!(result.is_err());
+		assert!(result.err().unwrap().to_string().contains("VAULT_TOKEN"));
+
+		cleanup_mock_env();
+	}
+
+	#[tokio::test]
+	async fn test_vault_type_from_env() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		setup_mock_env();
+
+		let result = VaultType::from_env();
+		assert!(result.is_ok());
+		match result.unwrap() {
+			VaultType::Cloud(_) => (), // Expected
+		}
+
+		cleanup_mock_env();
+	}
+
+	#[tokio::test]
+	#[allow(clippy::await_holding_lock)]
+	async fn test_get_vault_client() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		setup_mock_env();
+
+		// First call should initialize the client
+		let result = get_vault_client().await;
+		assert!(result.is_ok());
+		let client = result.unwrap();
+		match client {
+			VaultType::Cloud(_) => (), // Expected
+		}
+
+		// Second call should return the same instance
+		let result2 = get_vault_client().await;
+		assert!(result2.is_ok());
+		assert!(std::ptr::eq(client, result2.unwrap()));
+
+		cleanup_mock_env();
+	}
+
+	#[tokio::test]
+	#[ignore]
+	// TODO: Fix this test after oz-keystore is updated
+	async fn test_vault_client_get_secret_error() {
+		// 	let _lock = ENV_LOCK.lock().unwrap();
+		// 	setup_mock_env();
+
+		// 	let client = CloudVaultClient::from_env().unwrap();
+		// 	let result = client.get_secret("test-secret").await;
+
+		// 	assert!(result.is_err());
+		// 	assert!(result
+		// 		.unwrap_err()
+		// 		.to_string()
+		// 		.contains("Failed to get secret"));
+
+		// 	cleanup_mock_env();
+		// }
+
+		// #[tokio::test]
+		// #[allow(clippy::await_holding_lock)]
+		// async fn test_vault_client_get_secret() {
+		// 	let _lock = ENV_LOCK.lock().unwrap();
+		// 	setup_mock_env();
+
+		// 	// Create a mock server
+		// 	let mut server = mockito::Server::new_async().await;
+
+		// 	// Mock token endpoint
+		// 	let token_mock = server
+		// 		.mock("POST", "/oauth2/token")
+		// 		.with_status(200)
+		// 		.with_body(r#"{"access_token": "test-token"}"#)
+		// 		.create_async()
+		// 		.await;
+
+		// 	// Mock secret endpoint
+		// 	let secret_mock = server
+		// 		.mock("GET", "/secrets/2023-11-28/organizations/test-org/projects/test-project/apps/test-app/secrets/test-secret:open")
+		// 		.with_status(200)
+		// 		.with_header("content-type", "application/json")
+		// 		.with_body(r#"{
+		// 			"secret": {
+		// 				"static_version": {
+		// 					"value": "test-secret-value"
+		// 				}
+		// 			}
+		// 		}"#)
+		// 		.create_async()
+		// 		.await;
+
+		// 	// Create a reqwest client that uses our mock server
+		// 	let client = reqwest::Client::builder()
+		// 		.danger_accept_invalid_certs(true)
+		// 		.redirect(reqwest::redirect::Policy::none())
+		// 		.build()
+		// 		.unwrap();
+
+		// 	// let hashicorp_client = HashicorpCloudClient::new(
+		// 	// 	"test-client-id".to_string(),
+		// 	// 	"test-client-secret".to_string(),
+		// 	// 	"test-org".to_string(),
+		// 	// 	"test-project".to_string(),
+		// 	// 	"test-app".to_string(),
+		// 	// )
+		// 	// .with_client(client);
+
+		// 	let vault_client = CloudVaultClient::new(hashicorp_client);
+		// 	let result = vault_client.get_secret("test-secret").await;
+
+		// 	assert!(result.is_ok());
+		// 	assert_eq!(result.unwrap().as_str(), "test-secret-value");
+		// 	token_mock.assert();
+		// 	secret_mock.assert();
+
+		// 	cleanup_mock_env();
+	}
+
+	#[test]
+	fn test_vault_type_clone() {
+		let _lock = ENV_LOCK.lock().unwrap();
+		setup_mock_env();
+
+		let vault_type = VaultType::from_env().unwrap();
+		let cloned = vault_type.clone();
+
+		match (vault_type, cloned) {
+			(VaultType::Cloud(_), VaultType::Cloud(_)) => (), // Expected
+		}
+
+		cleanup_mock_env();
+	}
+}

--- a/src/models/security/secret.rs
+++ b/src/models/security/secret.rs
@@ -568,56 +568,54 @@ mod tests {
 
 	#[tokio::test]
 	#[allow(clippy::await_holding_lock)]
-	#[ignore]
-	// TODO: enable again after oz-keystore is updated to 0.1.4
 	async fn test_vault_client_get_secret() {
-		// let mut server = mockito::Server::new_async().await;
-		// // Mock the token request
-		// let token_mock = server
-		// 	.mock("POST", "/oauth2/token")
-		// 	.with_status(200)
-		// 	.with_header("content-type", "application/json")
-		// 	.with_body(
-		// 		r#"{"access_token": "test-token", "token_type": "Bearer", "expires_in": 3600}"#,
-		// 	)
-		// 	.create_async()
-		// 	.await;
+		let mut server = mockito::Server::new_async().await;
+		// Mock the token request
+		let token_mock = server
+			.mock("POST", "/oauth2/token")
+			.with_status(200)
+			.with_header("content-type", "application/json")
+			.with_body(
+				r#"{"access_token": "test-token", "token_type": "Bearer", "expires_in": 3600}"#,
+			)
+			.create_async()
+			.await;
 
-		// // Mock the secret request
-		// let secret_mock = server
-		// 	.mock(
-		// 		"GET",
-		// 		"/secrets/2023-11-28/organizations/test-org/projects/test-project/apps/test-app/secrets/test-secret:open",
-		// 	)
-		// 	.with_status(200)
-		// 	.with_header("content-type", "application/json")
-		// 	.with_body(r#"{"secret": {"static_version": {"value": "test-secret-value"}}}"#)
-		// 	.create_async()
-		// 	.await;
+		// Mock the secret request
+		let secret_mock = server
+			.mock(
+				"GET",
+				"/secrets/2023-11-28/organizations/test-org/projects/test-project/apps/test-app/secrets/test-secret:open",
+			)
+			.with_status(200)
+			.with_header("content-type", "application/json")
+			.with_body(r#"{"secret": {"static_version": {"value": "test-secret-value"}}}"#)
+			.create_async()
+			.await;
 
-		// // Create the HashicorpCloudClient with the custom client
-		// let hashicorp_client = HashicorpCloudClient::new(
-		// 	"test-client-id".to_string(),
-		// 	"test-client-secret".to_string(),
-		// 	"test-org".to_string(),
-		// 	"test-project".to_string(),
-		// 	"test-app".to_string(),
-		// )
-		// .with_api_base_url(server.url())
-		// .with_auth_base_url(server.url());
+		// Create the HashicorpCloudClient with the custom client
+		let hashicorp_client = HashicorpCloudClient::new(
+			"test-client-id".to_string(),
+			"test-client-secret".to_string(),
+			"test-org".to_string(),
+			"test-project".to_string(),
+			"test-app".to_string(),
+		)
+		.with_api_base_url(server.url())
+		.with_auth_base_url(server.url());
 
-		// let vault_client = CloudVaultClient::new(hashicorp_client);
+		let vault_client = CloudVaultClient::new(hashicorp_client);
 
-		// // Get the secret
-		// let result = vault_client.get_secret("test-secret").await;
+		// Get the secret
+		let result = vault_client.get_secret("test-secret").await;
 
-		// // Verify the mocks were called
-		// token_mock.assert_async().await;
-		// secret_mock.assert_async().await;
+		// Verify the mocks were called
+		token_mock.assert_async().await;
+		secret_mock.assert_async().await;
 
-		// // Verify the result
-		// assert!(result.is_ok());
-		// assert_eq!(result.unwrap().as_str(), "test-secret-value");
+		// Verify the result
+		assert!(result.is_ok());
+		assert_eq!(result.unwrap().as_str(), "test-secret-value");
 	}
 
 	#[test]

--- a/src/models/security/secret.rs
+++ b/src/models/security/secret.rs
@@ -568,54 +568,56 @@ mod tests {
 
 	#[tokio::test]
 	#[allow(clippy::await_holding_lock)]
+	#[ignore]
+	// TODO: enable again after oz-keystore is updated to 0.1.4
 	async fn test_vault_client_get_secret() {
-		let mut server = mockito::Server::new_async().await;
-		// Mock the token request
-		let token_mock = server
-			.mock("POST", "/oauth2/token")
-			.with_status(200)
-			.with_header("content-type", "application/json")
-			.with_body(
-				r#"{"access_token": "test-token", "token_type": "Bearer", "expires_in": 3600}"#,
-			)
-			.create_async()
-			.await;
+		// let mut server = mockito::Server::new_async().await;
+		// // Mock the token request
+		// let token_mock = server
+		// 	.mock("POST", "/oauth2/token")
+		// 	.with_status(200)
+		// 	.with_header("content-type", "application/json")
+		// 	.with_body(
+		// 		r#"{"access_token": "test-token", "token_type": "Bearer", "expires_in": 3600}"#,
+		// 	)
+		// 	.create_async()
+		// 	.await;
 
-		// Mock the secret request
-		let secret_mock = server
-			.mock(
-				"GET",
-				"/secrets/2023-11-28/organizations/test-org/projects/test-project/apps/test-app/secrets/test-secret:open",
-			)
-			.with_status(200)
-			.with_header("content-type", "application/json")
-			.with_body(r#"{"secret": {"static_version": {"value": "test-secret-value"}}}"#)
-			.create_async()
-			.await;
+		// // Mock the secret request
+		// let secret_mock = server
+		// 	.mock(
+		// 		"GET",
+		// 		"/secrets/2023-11-28/organizations/test-org/projects/test-project/apps/test-app/secrets/test-secret:open",
+		// 	)
+		// 	.with_status(200)
+		// 	.with_header("content-type", "application/json")
+		// 	.with_body(r#"{"secret": {"static_version": {"value": "test-secret-value"}}}"#)
+		// 	.create_async()
+		// 	.await;
 
-		// Create the HashicorpCloudClient with the custom client
-		let hashicorp_client = HashicorpCloudClient::new(
-			"test-client-id".to_string(),
-			"test-client-secret".to_string(),
-			"test-org".to_string(),
-			"test-project".to_string(),
-			"test-app".to_string(),
-		)
-		.with_api_base_url(server.url())
-		.with_auth_base_url(server.url());
+		// // Create the HashicorpCloudClient with the custom client
+		// let hashicorp_client = HashicorpCloudClient::new(
+		// 	"test-client-id".to_string(),
+		// 	"test-client-secret".to_string(),
+		// 	"test-org".to_string(),
+		// 	"test-project".to_string(),
+		// 	"test-app".to_string(),
+		// )
+		// .with_api_base_url(server.url())
+		// .with_auth_base_url(server.url());
 
-		let vault_client = CloudVaultClient::new(hashicorp_client);
+		// let vault_client = CloudVaultClient::new(hashicorp_client);
 
-		// Get the secret
-		let result = vault_client.get_secret("test-secret").await;
+		// // Get the secret
+		// let result = vault_client.get_secret("test-secret").await;
 
-		// Verify the mocks were called
-		token_mock.assert_async().await;
-		secret_mock.assert_async().await;
+		// // Verify the mocks were called
+		// token_mock.assert_async().await;
+		// secret_mock.assert_async().await;
 
-		// Verify the result
-		assert!(result.is_ok());
-		assert_eq!(result.unwrap().as_str(), "test-secret-value");
+		// // Verify the result
+		// assert!(result.is_ok());
+		// assert_eq!(result.unwrap().as_str(), "test-secret-value");
 	}
 
 	#[test]

--- a/src/services/blockchain/transports/http.rs
+++ b/src/services/blockchain/transports/http.rs
@@ -95,7 +95,7 @@ impl HttpTransportClient {
 			.build();
 
 		for rpc_url in rpc_urls.iter() {
-			let url = match Url::parse(&rpc_url.url) {
+			let url = match Url::parse(rpc_url.url.as_ref()) {
 				Ok(url) => url,
 				Err(_) => continue,
 			};
@@ -126,7 +126,7 @@ impl HttpTransportClient {
 					let fallback_urls: Vec<String> = rpc_urls
 						.iter()
 						.filter(|url| url.url != rpc_url.url)
-						.map(|url| url.url.clone())
+						.map(|url| url.url.as_ref().to_string())
 						.collect();
 
 					// Successfully connected - create and return the client

--- a/src/services/filter/filters/stellar/filter.rs
+++ b/src/services/filter/filters/stellar/filter.rs
@@ -1199,9 +1199,12 @@ impl<T: BlockChainClient + StellarClientTrait> BlockFilter for StellarBlockFilte
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::models::{
-		AddressWithABI, MatchConditions, Monitor, StellarDecodedTransaction, StellarTransaction,
-		StellarTransactionInfo, TransactionStatus,
+	use crate::{
+		models::{
+			AddressWithABI, MatchConditions, Monitor, StellarDecodedTransaction,
+			StellarTransaction, StellarTransactionInfo, TransactionStatus,
+		},
+		utils::tests::stellar::monitor::MonitorBuilder,
 	};
 	use serde_json::json;
 	use stellar_strkey::ed25519::PublicKey as StrPublicKey;
@@ -1226,19 +1229,22 @@ mod tests {
 		transaction_conditions: Vec<TransactionCondition>,
 		addresses: Vec<AddressWithABI>,
 	) -> Monitor {
-		Monitor {
-			match_conditions: MatchConditions {
+		MonitorBuilder::new()
+			.name("test")
+			.networks(vec!["stellar_mainnet".to_string()])
+			.paused(false)
+			.addresses_with_abi(
+				addresses
+					.iter()
+					.map(|a| (a.address.clone(), a.abi.clone()))
+					.collect(),
+			)
+			.match_conditions(MatchConditions {
 				events: event_conditions,
 				functions: function_conditions,
 				transactions: transaction_conditions,
-			},
-			addresses,
-			name: "test".to_string(),
-			networks: vec!["evm_mainnet".to_string()],
-			paused: false,
-			trigger_conditions: vec![],
-			triggers: vec![],
-		}
+			})
+			.build()
 	}
 
 	/// Creates a mock transaction for testing

--- a/src/services/notification/discord.rs
+++ b/src/services/notification/discord.rs
@@ -125,7 +125,7 @@ impl DiscordNotifier {
 				discord_url,
 				message,
 			} => WebhookNotifier::new(WebhookConfig {
-				url: discord_url.clone(),
+				url: discord_url.as_ref().to_string(),
 				url_params: None,
 				title: message.title.clone(),
 				body_template: message.body.clone(),
@@ -172,7 +172,7 @@ impl Notifier for DiscordNotifier {
 
 #[cfg(test)]
 mod tests {
-	use crate::models::NotificationMessage;
+	use crate::models::{NotificationMessage, SecretString, SecretValue};
 
 	use super::*;
 
@@ -187,7 +187,9 @@ mod tests {
 
 	fn create_test_discord_config() -> TriggerTypeConfig {
 		TriggerTypeConfig::Discord {
-			discord_url: "https://discord.example.com".to_string(),
+			discord_url: SecretValue::Plain(SecretString::new(
+				"https://discord.example.com".to_string(),
+			)),
 			message: NotificationMessage {
 				title: "Test Alert".to_string(),
 				body: "Test message ${value}".to_string(),

--- a/src/services/notification/email.rs
+++ b/src/services/notification/email.rs
@@ -145,8 +145,8 @@ impl EmailNotifier<SmtpTransport> {
 				let smtp_config = SmtpConfig {
 					host: host.clone(),
 					port: port.unwrap_or(465),
-					username: username.clone(),
-					password: password.clone(),
+					username: username.as_ref().to_string(),
+					password: password.as_ref().to_string(),
 				};
 
 				let email_content = EmailContent {
@@ -217,7 +217,7 @@ where
 
 #[cfg(test)]
 mod tests {
-	use crate::models::NotificationMessage;
+	use crate::models::{NotificationMessage, SecretString, SecretValue};
 
 	use super::*;
 
@@ -243,8 +243,8 @@ mod tests {
 		TriggerTypeConfig::Email {
 			host: "smtp.test.com".to_string(),
 			port,
-			username: "testuser".to_string(),
-			password: "testpass".to_string(),
+			username: SecretValue::Plain(SecretString::new("testuser".to_string())),
+			password: SecretValue::Plain(SecretString::new("testpass".to_string())),
 			message: NotificationMessage {
 				title: "Test Subject".to_string(),
 				body: "Hello ${name}".to_string(),

--- a/src/services/notification/slack.rs
+++ b/src/services/notification/slack.rs
@@ -75,7 +75,7 @@ impl SlackNotifier {
 				payload_fields.insert("text".to_string(), serde_json::json!(null));
 
 				WebhookNotifier::new(WebhookConfig {
-					url: slack_url.clone(),
+					url: slack_url.as_ref().to_string(),
 					url_params: None,
 					title: message.title.clone(),
 					body_template: message.body.clone(),
@@ -113,7 +113,7 @@ impl Notifier for SlackNotifier {
 
 #[cfg(test)]
 mod tests {
-	use crate::models::NotificationMessage;
+	use crate::models::{NotificationMessage, SecretString, SecretValue};
 
 	use super::*;
 
@@ -128,7 +128,9 @@ mod tests {
 
 	fn create_test_slack_config() -> TriggerTypeConfig {
 		TriggerTypeConfig::Slack {
-			slack_url: "https://slack.example.com".to_string(),
+			slack_url: SecretValue::Plain(SecretString::new(
+				"https://slack.example.com".to_string(),
+			)),
 			message: NotificationMessage {
 				title: "Test Alert".to_string(),
 				body: "Test message ${value}".to_string(),

--- a/src/services/notification/telegram.rs
+++ b/src/services/notification/telegram.rs
@@ -152,7 +152,7 @@ impl Notifier for TelegramNotifier {
 
 #[cfg(test)]
 mod tests {
-	use crate::models::NotificationMessage;
+	use crate::models::{NotificationMessage, SecretString, SecretValue};
 
 	use super::*;
 
@@ -170,7 +170,7 @@ mod tests {
 
 	fn create_test_telegram_config() -> TriggerTypeConfig {
 		TriggerTypeConfig::Telegram {
-			token: "test-token".to_string(),
+			token: SecretValue::Plain(SecretString::new("test-token".to_string())),
 			chat_id: "test-chat-id".to_string(),
 			disable_web_preview: Some(true),
 			message: NotificationMessage {

--- a/src/services/notification/webhook.rs
+++ b/src/services/notification/webhook.rs
@@ -129,13 +129,13 @@ impl WebhookNotifier {
 				secret,
 				headers,
 			} => Some(Self {
-				url: url.clone(),
+				url: url.as_ref().to_string(),
 				url_params: None,
 				title: message.title.clone(),
 				body_template: message.body.clone(),
 				client: Client::new(),
 				method: method.clone(),
-				secret: secret.clone(),
+				secret: secret.as_ref().map(|s| s.as_ref().to_string()),
 				headers: headers.clone(),
 				payload_fields: None,
 			}),
@@ -292,7 +292,7 @@ impl Notifier for WebhookNotifier {
 
 #[cfg(test)]
 mod tests {
-	use crate::models::NotificationMessage;
+	use crate::models::{NotificationMessage, SecretString, SecretValue};
 
 	use super::*;
 	use mockito::{Matcher, Mock};
@@ -319,7 +319,7 @@ mod tests {
 
 	fn create_test_webhook_config() -> TriggerTypeConfig {
 		TriggerTypeConfig::Webhook {
-			url: "https://webhook.example.com".to_string(),
+			url: SecretValue::Plain(SecretString::new("https://webhook.example.com".to_string())),
 			method: Some("POST".to_string()),
 			secret: None,
 			headers: None,

--- a/src/utils/macros/deserialization.rs
+++ b/src/utils/macros/deserialization.rs
@@ -1,0 +1,243 @@
+//! Utilities for case-insensitive enum serialization/deserialization
+//!
+//! This module provides macros and utilities to help with case-insensitive
+//! handling of enum variants in JSON and other serialization formats.
+
+/// Macro to implement case-insensitive deserialization for enums with simple string variants.
+///
+/// This macro generates a custom `Deserialize` implementation for an enum that makes
+/// variant string matching case-insensitive. It works with enums that use string
+/// representation in serialization (e.g., with `#[serde(tag = "type")]`).
+///
+/// # Example
+///
+/// ```
+/// use serde::{Serialize, Deserialize};
+/// use crate::models::utils::case_insensitive::impl_case_insensitive_enum;
+///
+/// #[derive(Debug, Clone, Serialize)]
+/// #[serde(tag = "type", content = "value")]
+/// pub enum MyEnum {
+///     Variant1(String),
+///     Variant2(String),
+/// }
+///
+/// impl_case_insensitive_enum!(MyEnum, {
+///     "variant1" => Variant1,
+///     "variant2" => Variant2,
+/// });
+/// ```
+///
+/// The generated implementation will match variant names case-insensitively, so both
+/// `"variant1"` and `"VARIANT1"` will be deserialized as `MyEnum::Variant1`.
+#[macro_export]
+macro_rules! impl_case_insensitive_enum {
+    ($enum_name:ident, { $($variant_str:expr => $variant:ident),* $(,)? }) => {
+        impl<'de> ::serde::Deserialize<'de> for $enum_name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: ::serde::Deserializer<'de>,
+            {
+                use ::serde::de::{self, MapAccess, Visitor};
+                use std::fmt;
+
+                struct EnumVisitor;
+
+                impl<'de> Visitor<'de> for EnumVisitor {
+                    type Value = $enum_name;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str(concat!("a struct with a `type` field for ", stringify!($enum_name)))
+                    }
+
+                    fn visit_map<M>(self, mut map: M) -> Result<Self::Value, M::Error>
+                    where
+                        M: MapAccess<'de>,
+                    {
+                        let mut type_: Option<String> = None;
+                        let mut value: Option<::serde_json::Value> = None;
+
+                        while let Some(key) = map.next_key::<String>()? {
+                            if key == "type" {
+                                type_ = Some(map.next_value()?);
+                            } else if key == "value" {
+                                value = Some(map.next_value()?);
+                            } else {
+                                let _: ::serde_json::Value = map.next_value()?;
+                            }
+                        }
+
+                        let type_ = type_.ok_or_else(|| de::Error::missing_field("type"))?;
+                        let value = value.ok_or_else(|| de::Error::missing_field("value"))?;
+                        let type_lowercase = type_.to_lowercase();
+
+                        match type_lowercase.as_str() {
+                            $(
+                                $variant_str => {
+                                    let content = ::serde_json::from_value::<String>(value)
+                                        .map_err(|e| de::Error::custom(format!(
+                                            concat!("invalid ", $variant_str, " value: {}"), e
+                                        )))?;
+                                    Ok($enum_name::$variant(content.into()))
+                                },
+                            )*
+                            _ => Err(de::Error::unknown_variant(
+                                &type_,
+                                &[$($variant_str),*],
+                            )),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_map(EnumVisitor)
+            }
+        }
+    };
+}
+
+/// Macro to implement case-insensitive deserialize for struct enum variants
+///
+/// Similar to `impl_case_insensitive_enum` but for enums where variants contain structs
+/// rather than simple types.
+///
+/// # Example
+///
+/// ```
+/// use serde::{Serialize, Deserialize};
+/// use crate::models::utils::case_insensitive::impl_case_insensitive_enum_struct;
+///
+/// #[derive(Debug, Clone, Serialize)]
+/// #[serde(tag = "type")]
+/// pub enum MyEnum {
+///     Variant1 { field1: String, field2: i32 },
+///     Variant2 { other_field: bool },
+/// }
+///
+/// impl_case_insensitive_enum_struct!(MyEnum, {
+///     "variant1" => Variant1,
+///     "variant2" => Variant2,
+/// });
+/// ```
+#[macro_export]
+macro_rules! impl_case_insensitive_enum_struct {
+    ($enum_name:ident, { $($variant_str:expr => $variant:ident),* $(,)? }) => {
+        impl<'de> ::serde::Deserialize<'de> for $enum_name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: ::serde::Deserializer<'de>,
+            {
+                use ::serde::de::{self, MapAccess, Visitor};
+                use std::fmt;
+
+                #[derive(::serde::Deserialize)]
+                struct TypeField {
+                    #[serde(rename = "type")]
+                    type_: String,
+                    #[serde(flatten)]
+                    rest: ::serde_json::Value,
+                }
+
+                struct EnumVisitor;
+
+                impl<'de> Visitor<'de> for EnumVisitor {
+                    type Value = $enum_name;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                        formatter.write_str(concat!("a struct with a `type` field for ", stringify!($enum_name)))
+                    }
+
+                    fn visit_map<M>(self, map: M) -> Result<Self::Value, M::Error>
+                    where
+                        M: MapAccess<'de>,
+                    {
+                        // First deserialize into an intermediate structure to extract the type field
+                        let TypeField { type_, rest } = ::serde::Deserialize::deserialize(
+                            ::serde::de::value::MapAccessDeserializer::new(map)
+                        )?;
+
+                        let type_lowercase = type_.to_lowercase();
+
+                        // Then match on the type field to determine the variant
+                        match type_lowercase.as_str() {
+                            $(
+                                $variant_str => {
+                                    // Create a new value with the corrected type field
+                                    let mut json_value = rest;
+                                    if let ::serde_json::Value::Object(ref mut map) = json_value {
+                                        map.insert("type".to_string(), ::serde_json::Value::String(stringify!($variant).to_string()));
+                                    }
+
+                                    // Deserialize into the enum
+                                    ::serde_json::from_value(json_value)
+                                        .map_err(de::Error::custom)
+                                }
+                            )*
+                            _ => Err(de::Error::unknown_variant(
+                                &type_,
+                                &[$($variant_str),*],
+                            )),
+                        }
+                    }
+                }
+
+                deserializer.deserialize_map(EnumVisitor)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+	use serde::Serialize;
+
+	#[test]
+	fn test_impl_case_insensitive_enum() {
+		#[derive(Debug, Clone, Serialize, PartialEq)]
+		#[serde(tag = "type", content = "value")]
+		enum MyEnum {
+			Variant1(String),
+			Variant2(String),
+		}
+
+		impl_case_insensitive_enum!(MyEnum, {
+			"variant1" => Variant1,
+			"variant2" => Variant2,
+		});
+
+		let json = r#"{"type": "variant1", "value": "test"}"#;
+		let deserialized: MyEnum = serde_json::from_str(json).unwrap();
+		assert_eq!(deserialized, MyEnum::Variant1("test".to_string()));
+
+		let json = r#"{"type": "VARIANT1", "value": "test"}"#;
+		let deserialized: MyEnum = serde_json::from_str(json).unwrap();
+		assert_eq!(deserialized, MyEnum::Variant1("test".to_string()));
+
+		let json = r#"{"type": "Variant1", "value": "test"}"#;
+		let deserialized: MyEnum = serde_json::from_str(json).unwrap();
+		assert_eq!(deserialized, MyEnum::Variant1("test".to_string()));
+
+		let json = r#"{"type": "variant2", "value": "test"}"#;
+		let deserialized: MyEnum = serde_json::from_str(json).unwrap();
+		assert_eq!(deserialized, MyEnum::Variant2("test".to_string()));
+
+		let json = r#"{"type": "VARIANT2", "value": "test"}"#;
+		let deserialized: MyEnum = serde_json::from_str(json).unwrap();
+		assert_eq!(deserialized, MyEnum::Variant2("test".to_string()));
+
+		let json = r#"{"type": "Variant2", "value": "test"}"#;
+		let deserialized: MyEnum = serde_json::from_str(json).unwrap();
+		assert_eq!(deserialized, MyEnum::Variant2("test".to_string()));
+
+		let json = r#"{"type": "variant3", "value": "test"}"#;
+		let deserialized: Result<MyEnum, serde_json::Error> = serde_json::from_str(json);
+		assert!(deserialized.is_err());
+
+		let json = r#"{"type": "VARIANT3", "value": "test"}"#;
+		let deserialized: Result<MyEnum, serde_json::Error> = serde_json::from_str(json);
+		assert!(deserialized.is_err());
+
+		let json = r#"{"type": "Variant3", "value": "test"}"#;
+		let deserialized: Result<MyEnum, serde_json::Error> = serde_json::from_str(json);
+		assert!(deserialized.is_err());
+	}
+}

--- a/src/utils/macros/mod.rs
+++ b/src/utils/macros/mod.rs
@@ -1,0 +1,4 @@
+//! Utility macros.
+
+/// Case-insensitive enum deserialization utilities
+pub mod deserialization;

--- a/src/utils/metrics/server.rs
+++ b/src/utils/metrics/server.rs
@@ -224,7 +224,7 @@ mod tests {
 		(monitor_dir, trigger_dir, network_dir, temp_dir)
 	}
 
-	fn create_test_services() -> (
+	async fn create_test_services() -> (
 		MonitorServiceArc,
 		NetworkServiceArc,
 		TriggerServiceArc,
@@ -232,14 +232,19 @@ mod tests {
 	) {
 		let (monitor_path, trigger_path, network_path, temp_dir) = create_mock_configs();
 		let network_service =
-			NetworkService::<NetworkRepository>::new(Some(network_path.parent().unwrap())).unwrap();
+			NetworkService::<NetworkRepository>::new(Some(network_path.parent().unwrap()))
+				.await
+				.unwrap();
 		let trigger_service =
-			TriggerService::<TriggerRepository>::new(Some(trigger_path.parent().unwrap())).unwrap();
+			TriggerService::<TriggerRepository>::new(Some(trigger_path.parent().unwrap()))
+				.await
+				.unwrap();
 		let monitor_service = MonitorService::new(
 			Some(monitor_path.parent().unwrap()),
 			Some(network_service.clone()),
 			Some(trigger_service.clone()),
 		)
+		.await
 		.unwrap();
 
 		(
@@ -253,7 +258,8 @@ mod tests {
 	#[actix_web::test]
 	async fn test_metrics_handler() {
 		// Create test services
-		let (monitor_service, network_service, trigger_service, _temp_dir) = create_test_services();
+		let (monitor_service, network_service, trigger_service, _temp_dir) =
+			create_test_services().await;
 
 		// Create test app
 		let app = test::init_service(
@@ -294,7 +300,8 @@ mod tests {
 	#[tokio::test]
 	async fn test_create_metrics_server() {
 		// Create test services
-		let (monitor_service, network_service, trigger_service, _temp_dir) = create_test_services();
+		let (monitor_service, network_service, trigger_service, _temp_dir) =
+			create_test_services().await;
 
 		// Find an available port
 		let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@
 //! - cron_utils: Utilities for working with cron schedules and time intervals
 //! - expression: Utilities for working with cron expressions
 //! - logging: Logging utilities
+//! - macros: Macros for common functionality
 //! - metrics: Metrics utilities
 //! - monitor: Monitor utilities
 //! - parsing: Parsing utilities
@@ -17,6 +18,7 @@ mod expression;
 
 pub mod constants;
 pub mod logging;
+pub mod macros;
 pub mod metrics;
 pub mod monitor;
 pub mod parsing;
@@ -25,4 +27,5 @@ pub mod tests;
 pub use constants::*;
 pub use cron_utils::*;
 pub use expression::*;
+pub use macros::*;
 pub use parsing::*;

--- a/src/utils/monitor/execution.rs
+++ b/src/utils/monitor/execution.rs
@@ -43,8 +43,8 @@ pub type ExecutionResult<T> = std::result::Result<T, MonitorExecutionError>;
 pub async fn execute_monitor<
 	T: ClientPoolTrait,
 	M: MonitorRepositoryTrait<N, TR>,
-	N: NetworkRepositoryTrait,
-	TR: TriggerRepositoryTrait,
+	N: NetworkRepositoryTrait + Send + Sync + 'static,
+	TR: TriggerRepositoryTrait + Send + Sync + 'static,
 >(
 	monitor_path: &str,
 	network_slug: Option<&String>,
@@ -59,6 +59,7 @@ pub async fn execute_monitor<
 		.lock()
 		.await
 		.load_from_path(Some(Path::new(monitor_path)), None, None)
+		.await
 		.map_err(|e| MonitorExecutionError::execution_error(e.to_string(), None, None))?;
 
 	tracing::debug!(monitor_name = %monitor.name, "Monitor loaded successfully");

--- a/src/utils/parsing.rs
+++ b/src/utils/parsing.rs
@@ -3,6 +3,7 @@
 //! This module provides utilities for parsing various types of data.
 
 use byte_unit::Byte;
+use std::str::FromStr;
 
 /// Parses a string argument into a `u64` value representing a file size.
 ///
@@ -10,7 +11,7 @@ use byte_unit::Byte;
 /// Returns an error if the format is invalid.
 pub fn parse_string_to_bytes_size(s: &str) -> Result<u64, String> {
 	match Byte::from_str(s) {
-		Ok(byte) => Ok(byte.get_bytes() as u64),
+		Ok(byte) => Ok(byte.as_u64()),
 		Err(e) => Err(format!("Invalid size format: '{}'. Error: {}", s, e)),
 	}
 }

--- a/src/utils/tests/builders/network.rs
+++ b/src/utils/tests/builders/network.rs
@@ -2,7 +2,7 @@
 //!
 //! - `NetworkBuilder`: Builder for creating test Network instances
 
-use crate::models::{BlockChainType, Network, RpcUrl};
+use crate::models::{BlockChainType, Network, RpcUrl, SecretString, SecretValue};
 
 /// Builder for creating test Network instances
 pub struct NetworkBuilder {
@@ -30,7 +30,7 @@ impl Default for NetworkBuilder {
 			store_blocks: Some(true),
 			rpc_urls: vec![RpcUrl {
 				type_: "rpc".to_string(),
-				url: "https://test.network".to_string(),
+				url: SecretValue::Plain(SecretString::new("https://test.network".to_string())),
 				weight: 100,
 			}],
 			block_time_ms: 1000,
@@ -79,7 +79,7 @@ impl NetworkBuilder {
 	pub fn rpc_url(mut self, url: &str) -> Self {
 		self.rpc_urls = vec![RpcUrl {
 			type_: "rpc".to_string(),
-			url: url.to_string(),
+			url: SecretValue::Plain(SecretString::new(url.to_string())),
 			weight: 100,
 		}];
 		self
@@ -90,7 +90,7 @@ impl NetworkBuilder {
 			.into_iter()
 			.map(|url| RpcUrl {
 				type_: "rpc".to_string(),
-				url: url.to_string(),
+				url: SecretValue::Plain(SecretString::new(url.to_string())),
 				weight: 100,
 			})
 			.collect();
@@ -100,7 +100,7 @@ impl NetworkBuilder {
 	pub fn add_rpc_url(mut self, url: &str, type_: &str, weight: u32) -> Self {
 		self.rpc_urls.push(RpcUrl {
 			type_: type_.to_string(),
-			url: url.to_string(),
+			url: SecretValue::Plain(SecretString::new(url.to_string())),
 			weight,
 		});
 		self
@@ -169,7 +169,10 @@ mod tests {
 
 		// Check default RPC URL
 		assert_eq!(network.rpc_urls.len(), 1);
-		assert_eq!(network.rpc_urls[0].url, "https://test.network");
+		assert_eq!(
+			network.rpc_urls[0].url.as_ref().to_string(),
+			"https://test.network".to_string()
+		);
 		assert_eq!(network.rpc_urls[0].type_, "rpc");
 		assert_eq!(network.rpc_urls[0].weight, 100);
 	}
@@ -204,10 +207,16 @@ mod tests {
 			.build();
 
 		assert_eq!(network.rpc_urls.len(), 2);
-		assert_eq!(network.rpc_urls[0].url, "https://rpc1.example.com");
+		assert_eq!(
+			network.rpc_urls[0].url.as_ref().to_string(),
+			"https://rpc1.example.com".to_string()
+		);
 		assert_eq!(network.rpc_urls[0].type_, "http");
 		assert_eq!(network.rpc_urls[0].weight, 50);
-		assert_eq!(network.rpc_urls[1].url, "https://rpc2.example.com");
+		assert_eq!(
+			network.rpc_urls[1].url.as_ref().to_string(),
+			"https://rpc2.example.com".to_string()
+		);
 		assert_eq!(network.rpc_urls[1].type_, "ws");
 		assert_eq!(network.rpc_urls[1].weight, 50);
 	}
@@ -219,8 +228,14 @@ mod tests {
 			.build();
 
 		assert_eq!(network.rpc_urls.len(), 2);
-		assert_eq!(network.rpc_urls[0].url, "https://rpc1.com");
-		assert_eq!(network.rpc_urls[1].url, "https://rpc2.com");
+		assert_eq!(
+			network.rpc_urls[0].url.as_ref().to_string(),
+			"https://rpc1.com".to_string()
+		);
+		assert_eq!(
+			network.rpc_urls[1].url.as_ref().to_string(),
+			"https://rpc2.com".to_string()
+		);
 		// Check defaults are applied
 		assert!(network.rpc_urls.iter().all(|url| url.type_ == "rpc"));
 		assert!(network.rpc_urls.iter().all(|url| url.weight == 100));

--- a/src/utils/tests/builders/network.rs
+++ b/src/utils/tests/builders/network.rs
@@ -106,6 +106,15 @@ impl NetworkBuilder {
 		self
 	}
 
+	pub fn add_secret_rpc_url(mut self, url: SecretValue, type_: &str, weight: u32) -> Self {
+		self.rpc_urls.push(RpcUrl {
+			type_: type_.to_string(),
+			url,
+			weight,
+		});
+		self
+	}
+
 	pub fn clear_rpc_urls(mut self) -> Self {
 		self.rpc_urls.clear();
 		self
@@ -219,6 +228,24 @@ mod tests {
 		);
 		assert_eq!(network.rpc_urls[1].type_, "ws");
 		assert_eq!(network.rpc_urls[1].weight, 50);
+	}
+
+	#[test]
+	fn test_secret_rpc_url() {
+		let network = NetworkBuilder::new()
+			.add_secret_rpc_url(
+				SecretValue::Plain(SecretString::new("https://rpc1.example.com".to_string())),
+				"rpc",
+				50,
+			)
+			.build();
+
+		assert_eq!(network.rpc_urls.len(), 2);
+		assert_eq!(
+			network.rpc_urls[1].url.as_ref().to_string(),
+			"https://rpc1.example.com".to_string()
+		);
+		assert_eq!(network.rpc_urls[1].type_, "rpc");
 	}
 
 	#[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -55,4 +55,8 @@ mod integration {
 	mod monitor {
 		mod execution;
 	}
+
+	mod security {
+		mod secret;
+	}
 }

--- a/tests/integration/bootstrap/main.rs
+++ b/tests/integration/bootstrap/main.rs
@@ -13,8 +13,8 @@ use openzeppelin_monitor::{
 	bootstrap::{create_block_handler, create_trigger_handler, initialize_services, process_block},
 	models::{
 		BlockChainType, EVMMonitorMatch, EVMTransactionReceipt, MatchConditions, Monitor,
-		MonitorMatch, ProcessedBlock, ScriptLanguage, StellarBlock, StellarMonitorMatch,
-		TransactionType, Trigger, TriggerConditions,
+		MonitorMatch, ProcessedBlock, ScriptLanguage, SecretString, SecretValue, StellarBlock,
+		StellarMonitorMatch, TransactionType, Trigger, TriggerConditions,
 	},
 	services::{
 		filter::FilterService,
@@ -819,7 +819,7 @@ async fn test_trigger_execution_service_execute_multiple_triggers_failed() {
 			.webhook(
 				"https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX", //noboost
 			)
-			.webhook_secret("secret")
+			.webhook_secret(SecretValue::Plain(SecretString::new("secret".to_string())))
 			.webhook_method("POST")
 			.message("Test Title", "Test Body")
 			.build(),
@@ -905,7 +905,7 @@ async fn test_trigger_execution_service_execute_multiple_triggers_success() {
 			.name("example_trigger_webhook")
 			.webhook(&webhook_server.url())
 			.webhook_headers(HashMap::new())
-			.webhook_secret("secret")
+			.webhook_secret(SecretValue::Plain(SecretString::new("secret".to_string())))
 			.webhook_method("POST")
 			.message("Test Title", "Test Body")
 			.build(),
@@ -978,7 +978,7 @@ async fn test_trigger_execution_service_execute_multiple_triggers_partial_succes
 			.name("example_trigger_webhook")
 			.webhook(&webhook_server.url())
 			.webhook_headers(HashMap::new())
-			.webhook_secret("secret")
+			.webhook_secret(SecretValue::Plain(SecretString::new("secret".to_string())))
 			.webhook_method("POST")
 			.message("Test Title", "Test Body")
 			.build(),

--- a/tests/integration/bootstrap/main.rs
+++ b/tests/integration/bootstrap/main.rs
@@ -125,6 +125,7 @@ async fn test_initialize_services() {
 		Some(mock_network_service),
 		Some(mock_trigger_service),
 	)
+	.await
 	.expect("Failed to initialize services");
 
 	assert!(
@@ -193,7 +194,8 @@ async fn test_create_trigger_handler() {
 
 	// Setup test triggers in JSON with known configurations
 	let trigger_execution_service =
-		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json");
+		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json")
+			.await;
 
 	let (shutdown_tx, _) = watch::channel(false);
 	let trigger_handler = create_trigger_handler(
@@ -220,7 +222,8 @@ async fn test_create_trigger_handler() {
 async fn test_create_trigger_handler_empty_matches() {
 	// Setup test triggers in JSON with known configurations
 	let trigger_execution_service =
-		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json");
+		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json")
+			.await;
 
 	let (shutdown_tx, _) = watch::channel(false);
 	let trigger_handler = create_trigger_handler(
@@ -389,7 +392,8 @@ async fn test_create_trigger_handler_with_conditions() {
 
 	// Setup test triggers in JSON with known configurations
 	let trigger_execution_service =
-		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json");
+		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json")
+			.await;
 
 	// Create a HashMap with trigger conditions
 	let mut trigger_scripts = HashMap::new();

--- a/tests/integration/filters/common.rs
+++ b/tests/integration/filters/common.rs
@@ -72,7 +72,7 @@ pub fn read_and_parse_json<T: serde::de::DeserializeOwned>(path: &str) -> T {
 	serde_json::from_str(&content).unwrap_or_else(|_| panic!("Failed to parse JSON from: {}", path))
 }
 
-pub fn setup_trigger_execution_service(
+pub async fn setup_trigger_execution_service(
 	trigger_json: &str,
 ) -> MockTriggerExecutionService<MockTriggerRepository> {
 	let trigger_map: HashMap<String, Trigger> = read_and_parse_json(trigger_json);
@@ -89,7 +89,7 @@ pub fn setup_trigger_execution_service(
 		.withf(|_| true)
 		.returning(|_| Ok(MockTriggerRepository::default()));
 
-	let mut mock_trigger_repository = MockTriggerRepository::new(None).unwrap();
+	let mut mock_trigger_repository = MockTriggerRepository::new(None).await.unwrap();
 
 	mock_trigger_repository
 		.expect_get()

--- a/tests/integration/filters/evm/filter.rs
+++ b/tests/integration/filters/evm/filter.rs
@@ -497,7 +497,8 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 	let trigger_scripts = HashMap::new();
 
 	let mut trigger_execution_service =
-		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json");
+		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json")
+			.await;
 
 	// Set up expectations for execute()
 	trigger_execution_service.expect_execute()
@@ -593,7 +594,8 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 			let trigger_scripts = HashMap::new();
 			let mut trigger_execution_service = setup_trigger_execution_service(
 				"tests/integration/fixtures/evm/triggers/trigger.json",
-			);
+			)
+			.await;
 
 			// Set up expectations for execute()
 			trigger_execution_service

--- a/tests/integration/filters/stellar/filter.rs
+++ b/tests/integration/filters/stellar/filter.rs
@@ -679,7 +679,8 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 		.returning(move |_, _| Ok(events.clone()));
 
 	let mut trigger_execution_service =
-		setup_trigger_execution_service("tests/integration/fixtures/stellar/triggers/trigger.json");
+		setup_trigger_execution_service("tests/integration/fixtures/stellar/triggers/trigger.json")
+			.await;
 
 	trigger_execution_service
 		.expect_execute()
@@ -813,7 +814,8 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 			let trigger_scripts = HashMap::new();
 			let mut trigger_execution_service = setup_trigger_execution_service(
 				"tests/integration/fixtures/stellar/triggers/trigger.json",
-			);
+			)
+			.await;
 
 			// Set up expectations for execute()
 			trigger_execution_service

--- a/tests/integration/fixtures/evm/networks/network.json
+++ b/tests/integration/fixtures/evm/networks/network.json
@@ -4,13 +4,19 @@
   "name": "Ethereum Mainnet",
   "rpc_urls": [
     {
-      "url": "https://eth.drpc.org",
+      "url": {
+        "type": "Plain",
+        "value": "https://eth.drpc.org"
+      },
       "type_": "rpc",
       "weight": 100
     },
     {
       "type_": "rpc",
-      "url": "https://ethereum-rpc.publicnode.com",
+      "url": {
+        "type": "Plain",
+        "value": "https://ethereum-rpc.publicnode.com"
+      },
       "weight": 90
     }
   ],

--- a/tests/integration/fixtures/evm/triggers/trigger.json
+++ b/tests/integration/fixtures/evm/triggers/trigger.json
@@ -3,7 +3,10 @@
     "name": "Example Trigger Slack Notification",
     "trigger_type": "slack",
     "config": {
-      "slack_url": "https://hooks.slack.com/services/AAA/BBB/CCC",
+      "slack_url": {
+        "type": "Plain",
+        "value": "https://hooks.slack.com/services/AAA/BBB/CCC"
+      },
       "message": {
         "title": "example_trigger_slack triggered",
         "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
@@ -14,9 +17,15 @@
     "name": "Example Trigger Webhook Notification",
     "trigger_type": "webhook",
     "config": {
-      "url": "https://webhook.site/123",
+      "url": {
+        "type": "Plain",
+        "value": "https://webhook.site/123"
+      },
       "method": "POST",
-      "secret": "some-secret",
+      "secret": {
+        "type": "Plain",
+        "value": "some-secret"
+      },
       "headers": {
         "Content-Type": "application/json"
       },
@@ -30,7 +39,10 @@
     "name": "Example Trigger Discord Notification",
     "trigger_type": "discord",
     "config": {
-      "discord_url": "https://discord.com/api/webhooks/123/123",
+      "discord_url": {
+        "type": "Plain",
+        "value": "https://discord.com/api/webhooks/123/123"
+      },
       "message": {
         "title": "example_trigger_discord triggered",
         "body": "${monitor_name} triggered because someone called the ${function_0_signature} function with value ${function_0_value} | https://etherscan.io/tx/${transaction_hash}"
@@ -41,7 +53,10 @@
     "name": "Example Trigger Telegram Notification",
     "trigger_type": "telegram",
     "config": {
-      "token": "123",
+      "token": {
+        "type": "Plain",
+        "value": "123"
+      },
       "chat_id": "123",
       "disable_web_preview": true,
       "message": {

--- a/tests/integration/fixtures/evm/triggers/trigger.json
+++ b/tests/integration/fixtures/evm/triggers/trigger.json
@@ -4,7 +4,7 @@
     "trigger_type": "slack",
     "config": {
       "slack_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://hooks.slack.com/services/AAA/BBB/CCC"
       },
       "message": {
@@ -18,12 +18,12 @@
     "trigger_type": "webhook",
     "config": {
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://webhook.site/123"
       },
       "method": "POST",
       "secret": {
-        "type": "Plain",
+        "type": "plain",
         "value": "some-secret"
       },
       "headers": {
@@ -40,7 +40,7 @@
     "trigger_type": "discord",
     "config": {
       "discord_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://discord.com/api/webhooks/123/123"
       },
       "message": {
@@ -54,7 +54,7 @@
     "trigger_type": "telegram",
     "config": {
       "token": {
-        "type": "Plain",
+        "type": "plain",
         "value": "123"
       },
       "chat_id": "123",

--- a/tests/integration/fixtures/stellar/networks/network.json
+++ b/tests/integration/fixtures/stellar/networks/network.json
@@ -5,7 +5,10 @@
   "rpc_urls": [
     {
       "type_": "rpc",
-      "url": "https://soroban-testnet.stellar.org",
+      "url": {
+        "type": "Plain",
+        "value": "https://soroban-testnet.stellar.org"
+      },
       "weight": 100
     }
   ],

--- a/tests/integration/fixtures/stellar/networks/network.json
+++ b/tests/integration/fixtures/stellar/networks/network.json
@@ -6,7 +6,7 @@
     {
       "type_": "rpc",
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://soroban-testnet.stellar.org"
       },
       "weight": 100

--- a/tests/integration/fixtures/stellar/triggers/trigger.json
+++ b/tests/integration/fixtures/stellar/triggers/trigger.json
@@ -3,7 +3,10 @@
     "name": "Example Trigger Slack Notification",
     "trigger_type": "slack",
     "config": {
-      "slack_url": "https://hooks.slack.com/services/AAA/BBB/CCC",
+      "slack_url": {
+        "type": "Plain",
+        "value": "https://hooks.slack.com/services/AAA/BBB/CCC"
+      },
       "message": {
         "title": "example_trigger_slack triggered",
         "body": "${monitor_name} triggered because of a large transfer of ${function_0_2} USDC to ${function_0_1} | https://stellar.expert/explorer/testnet/tx/${transaction_hash}"
@@ -14,9 +17,15 @@
     "name": "Example Trigger Webhook Notification",
     "trigger_type": "webhook",
     "config": {
-      "url": "https://webhook.site/123",
+      "url": {
+        "type": "Plain",
+        "value": "https://webhook.site/123"
+      },
       "method": "POST",
-      "secret": "some-secret",
+      "secret": {
+        "type": "Plain",
+        "value": "some-secret"
+      },
       "headers": {
         "Content-Type": "application/json"
       },
@@ -30,7 +39,10 @@
     "name": "Example Trigger Discord Notification",
     "trigger_type": "discord",
     "config": {
-      "discord_url": "https://discord.com/api/webhooks/123/123",
+      "discord_url": {
+        "type": "Plain",
+        "value": "https://discord.com/api/webhooks/123/123"
+      },
       "message": {
         "title": "example_trigger_discord triggered",
         "body": "${monitor_name} triggered because someone called the ${function_0_signature} function with value ${function_0_0} | https://stellar.expert/explorer/testnet/tx/${transaction_hash}"
@@ -41,7 +53,10 @@
     "name": "Example Trigger Telegram Notification",
     "trigger_type": "telegram",
     "config": {
-      "token": "123",
+      "token": {
+        "type": "Plain",
+        "value": "123"
+      },
       "chat_id": "123",
       "disable_web_preview": true,
       "message": {

--- a/tests/integration/fixtures/stellar/triggers/trigger.json
+++ b/tests/integration/fixtures/stellar/triggers/trigger.json
@@ -4,7 +4,7 @@
     "trigger_type": "slack",
     "config": {
       "slack_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://hooks.slack.com/services/AAA/BBB/CCC"
       },
       "message": {
@@ -18,12 +18,12 @@
     "trigger_type": "webhook",
     "config": {
       "url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://webhook.site/123"
       },
       "method": "POST",
       "secret": {
-        "type": "Plain",
+        "type": "plain",
         "value": "some-secret"
       },
       "headers": {
@@ -40,7 +40,7 @@
     "trigger_type": "discord",
     "config": {
       "discord_url": {
-        "type": "Plain",
+        "type": "plain",
         "value": "https://discord.com/api/webhooks/123/123"
       },
       "message": {
@@ -54,7 +54,7 @@
     "trigger_type": "telegram",
     "config": {
       "token": {
-        "type": "Plain",
+        "type": "plain",
         "value": "123"
       },
       "chat_id": "123",

--- a/tests/integration/monitor/execution.rs
+++ b/tests/integration/monitor/execution.rs
@@ -658,8 +658,8 @@ async fn test_execute_monitor_stellar_get_latest_block_number_failed() {
 	assert!(result.is_err());
 }
 
-#[test]
-fn test_load_from_path() {
+#[tokio::test]
+async fn test_load_from_path() {
 	// Setup temporary directory and files
 	let temp_dir = TempDir::new().unwrap();
 	let monitor_path = create_test_monitor_file(
@@ -684,7 +684,9 @@ fn test_load_from_path() {
 	let monitor_service = setup_monitor_service(mocked_monitors);
 
 	// Test loading from path
-	let result = monitor_service.load_from_path(Some(&monitor_path), None, None);
+	let result = monitor_service
+		.load_from_path(Some(&monitor_path), None, None)
+		.await;
 
 	assert!(result.is_ok());
 	let monitor = result.unwrap();
@@ -693,8 +695,8 @@ fn test_load_from_path() {
 	assert!(monitor.triggers.contains(&"test-trigger".to_string()));
 }
 
-#[test]
-fn test_load_from_path_with_services() {
+#[tokio::test]
+async fn test_load_from_path_with_services() {
 	// Setup temporary directory and files
 	let temp_dir = TempDir::new().unwrap();
 	let monitor_path = create_test_monitor_file(
@@ -724,11 +726,13 @@ fn test_load_from_path_with_services() {
 
 	let mock_monitor_service = setup_monitor_service(mocked_monitors);
 
-	let result = mock_monitor_service.load_from_path(
-		Some(&monitor_path),
-		Some(mock_network_service),
-		Some(mock_trigger_service),
-	);
+	let result = mock_monitor_service
+		.load_from_path(
+			Some(&monitor_path),
+			Some(mock_network_service),
+			Some(mock_trigger_service),
+		)
+		.await;
 
 	assert!(result.is_ok());
 	let monitor = result.unwrap();
@@ -737,8 +741,8 @@ fn test_load_from_path_with_services() {
 	assert!(monitor.triggers.contains(&"test-trigger".to_string()));
 }
 
-#[test]
-fn test_load_from_path_trait_implementation() {
+#[tokio::test]
+async fn test_load_from_path_trait_implementation() {
 	// Setup temporary directory and files
 	let temp_dir = TempDir::new().unwrap();
 	let monitor_path = create_test_monitor_file(
@@ -779,7 +783,8 @@ fn test_load_from_path_trait_implementation() {
 			Some(&monitor_path),
 			Some(mock_network_service),
 			Some(mock_trigger_service),
-		);
+		)
+		.await;
 
 	assert!(result.is_ok());
 	let monitor = result.unwrap();
@@ -788,8 +793,8 @@ fn test_load_from_path_trait_implementation() {
 	assert!(monitor.triggers.contains(&"test-trigger".to_string()));
 }
 
-#[test]
-fn test_load_from_path_trait_implementation_error() {
+#[tokio::test]
+async fn test_load_from_path_trait_implementation_error() {
 	// Setup temporary directory and files
 	let mock_network_service =
 		setup_mocked_network_service("Ethereum", "ethereum_mainnet", BlockChainType::EVM);
@@ -822,7 +827,8 @@ fn test_load_from_path_trait_implementation_error() {
 			None,
 			Some(mock_network_service),
 			Some(mock_trigger_service),
-		);
+		)
+		.await;
 
 	assert!(result.is_err());
 	assert!(result
@@ -833,9 +839,9 @@ fn test_load_from_path_trait_implementation_error() {
 
 // This test is ignored because it creates files in the config directory
 // and we don't want to pollute the default config directory
-#[test]
+#[tokio::test]
 #[cfg_attr(not(feature = "test-ci-only"), ignore)]
-fn test_load_from_path_with_mixed_services() {
+async fn test_load_from_path_with_mixed_services() {
 	// Create default config paths for when we use None for path
 	let config_path = PathBuf::from("config");
 	let network_path = config_path.join("networks");
@@ -848,11 +854,15 @@ fn test_load_from_path_with_mixed_services() {
 	std::fs::create_dir_all(&monitor_path).unwrap();
 
 	let network_path = create_test_network_file(&network_path, "integration_test_ethereum_mainnet");
-	let network_repo = NetworkRepository::new(Some(network_path.parent().unwrap())).unwrap();
+	let network_repo = NetworkRepository::new(Some(network_path.parent().unwrap()))
+		.await
+		.unwrap();
 	let network_service = NetworkService::new_with_repository(network_repo).unwrap();
 
 	let trigger_path = create_test_trigger_file(&trigger_path, "integration_test_trigger");
-	let trigger_repo = TriggerRepository::new(Some(trigger_path.parent().unwrap())).unwrap();
+	let trigger_repo = TriggerRepository::new(Some(trigger_path.parent().unwrap()))
+		.await
+		.unwrap();
 	let trigger_service = TriggerService::new_with_repository(trigger_repo).unwrap();
 
 	let repository = MonitorRepository::<NetworkRepository, TriggerRepository>::new_with_monitors(
@@ -866,24 +876,30 @@ fn test_load_from_path_with_mixed_services() {
 		vec![],
 		vec!["integration_test_ethereum_mainnet"],
 	);
-	let result = repository.load_from_path(Some(&monitor_path), None, None);
+	let result = repository
+		.load_from_path(Some(&monitor_path), None, None)
+		.await;
 	assert!(result.is_ok());
 
 	// Test 2: Empty monitor content
 	let monitor_temp_dir = TempDir::new().unwrap();
-	let result = repository.load_from_path(Some(monitor_temp_dir.path()), None, None);
+	let result = repository
+		.load_from_path(Some(monitor_temp_dir.path()), None, None)
+		.await;
 	assert!(result.is_err());
 	let err = result.unwrap_err();
 	assert!(matches!(err, RepositoryError::LoadError(_)));
 	assert!(err.to_string().contains("Failed to load monitors"));
 
 	// Test 3: Mixed service configuration
-	let result =
-		repository.load_from_path(Some(&monitor_path), Some(network_service.clone()), None);
+	let result = repository
+		.load_from_path(Some(&monitor_path), Some(network_service.clone()), None)
+		.await;
 	assert!(result.is_ok());
 
-	let result =
-		repository.load_from_path(Some(&monitor_path), None, Some(trigger_service.clone()));
+	let result = repository
+		.load_from_path(Some(&monitor_path), None, Some(trigger_service.clone()))
+		.await;
 	assert!(result.is_ok());
 
 	// Test 4: Invalid monitor references
@@ -893,7 +909,9 @@ fn test_load_from_path_with_mixed_services() {
 		vec!["invalid-trigger"],
 		vec!["integration_test_ethereum_mainnet"],
 	);
-	let result = repository.load_from_path(Some(&invalid_monitor_path), None, None);
+	let result = repository
+		.load_from_path(Some(&invalid_monitor_path), None, None)
+		.await;
 	assert!(result.is_err());
 	let err = result.unwrap_err();
 	assert!(err.to_string().contains("references non-existent"));

--- a/tests/integration/security/secret.rs
+++ b/tests/integration/security/secret.rs
@@ -1,0 +1,111 @@
+use once_cell::sync::Lazy;
+use std::sync::Mutex;
+use std::{env, fs};
+use tempfile::TempDir;
+use zeroize::Zeroize;
+
+use openzeppelin_monitor::models::{BlockChainType, SecretString, SecretValue};
+use openzeppelin_monitor::repositories::{NetworkRepository, NetworkRepositoryTrait};
+use openzeppelin_monitor::utils::tests::builders::network::NetworkBuilder;
+
+// Lock to prevent concurrent test execution
+static TEST_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn test_secret_resolution_from_network_config() {
+	let _lock = TEST_LOCK.lock().unwrap();
+
+	// Create a temporary directory for our test
+	let temp_dir = TempDir::new().unwrap();
+	let config_path = temp_dir.path().join("network.json");
+
+	// Set up test environment variables
+	const RPC_URL_ENV: &str = "TEST_RPC_URL";
+	const RPC_URL_VALUE: &str = "https://test-rpc.example.com";
+	env::set_var(RPC_URL_ENV, RPC_URL_VALUE);
+
+	// Create test network configuration using NetworkBuilder
+	let network = NetworkBuilder::new()
+		.name("Ethereum Testnet")
+		.slug("ethereum_testnet")
+		.network_type(BlockChainType::EVM)
+		.chain_id(1)
+		.block_time_ms(12000)
+		.confirmation_blocks(12)
+		.cron_schedule("0 */1 * * * *")
+		.max_past_blocks(50)
+		.store_blocks(true)
+		.clear_rpc_urls()
+		.add_rpc_url("https://eth.drpc.org", "rpc", 100)
+		.add_secret_rpc_url(SecretValue::Environment(RPC_URL_ENV.to_string()), "rpc", 90)
+		.build();
+
+	// Write config to file
+	let config_json = serde_json::to_string_pretty(&network).unwrap();
+	fs::write(&config_path, config_json).unwrap();
+
+	// Create a repository instance using `load_all` to call `load_from_path` which resolves secrets
+	let repository = NetworkRepository::load_all(Some(temp_dir.path()))
+		.await
+		.unwrap();
+
+	let loaded_network = repository.get("network").unwrap();
+
+	// Test plain RPC URL resolution
+	let plain_rpc = loaded_network.rpc_urls[0].url.resolve().await.unwrap();
+	assert_eq!(plain_rpc.as_str(), "https://eth.drpc.org");
+
+	// Test environment variable RPC URL resolution
+	let env_rpc = loaded_network.rpc_urls[1].url.resolve().await.unwrap();
+	assert_eq!(env_rpc.as_str(), RPC_URL_VALUE);
+
+	// Clean up
+	env::remove_var(RPC_URL_ENV);
+}
+
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn test_secret_zeroization() {
+	let _lock = TEST_LOCK.lock().unwrap();
+
+	// Create a secret value
+	let mut secret = SecretValue::Plain(SecretString::new("sensitive_data".to_string()));
+
+	// Verify the secret is accessible
+	let resolved = secret.resolve().await.unwrap();
+	assert_eq!(resolved.as_str(), "sensitive_data");
+
+	// Zeroize the secret
+	secret.zeroize();
+
+	// Verify the secret is cleared
+	if let SecretValue::Plain(ref secret_string) = secret {
+		assert_eq!(secret_string.as_str(), "");
+	}
+}
+
+#[tokio::test]
+async fn test_secret_serialization_deserialization() {
+	let _lock = TEST_LOCK.lock().unwrap();
+
+	// Create test secrets
+	let plain_secret = SecretValue::Plain(SecretString::new("test_plain".to_string()));
+	let env_secret = SecretValue::Environment("TEST_ENV_VAR".to_string());
+	let vault_secret = SecretValue::HashicorpCloudVault("test-vault-secret".to_string());
+
+	// Serialize to JSON
+	let plain_json = serde_json::to_string(&plain_secret).unwrap();
+	let env_json = serde_json::to_string(&env_secret).unwrap();
+	let vault_json = serde_json::to_string(&vault_secret).unwrap();
+
+	// Deserialize back
+	let deserialized_plain: SecretValue = serde_json::from_str(&plain_json).unwrap();
+	let deserialized_env: SecretValue = serde_json::from_str(&env_json).unwrap();
+	let deserialized_vault: SecretValue = serde_json::from_str(&vault_json).unwrap();
+
+	// Verify the deserialized values match
+	assert_eq!(deserialized_plain, plain_secret);
+	assert_eq!(deserialized_env, env_secret);
+	assert_eq!(deserialized_vault, vault_secret);
+}

--- a/tests/properties/repositories/network.rs
+++ b/tests/properties/repositories/network.rs
@@ -1,7 +1,7 @@
 use crate::properties::strategies::network_strategy;
 
 use openzeppelin_monitor::{
-	models::ConfigLoader,
+	models::{ConfigLoader, SecretString, SecretValue},
 	repositories::{NetworkRepository, NetworkRepositoryTrait},
 };
 use proptest::{prelude::*, test_runner::Config};
@@ -93,7 +93,7 @@ proptest! {
 			prop_assert!(invalid_network.validate().is_err());
 
 			invalid_network = network.clone();
-			invalid_network.rpc_urls[0].url = "invalid-url".to_string(); // Invalid RPC URL
+			invalid_network.rpc_urls[0].url = SecretValue::Plain(SecretString::new("invalid-url".to_string())); // Invalid RPC URL
 			prop_assert!(invalid_network.validate().is_err());
 
 			invalid_network = network.clone();

--- a/tests/properties/repositories/trigger.rs
+++ b/tests/properties/repositories/trigger.rs
@@ -1,7 +1,10 @@
 use crate::properties::strategies::trigger_strategy;
 
 use openzeppelin_monitor::{
-	models::{ConfigLoader, NotificationMessage, TriggerType, TriggerTypeConfig},
+	models::{
+		ConfigLoader, NotificationMessage, SecretString, SecretValue, TriggerType,
+		TriggerTypeConfig,
+	},
 	repositories::{TriggerRepository, TriggerRepositoryTrait},
 };
 use proptest::{prelude::*, test_runner::Config};
@@ -93,7 +96,7 @@ proptest! {
 					if let TriggerTypeConfig::Slack { slack_url: _, message: _ } = &trigger.config {
 						invalid_trigger = trigger.clone();
 						if let TriggerTypeConfig::Slack { slack_url, .. } = &mut invalid_trigger.config {
-							*slack_url = "not-a-url".to_string(); // Invalid URL format
+							*slack_url = SecretValue::Plain(SecretString::new("not-a-url".to_string())); // Invalid URL format
 						}
 						prop_assert!(invalid_trigger.validate().is_err());
 
@@ -158,7 +161,7 @@ proptest! {
 						// Test invalid URL
 						invalid_trigger = trigger.clone();
 						if let TriggerTypeConfig::Webhook { url: u, .. } = &mut invalid_trigger.config {
-							*u = "not-a-url".to_string();
+							*u = SecretValue::Plain(SecretString::new("not-a-url".to_string()));
 						}
 						prop_assert!(invalid_trigger.validate().is_err());
 
@@ -188,7 +191,7 @@ proptest! {
 						// Test invalid URL
 						invalid_trigger = trigger.clone();
 						if let TriggerTypeConfig::Discord { discord_url: u, .. } = &mut invalid_trigger.config {
-							*u = "not-a-url".to_string();
+							*u = SecretValue::Plain(SecretString::new("not-a-url".to_string()));
 						}
 						prop_assert!(invalid_trigger.validate().is_err());
 
@@ -218,7 +221,7 @@ proptest! {
 						// Test invalid token
 						invalid_trigger = trigger.clone();
 						if let TriggerTypeConfig::Telegram { token: t, .. } = &mut invalid_trigger.config {
-							*t = "INVALID_TOKEN".to_string();
+							*t = SecretValue::Plain(SecretString::new("INVALID_TOKEN".to_string()));
 						}
 						prop_assert!(invalid_trigger.validate().is_err());
 


### PR DESCRIPTION
# Summary

https://linear.app/openzeppelin-development/issue/PLAT-6494/add-vault-kms-support-for-viewing-keys

**This is a breaking change**: It requires reformatting URLs, token, secret variables in config files.

The `SecretValue` type provides secure handling of sensitive data in configuration files, with the following features:

- Secure memory management with automatic zeroization of sensitive data when no longer needed
- Multiple secret source types:
  * Plain text secrets (wrapped in `SecretString` for secure memory handling)
  * Environment variable references
  * Hashicorp Cloud Vault references
- Type-safe secret resolution with proper error handling
- Serde support for JSON configuration files
- Automatic validation of secret resolution during configuration loading

The type is used throughout the codebase for various sensitive fields:
- RPC URLs in network configurations
- Slack webhook URLs
- SMTP credentials for email notifications
- Webhook URLs and secrets
- Telegram bot tokens
- Discord webhook URLs

When loading configurations, the system automatically resolves all secrets to their actual values while maintaining security best practices. This includes:
- Zeroizing sensitive data from memory when no longer needed
- Proper error handling for missing environment variables or vault access failures

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
