### PR TITLE
fix: Monitor match template var signature collission (breaking)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.7",
+ "winnow 0.7.8",
 ]
 
 [[package]]
@@ -581,7 +581,7 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "indexmap 2.9.0",
  "itoa",
  "k256",
@@ -921,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.7",
+ "winnow 0.7.8",
 ]
 
 [[package]]
@@ -1777,9 +1777,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.20"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -2929,9 +2929,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -3454,7 +3454,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -3795,7 +3795,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -4121,9 +4121,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.108"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "e145e1651e858e820e4860f7b9c5e169bc1d8ce1c86043be79fa7b7634821847"
 dependencies = [
  "cc",
  "libc",
@@ -5115,9 +5115,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -5569,9 +5569,9 @@ dependencies = [
 
 [[package]]
 name = "shared_child"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
+checksum = "7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -6005,7 +6005,7 @@ dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -6336,7 +6336,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.7",
+ "winnow 0.7.8",
 ]
 
 [[package]]
@@ -7098,9 +7098,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
 dependencies = [
  "memchr",
 ]
@@ -7161,7 +7161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
 dependencies = [
  "libc",
- "rustix 1.0.5",
+ "rustix 1.0.7",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,7 +430,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.8",
+ "winnow 0.7.9",
 ]
 
 [[package]]
@@ -921,7 +921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
 dependencies = [
  "serde",
- "winnow 0.7.8",
+ "winnow 0.7.9",
 ]
 
 [[package]]
@@ -6336,7 +6336,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "winnow 0.7.8",
+ "winnow 0.7.9",
 ]
 
 [[package]]
@@ -7098,9 +7098,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
+checksum = "d9fb597c990f03753e08d3c29efbfcf2019a003b4bf4ba19225c158e1549f0f3"
 dependencies = [
  "memchr",
 ]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -567,7 +567,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
       "slack_url": "https://hooks.slack.com/services/A/B/C",
       "message": {
         "title": "large_transfer_slack triggered",
-        "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+        "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
   },
@@ -578,7 +578,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
       "slack_url": "https://hooks.slack.com/services/A/B/C",
       "message": {
         "title": "large_transfer_usdc_slack triggered",
-        "body": "${monitor_name} triggered because of a large transfer of ${function_0_2} USDC to ${function_0_1} | https://stellar.expert/explorer/testnet/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because of a large transfer of ${functions.0.args.2} USDC to ${functions.0.args.1} | https://stellar.expert/explorer/testnet/tx/${transaction.hash}"
       }
     }
   }
@@ -594,7 +594,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
   "slack_url": "https://hooks.slack.com/...",
   "message": {
     "title": "Alert Title",
-    "body": "Alert message for ${transaction_hash}"
+    "body": "Alert message for ${transaction.hash}"
   }
 }
 ----
@@ -635,7 +635,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
   "password": "smtp_password",
   "message": {
     "title": "Alert Subject",
-    "body": "Alert message for ${transaction_hash}",
+    "body": "Alert message for ${transaction.hash}",
   },
   "sender": "sender@example.com",
   "recipients": ["recipient@example.com"]
@@ -700,7 +700,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
   },
   "message": {
     "title": "Alert Title",
-    "body": "Alert message for ${transaction_hash}"
+    "body": "Alert message for ${transaction.hash}"
   }
 }
 ----
@@ -750,7 +750,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
   "discord_url": "https://discord.com/api/webhooks/123-456-789",
   "message": {
     "title": "Alert Title",
-    "body": "Alert message for ${transaction_hash}"
+    "body": "Alert message for ${transaction.hash}"
   }
 }
 ----
@@ -789,7 +789,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
   "chat_id": "9876543210",
   "message": {
     "title": "Alert Title",
-    "body": "Alert message for ${transaction_hash}"
+    "body": "Alert message for ${transaction.hash}"
   }
 }
 ----
@@ -880,21 +880,23 @@ For more information about custom scripts, see xref:scripts.adoc[Custom Scripts 
 
 ==== Available Template Variables
 
+The monitor uses a structured JSON format with nested objects for template variables. The data is flattened into dot notation for template use.
+
 ===== Common Variables
 [cols="1,2"]
 |===
 |Variable |Description
 
-|monitor_name
+|monitor.name
 |Name of the triggered monitor
 
-|transaction_hash
+|transaction.hash
 |Hash of the transaction
 
-|function_[index]_signature
+|functions.[index].signature
 |Function signature
 
-|event_[index]_signature
+|events.[index].signature
 |Event signature
 |===
 
@@ -905,19 +907,19 @@ For more information about custom scripts, see xref:scripts.adoc[Custom Scripts 
 |===
 |Variable |Description
 
-|transaction_from
+|transaction.from
 |Sender address
 
-|transaction_to
+|transaction.to
 |Recipient address
 
-|transaction_value
+|transaction.value
 |Transaction value
 
-|event_[index]_[param]
+|events.[index].args.[param]
 |Event parameters by name
 
-|function_[index]_[param]
+|functions.[index].args.[param]
 |Function parameters by name
 |===
 
@@ -926,16 +928,16 @@ For more information about custom scripts, see xref:scripts.adoc[Custom Scripts 
 |===
 |Variable |Description
 
-|event_[index]_[position]
+|events.[index].args.[position]
 |Event parameters by position
 
-|function_[index]_[position]
+|functions.[index].args.[position]
 |Function parameters by position
 |===
 
 [NOTE]
 ====
-Transaction-related variables (`transaction_from`, `transaction_to`, `transaction_value`) are not available for Stellar networks.
+Transaction-related variables (`transaction.from`, `transaction.to`, `transaction.value`) are not available for Stellar networks.
 ====
 
 ==== Important Considerations:

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -283,7 +283,7 @@ Update the webhook URL in the link:https://github.com/OpenZeppelin/openzeppelin-
             "slack_url": "https://hooks.slack.com/services/A/B/C",
             "message": {
                 "title": "large_transfer_slack triggered",
-                "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+                "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
             }
         }
     }
@@ -312,7 +312,7 @@ Update the SMTP settings in the link:https://github.com/OpenZeppelin/openzeppeli
             "password": "your_password",
             "message": {
                 "title": "large_transfer_usdc_email triggered",
-                "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+                "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
             },
             "sender": "your_email@gmail.com",
             "recipients": [
@@ -468,7 +468,7 @@ Update the webhook URL in the link:https://github.com/OpenZeppelin/openzeppelin-
       "slack_url": "https://hooks.slack.com/services/A/B/C",
       "message": {
         "title": "large_swap_by_dex_slack triggered",
-        "body": "${monitor_name} triggered because of a large swap of ${function_0_4} tokens | https://stellar.expert/explorer/public/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because of a large swap of ${functions.0.args.4} tokens | https://stellar.expert/explorer/public/tx/${transaction.hash}"
       }
     }
   }

--- a/examples/config/triggers/discord_notifications.json
+++ b/examples/config/triggers/discord_notifications.json
@@ -6,7 +6,7 @@
       "discord_url": "https://discord.com/api/webhooks/123-456-789",
       "message": {
         "title": "large_transfer_discord triggered",
-        "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+        "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
   },
@@ -17,7 +17,7 @@
       "discord_url": "https://discord.com/api/webhooks/123-456-789",
       "message": {
         "title": "large_swap_by_dex_discord triggered",
-        "body": "${monitor_name} triggered because of a large swap of ${function_0_4} tokens | https://stellar.expert/explorer/public/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because of a large swap of ${functions.0.args.4} tokens | https://stellar.expert/explorer/public/tx/${transaction.hash}"
       }
     }
   }

--- a/examples/config/triggers/email_notifications.json
+++ b/examples/config/triggers/email_notifications.json
@@ -9,7 +9,7 @@
             "password": "your_password",
             "message": {
                 "title": "large_transfer_usdc_email triggered",
-                "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+                "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
             },
             "sender": "your_email@gmail.com",
             "recipients": [

--- a/examples/config/triggers/slack_notifications.json
+++ b/examples/config/triggers/slack_notifications.json
@@ -6,7 +6,7 @@
       "slack_url": "https://hooks.slack.com/services/A/B/C",
       "message": {
         "title": "large_transfer_slack triggered",
-        "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+        "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
   },
@@ -17,7 +17,7 @@
       "slack_url": "https://hooks.slack.com/services/A/B/C",
       "message": {
         "title": "large_swap_by_dex_slack triggered",
-        "body": "${monitor_name} triggered because of a large swap of ${function_0_4} tokens | https://stellar.expert/explorer/public/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because of a large swap of ${functions.0.args.4} tokens | https://stellar.expert/explorer/public/tx/${transaction.hash}"
       }
     }
   }

--- a/examples/config/triggers/telegram_notifications.json
+++ b/examples/config/triggers/telegram_notifications.json
@@ -8,7 +8,7 @@
       "disable_web_preview": true,
       "message": {
         "title": "large_transfer_telegram triggered",
-        "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+        "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
   },
@@ -21,7 +21,7 @@
       "disable_web_preview": true,
       "message": {
         "title": "large_swap_by_dex_telegram triggered",
-        "body": "${monitor_name} triggered because of a large swap of ${function_0_4} tokens | https://stellar.expert/explorer/public/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because of a large swap of ${functions.0.args.4} tokens | https://stellar.expert/explorer/public/tx/${transaction.hash}"
       }
     }
   }

--- a/examples/config/triggers/webhook_notifications.json
+++ b/examples/config/triggers/webhook_notifications.json
@@ -11,7 +11,7 @@
       },
       "message": {
         "title": "large_transfer_webhook triggered",
-        "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+        "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
   },
@@ -27,7 +27,7 @@
       },
       "message": {
         "title": "large_swap_by_dex_webhook triggered",
-        "body": "${monitor_name} triggered because of a large swap of ${function_0_4} tokens | https://stellar.expert/explorer/public/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because of a large swap of ${functions.0.args.4} tokens | https://stellar.expert/explorer/public/tx/${transaction.hash}"
       }
     }
   }

--- a/src/services/filter/filter_match.rs
+++ b/src/services/filter/filter_match.rs
@@ -45,9 +45,9 @@ use crate::{
 /// "transaction.to": "0x0000000000001ff3684f28c67538d4d072c22734"
 /// "transaction.value": "24504000000000000"
 /// "events.0.signature": "Transfer(address,address,uint256)"
-/// "events.0.to": "0x70bf6634ee8cb27d04478f184b9b8bb13e5f4710"
-/// "events.0.from": "0x2e8135be71230c6b1b4045696d41c09db0414226"
-/// "events.0.value": "88248701"
+/// "events.0.args.to": "0x70bf6634ee8cb27d04478f184b9b8bb13e5f4710"
+/// "events.0.args.from": "0x2e8135be71230c6b1b4045696d41c09db0414226"
+/// "events.0.args.value": "88248701"
 /// ```
 pub async fn handle_match<T: TriggerExecutionServiceTrait>(
 	matching_monitor: MonitorMatch,

--- a/src/services/filter/filter_match.rs
+++ b/src/services/filter/filter_match.rs
@@ -9,6 +9,7 @@
 use std::collections::HashMap;
 
 use alloy::primitives::Address;
+use serde_json::{json, Value as JsonValue};
 
 use crate::{
 	models::{MonitorMatch, ScriptLanguage},
@@ -35,18 +36,18 @@ use crate::{
 /// # Returns
 /// Result indicating success or failure of trigger execution
 ///
-/// # Example Template Variables
+/// # Example
 /// The function converts blockchain data into template variables like:
 /// ```text
-/// "monitor_name": "Transfer USDT Token"
-/// "transaction_hash": "0x99139c8f64b9b939678e261e1553660b502d9fd01c2ab1516e699ee6c8cc5791"
-/// "transaction_from": "0xf401346fd255e034a2e43151efe1d68c1e0f8ca5"
-/// "transaction_to": "0x0000000000001ff3684f28c67538d4d072c22734"
-/// "transaction_value": "24504000000000000"
-/// "event_0_signature": "Transfer(address,address,uint256)"
-/// "event_0_to": "0x70bf6634ee8cb27d04478f184b9b8bb13e5f4710"
-/// "event_0_from": "0x2e8135be71230c6b1b4045696d41c09db0414226"
-/// "event_0_value": "88248701"
+/// "monitor.name": "Transfer USDT Token"
+/// "transaction.hash": "0x99139c8f64b9b939678e261e1553660b502d9fd01c2ab1516e699ee6c8cc5791"
+/// "transaction.from": "0xf401346fd255e034a2e43151efe1d68c1e0f8ca5"
+/// "transaction.to": "0x0000000000001ff3684f28c67538d4d072c22734"
+/// "transaction.value": "24504000000000000"
+/// "events.0.signature": "Transfer(address,address,uint256)"
+/// "events.0.to": "0x70bf6634ee8cb27d04478f184b9b8bb13e5f4710"
+/// "events.0.from": "0x2e8135be71230c6b1b4045696d41c09db0414226"
+/// "events.0.value": "88248701"
 /// ```
 pub async fn handle_match<T: TriggerExecutionServiceTrait>(
 	matching_monitor: MonitorMatch,
@@ -58,75 +59,79 @@ pub async fn handle_match<T: TriggerExecutionServiceTrait>(
 			let transaction = evm_monitor_match.transaction.clone();
 			// If sender does not exist, we replace with 0x0000000000000000000000000000000000000000
 			let sender = transaction.sender().unwrap_or(&Address::ZERO);
-			// Convert transaction data to a HashMap
-			let mut data = HashMap::new();
-			data.insert(
-				"transaction_hash".to_string(),
-				b256_to_string(*transaction.hash()),
-			);
-			data.insert("transaction_from".to_string(), h160_to_string(*sender));
-			data.insert(
-				"transaction_value".to_string(),
-				transaction.value().to_string(),
-			);
+
+			// Create structured JSON data
+			let mut data_json = json!({
+				"monitor": {
+					"name": evm_monitor_match.monitor.name.clone(),
+				},
+				"transaction": {
+					"hash": b256_to_string(*transaction.hash()),
+					"from": h160_to_string(*sender),
+					"value": transaction.value().to_string(),
+				},
+				"functions": [],
+				"events": []
+			});
+
+			// Add 'to' address if present
 			if let Some(to) = transaction.to() {
-				data.insert("transaction_to".to_string(), h160_to_string(*to));
+				data_json["transaction"]["to"] = json!(h160_to_string(*to));
 			}
-			data.insert(
-				"monitor_name".to_string(),
-				evm_monitor_match.monitor.name.clone(),
-			);
 
-			let matched_on: HashMap<String, String> = {
-				let matched_on = &evm_monitor_match.matched_on;
-				let mut map = HashMap::new();
-				for (idx, func) in matched_on.functions.iter().enumerate() {
-					map.insert(
-						format!("function_{}_signature", idx),
-						func.signature.clone(),
-					);
-				}
-				for (idx, event) in matched_on.events.iter().enumerate() {
-					map.insert(format!("event_{}_signature", idx), event.signature.clone());
-				}
-				map
-			};
+			// Process matched functions
+			let functions = data_json["functions"].as_array_mut().unwrap();
+			for func in evm_monitor_match.matched_on.functions.iter() {
+				let mut function_data = json!({
+					"signature": func.signature.clone(),
+					"args": {}
+				});
 
-			data.extend(matched_on);
-
-			let matched_args: HashMap<String, String> =
+				// Add function arguments if present
 				if let Some(args) = &evm_monitor_match.matched_on_args {
-					let mut map = HashMap::new();
-					if let Some(functions) = &args.functions {
-						for (idx, func) in functions.iter().enumerate() {
-							if let Some(func_args) = &func.args {
-								for arg in func_args {
-									map.insert(
-										format!("function_{}_{}", idx, arg.name),
-										arg.value.clone(),
-									);
+					if let Some(func_args) = &args.functions {
+						for func_arg in func_args {
+							if func_arg.signature == func.signature {
+								if let Some(arg_entries) = &func_arg.args {
+									let args_obj = function_data["args"].as_object_mut().unwrap();
+									for arg in arg_entries {
+										args_obj.insert(arg.name.clone(), json!(arg.value.clone()));
+									}
 								}
 							}
 						}
 					}
-					if let Some(events) = &args.events {
-						for (idx, event) in events.iter().enumerate() {
-							if let Some(event_args) = &event.args {
-								for arg in event_args {
-									map.insert(
-										format!("event_{}_{}", idx, arg.name),
-										arg.value.clone(),
-									);
-								}
-							}
-						}
-					}
-					map
-				} else {
-					HashMap::new()
-				};
+				}
 
-			data.extend(matched_args);
+				functions.push(function_data);
+			}
+
+			// Process matched events
+			let events = data_json["events"].as_array_mut().unwrap();
+			for event in evm_monitor_match.matched_on.events.iter() {
+				let mut event_data = json!({
+					"signature": event.signature.clone(),
+					"args": {}
+				});
+
+				// Add event arguments if present
+				if let Some(args) = &evm_monitor_match.matched_on_args {
+					if let Some(event_args) = &args.events {
+						for event_arg in event_args {
+							if event_arg.signature == event.signature {
+								if let Some(arg_entries) = &event_arg.args {
+									let args_obj = event_data["args"].as_object_mut().unwrap();
+									for arg in arg_entries {
+										args_obj.insert(arg.name.clone(), json!(arg.value.clone()));
+									}
+								}
+							}
+						}
+					}
+				}
+
+				events.push(event_data);
+			}
 
 			// Swallow any errors since it's logged in the trigger service and we want to continue
 			// processing other matches
@@ -138,7 +143,7 @@ pub async fn handle_match<T: TriggerExecutionServiceTrait>(
 						.iter()
 						.map(|s| s.to_string())
 						.collect::<Vec<_>>(),
-					data,
+					json_to_hashmap(&data_json),
 					&matching_monitor,
 					trigger_scripts,
 				)
@@ -146,80 +151,72 @@ pub async fn handle_match<T: TriggerExecutionServiceTrait>(
 		}
 		MonitorMatch::Stellar(stellar_monitor_match) => {
 			let transaction = stellar_monitor_match.transaction.clone();
-			// Convert transaction data to a HashMap
-			let mut data = HashMap::new();
-			data.insert(
-				"transaction_hash".to_string(),
-				transaction.hash().to_string(),
-			);
 
-			// TODO: Add sender and value to the data so it can be used in the body template of the
-			// trigger data.insert(
-			//     "transaction_from".to_string(),
-			//     transaction.sender().to_string(),
-			// );
-			// data.insert(
-			//     "transaction_value".to_string(),
-			//     transaction.value().to_string(),
-			// );
-			// if let Some(to) = transaction.to() {
-			//     data.insert("transaction_to".to_string(), to.to_string());
-			// }
-			data.insert(
-				"monitor_name".to_string(),
-				stellar_monitor_match.monitor.name.clone(),
-			);
+			// Create structured JSON data
+			let mut data_json = json!({
+				"monitor": {
+					"name": stellar_monitor_match.monitor.name.clone(),
+				},
+				"transaction": {
+					"hash": transaction.hash().to_string(),
+				},
+				"functions": [],
+				"events": []
+			});
 
-			let matched_on: HashMap<String, String> = {
-				let matched_on = &stellar_monitor_match.matched_on;
-				let mut map = HashMap::new();
-				for (idx, func) in matched_on.functions.iter().enumerate() {
-					map.insert(
-						format!("function_{}_signature", idx),
-						func.signature.clone(),
-					);
-				}
-				for (idx, event) in matched_on.events.iter().enumerate() {
-					map.insert(format!("event_{}_signature", idx), event.signature.clone());
-				}
-				map
-			};
+			// Process matched functions
+			let functions = data_json["functions"].as_array_mut().unwrap();
+			for func in stellar_monitor_match.matched_on.functions.iter() {
+				let mut function_data = json!({
+					"signature": func.signature.clone(),
+					"args": {}
+				});
 
-			data.extend(matched_on);
-
-			let matched_args: HashMap<String, String> =
+				// Add function arguments if present
 				if let Some(args) = &stellar_monitor_match.matched_on_args {
-					let mut map = HashMap::new();
-					if let Some(functions) = &args.functions {
-						for (idx, func) in functions.iter().enumerate() {
-							if let Some(func_args) = &func.args {
-								for arg in func_args {
-									map.insert(
-										format!("function_{}_{}", idx, arg.name),
-										arg.value.clone(),
-									);
+					if let Some(func_args) = &args.functions {
+						for func_arg in func_args {
+							if func_arg.signature == func.signature {
+								if let Some(arg_entries) = &func_arg.args {
+									let args_obj = function_data["args"].as_object_mut().unwrap();
+									for arg in arg_entries {
+										args_obj.insert(arg.name.clone(), json!(arg.value.clone()));
+									}
 								}
 							}
 						}
 					}
-					if let Some(events) = &args.events {
-						for (idx, event) in events.iter().enumerate() {
-							if let Some(event_args) = &event.args {
-								for arg in event_args {
-									map.insert(
-										format!("event_{}_{}", idx, arg.name),
-										arg.value.clone(),
-									);
-								}
-							}
-						}
-					}
-					map
-				} else {
-					HashMap::new()
-				};
+				}
 
-			data.extend(matched_args);
+				functions.push(function_data);
+			}
+
+			// Process matched events
+			let events = data_json["events"].as_array_mut().unwrap();
+			for event in stellar_monitor_match.matched_on.events.iter() {
+				let mut event_data = json!({
+					"signature": event.signature.clone(),
+					"args": {}
+				});
+
+				// Add event arguments if present
+				if let Some(args) = &stellar_monitor_match.matched_on_args {
+					if let Some(event_args) = &args.events {
+						for event_arg in event_args {
+							if event_arg.signature == event.signature {
+								if let Some(arg_entries) = &event_arg.args {
+									let args_obj = event_data["args"].as_object_mut().unwrap();
+									for arg in arg_entries {
+										args_obj.insert(arg.name.clone(), json!(arg.value.clone()));
+									}
+								}
+							}
+						}
+					}
+				}
+
+				events.push(event_data);
+			}
 
 			// Swallow any errors since it's logged in the trigger service and we want to continue
 			// processing other matches
@@ -231,7 +228,7 @@ pub async fn handle_match<T: TriggerExecutionServiceTrait>(
 						.iter()
 						.map(|s| s.to_string())
 						.collect::<Vec<_>>(),
-					data,
+					json_to_hashmap(&data_json),
 					&matching_monitor,
 					trigger_scripts,
 				)
@@ -239,4 +236,281 @@ pub async fn handle_match<T: TriggerExecutionServiceTrait>(
 		}
 	}
 	Ok(())
+}
+
+/// Converts a JsonValue to a flattened HashMap with dotted path notation
+fn json_to_hashmap(json: &JsonValue) -> HashMap<String, String> {
+	let mut result = HashMap::new();
+	flatten_json_path(json, "", &mut result);
+	result
+}
+
+/// Flattens a JsonValue into a HashMap with dotted path notation
+fn flatten_json_path(value: &JsonValue, prefix: &str, result: &mut HashMap<String, String>) {
+	match value {
+		JsonValue::Object(obj) => {
+			for (key, val) in obj {
+				let new_prefix = if prefix.is_empty() {
+					key.clone()
+				} else {
+					format!("{}.{}", prefix, key)
+				};
+				flatten_json_path(val, &new_prefix, result);
+			}
+		}
+		JsonValue::Array(arr) => {
+			for (idx, val) in arr.iter().enumerate() {
+				let new_prefix = format!("{}.{}", prefix, idx);
+				flatten_json_path(val, &new_prefix, result);
+			}
+		}
+		JsonValue::String(s) => {
+			let key = if prefix.is_empty() {
+				"value".to_string()
+			} else {
+				prefix.to_string()
+			};
+			result.insert(key, s.clone());
+		}
+		JsonValue::Number(n) => {
+			let key = if prefix.is_empty() {
+				"value".to_string()
+			} else {
+				prefix.to_string()
+			};
+			result.insert(key, n.to_string());
+		}
+		JsonValue::Bool(b) => {
+			let key = if prefix.is_empty() {
+				"value".to_string()
+			} else {
+				prefix.to_string()
+			};
+			result.insert(key, b.to_string());
+		}
+		JsonValue::Null => {
+			let key = if prefix.is_empty() {
+				"value".to_string()
+			} else {
+				prefix.to_string()
+			};
+			result.insert(key, "null".to_string());
+		}
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use serde_json::json;
+
+	#[test]
+	fn test_json_to_hashmap() {
+		let json = json!({
+			"monitor": {
+				"name": "Test Monitor",
+			},
+			"transaction": {
+				"hash": "0x1234567890abcdef",
+			},
+		});
+
+		let hashmap = json_to_hashmap(&json);
+		assert_eq!(hashmap["monitor.name"], "Test Monitor");
+		assert_eq!(hashmap["transaction.hash"], "0x1234567890abcdef");
+	}
+
+	#[test]
+	fn test_json_to_hashmap_with_functions() {
+		let json = json!({
+			"monitor": {
+				"name": "Test Monitor",
+			},
+			"functions": [
+				{
+					"signature": "function1(uint256)",
+					"args": {
+						"arg1": "100",
+					},
+				},
+			],
+		});
+
+		let hashmap = json_to_hashmap(&json);
+		assert_eq!(hashmap["monitor.name"], "Test Monitor");
+		assert_eq!(hashmap["functions.0.signature"], "function1(uint256)");
+		assert_eq!(hashmap["functions.0.args.arg1"], "100");
+	}
+
+	#[test]
+	fn test_json_to_hashmap_with_events() {
+		let json = json!({
+			"monitor": {
+				"name": "Test Monitor",
+			},
+			"events": [
+				{
+					"signature": "event1(uint256)",
+					"args": {
+						"arg1": "100",
+					},
+				},
+			],
+		});
+
+		let hashmap = json_to_hashmap(&json);
+		assert_eq!(hashmap["monitor.name"], "Test Monitor");
+		assert_eq!(hashmap["events.0.signature"], "event1(uint256)");
+		assert_eq!(hashmap["events.0.args.arg1"], "100");
+	}
+
+	// Add tests for flatten_json_path
+	#[test]
+	fn test_flatten_json_path_object() {
+		let json = json!({
+			"monitor": {
+				"name": "Test Monitor",
+			},
+		});
+
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "", &mut result);
+		assert_eq!(result["monitor.name"], "Test Monitor");
+	}
+
+	#[test]
+	fn test_flatten_json_path_array() {
+		let json = json!({
+			"monitor": {
+				"name": "Test Monitor",
+			},
+		});
+
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "", &mut result);
+		assert_eq!(result["monitor.name"], "Test Monitor");
+	}
+
+	#[test]
+	fn test_flatten_json_path_string() {
+		let json = json!("Test String");
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "test_prefix", &mut result);
+		assert_eq!(result["test_prefix"], "Test String");
+
+		let mut result2 = HashMap::new();
+		flatten_json_path(&json, "", &mut result2);
+		assert_eq!(result2["value"], "Test String");
+	}
+
+	#[test]
+	fn test_flatten_json_path_number() {
+		let json = json!(123);
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "test_prefix", &mut result);
+		assert_eq!(result["test_prefix"], "123");
+
+		let mut result2 = HashMap::new();
+		flatten_json_path(&json, "", &mut result2);
+		assert_eq!(result2["value"], "123");
+	}
+
+	#[test]
+	fn test_flatten_json_path_boolean() {
+		let json = json!(true);
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "test_prefix", &mut result);
+		assert_eq!(result["test_prefix"], "true");
+
+		// Test with empty prefix
+		let mut result2 = HashMap::new();
+		flatten_json_path(&json, "", &mut result2);
+		assert_eq!(result2["value"], "true");
+	}
+
+	#[test]
+	fn test_flatten_json_path_null() {
+		let json = json!(null);
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "test_prefix", &mut result);
+		assert_eq!(result["test_prefix"], "null");
+
+		let mut result2 = HashMap::new();
+		flatten_json_path(&json, "", &mut result2);
+		assert_eq!(result2["value"], "null");
+	}
+
+	#[test]
+	fn test_flatten_json_path_nested_object() {
+		let json = json!({
+			"monitor": {
+				"name": "Test Monitor",
+				"nested": {
+					"key": "value",
+				},
+			},
+		});
+
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "", &mut result);
+		assert_eq!(result["monitor.nested.key"], "value");
+	}
+
+	#[test]
+	fn test_flatten_json_path_nested_array() {
+		let json = json!({
+			"monitor": {
+				"name": "Test Monitor",
+				"nested": [
+					{
+						"key": "value1",
+					},
+					{
+						"key": "value2",
+					},
+				],
+			},
+		});
+
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "", &mut result);
+		assert_eq!(result["monitor.nested.0.key"], "value1");
+		assert_eq!(result["monitor.nested.1.key"], "value2");
+	}
+
+	#[test]
+	fn test_flatten_json_path_with_prefix() {
+		let json = json!({
+			"monitor": {
+				"name": "Test Monitor",
+			},
+		});
+
+		let mut result = HashMap::new();
+		flatten_json_path(&json, "prefix", &mut result);
+		assert_eq!(result["prefix.monitor.name"], "Test Monitor");
+	}
+
+	#[test]
+	fn test_json_to_hashmap_with_primitive_values() {
+		// String
+		let json_string = json!("Test String");
+		let hashmap_string = json_to_hashmap(&json_string);
+		assert_eq!(hashmap_string["value"], "Test String");
+
+		// Number
+		let json_number = json!(123);
+		let hashmap_number = json_to_hashmap(&json_number);
+		assert_eq!(hashmap_number["value"], "123");
+
+		// Boolean
+		let json_bool = json!(true);
+		let hashmap_bool = json_to_hashmap(&json_bool);
+		assert_eq!(hashmap_bool["value"], "true");
+
+		// Null
+		let json_null = json!(null);
+		let hashmap_null = json_to_hashmap(&json_null);
+		assert_eq!(hashmap_null["value"], "null");
+	}
 }

--- a/tests/integration/filters/evm/filter.rs
+++ b/tests/integration/filters/evm/filter.rs
@@ -3,6 +3,12 @@
 //! Tests the monitoring functionality for EVM-compatible blockchains,
 //! including event and transaction filtering.
 
+use alloy::{
+	consensus::{
+		transaction::Recovered, Receipt, ReceiptEnvelope, ReceiptWithBloom, Signed, TxEnvelope,
+	},
+	primitives::{Bytes, TxKind, U256},
+};
 use serde_json::json;
 use std::collections::HashMap;
 
@@ -504,21 +510,21 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 		.withf(|trigger_name, variables, _monitor_match, _trigger_scripts| {
 			trigger_name == ["example_trigger_slack"]
 				// Event variables
-				&& variables.get("event_0_signature") == Some(&"Transfer(address,address,uint256)".to_string())
-				&& variables.get("event_0_from") == Some(&"0x58b704065b7aff3ed351052f8560019e05925023".to_string())
-				&& variables.get("event_0_to") == Some(&"0xf423d9c1ffeb6386639d024f3b241dab2331b635".to_string())
-				&& variables.get("event_0_value") == Some(&"8181710000".to_string())
+				&& variables.get("events.0.signature") == Some(&"Transfer(address,address,uint256)".to_string())
+				&& variables.get("events.0.args.from") == Some(&"0x58b704065b7aff3ed351052f8560019e05925023".to_string())
+				&& variables.get("events.0.args.to") == Some(&"0xf423d9c1ffeb6386639d024f3b241dab2331b635".to_string())
+				&& variables.get("events.0.args.value") == Some(&"8181710000".to_string())
 				// Function variables
-				&& variables.get("function_0_signature") == Some(&"transfer(address,uint256)".to_string())
-				&& variables.get("function_0_to") == Some(&"0xf423d9c1ffeb6386639d024f3b241dab2331b635".to_string())
-				&& variables.get("function_0_value") == Some(&"8181710000".to_string())
+				&& variables.get("functions.0.signature") == Some(&"transfer(address,uint256)".to_string())
+				&& variables.get("functions.0.args.to") == Some(&"0xf423d9c1ffeb6386639d024f3b241dab2331b635".to_string())
+				&& variables.get("functions.0.args.value") == Some(&"8181710000".to_string())
 				// Transaction variables
-				&& variables.get("transaction_hash") == Some(&"0xd5069b22a3a89a36d592d5a1f72a281bc5d11d6d0bac6f0a878c13abb764b6d8".to_string())
-				&& variables.get("transaction_from") == Some(&"0x58b704065b7aff3ed351052f8560019e05925023".to_string())
-				&& variables.get("transaction_to") == Some(&"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string())
-				&& variables.get("transaction_value") == Some(&"0".to_string())
+				&& variables.get("transaction.hash") == Some(&"0xd5069b22a3a89a36d592d5a1f72a281bc5d11d6d0bac6f0a878c13abb764b6d8".to_string())
+				&& variables.get("transaction.from") == Some(&"0x58b704065b7aff3ed351052f8560019e05925023".to_string())
+				&& variables.get("transaction.to") == Some(&"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string())
+				&& variables.get("transaction.value") == Some(&"0".to_string())
 				// Monitor metadata
-				&& variables.get("monitor_name") == Some(&"Mint USDC Token".to_string())
+				&& variables.get("monitor.name") == Some(&"Mint USDC Token".to_string())
 		})
 		.once()
 		.returning(|_, _, _, _| Ok(()));
@@ -601,14 +607,14 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 				.withf(|trigger_name, variables, _monitor_match, _trigger_scripts| {
 					trigger_name == ["example_trigger_slack"]
 						// Monitor metadata
-						&& variables.get("monitor_name") == Some(&"Mint USDC Token".to_string())
+						&& variables.get("monitor.name") == Some(&"Mint USDC Token".to_string())
 						// Transaction variables
-						&& variables.get("transaction_hash") == Some(&"0x6fb716f3fc4e2edec31f01c8bb67e565e3efacba965090a38835d3f297232bf6".to_string())
-						&& variables.get("transaction_from") == Some(&"0x6b9501462d48f7e78ba11c98508ee16d29a03411".to_string())
-						&& variables.get("transaction_to") == Some(&"0xf18206b2289cf6ce15cddbee9c6f6a0f059efb56".to_string())
-						&& variables.get("transaction_value") == Some(&"0".to_string())
+						&& variables.get("transaction.hash") == Some(&"0x6fb716f3fc4e2edec31f01c8bb67e565e3efacba965090a38835d3f297232bf6".to_string())
+						&& variables.get("transaction.from") == Some(&"0x6b9501462d48f7e78ba11c98508ee16d29a03411".to_string())
+						&& variables.get("transaction.to") == Some(&"0xf18206b2289cf6ce15cddbee9c6f6a0f059efb56".to_string())
+						&& variables.get("transaction.value") == Some(&"0".to_string())
 						// Function signature should be present even without args
-						&& variables.get("function_0_signature") == Some(&"increment()".to_string())
+						&& variables.get("functions.0.signature") == Some(&"increment()".to_string())
 				})
 				.once()
 				.returning(|_, _, _, _| Ok(()));
@@ -625,6 +631,184 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 			panic!("Expected EVM match");
 		}
 	}
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_handle_match_with_key_collision() -> Result<(), Box<FilterError>> {
+	// Load test data using common utility
+	let test_data = load_test_data("evm");
+
+	// Setup trigger execution service and capture the data structure
+	let data_capture = std::sync::Arc::new(std::sync::Mutex::new(HashMap::new()));
+	let data_capture_clone = data_capture.clone();
+
+	let mut trigger_execution_service =
+		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json");
+
+	// Set up expectations for execute() with custom function to capture and verify data
+	trigger_execution_service
+		.expect_execute()
+		.withf(
+			move |_triggers, variables, _monitor_match, _trigger_scripts| {
+				let mut captured = data_capture_clone.lock().unwrap();
+				*captured = variables.clone();
+				true
+			},
+		)
+		.returning(|_, _, _, _| Ok(()));
+
+	// Create a monitor match with an argument named "signature"
+	use alloy::primitives::{Address, B256};
+	use openzeppelin_monitor::models::{
+		EVMMatchArguments, EVMMatchParamEntry, EVMMatchParamsMap, EVMMonitorMatch, EVMTransaction,
+		EVMTransactionReceipt, FunctionCondition, MatchConditions,
+	};
+
+	// Create test monitor with a function that has an argument called "signature"
+	let mut monitor = test_data.monitor.clone();
+	monitor.match_conditions.functions = vec![FunctionCondition {
+		signature: "dangerousFunc(bytes32 signature, uint256 value)".to_string(),
+		expression: None,
+	}];
+
+	fn create_test_evm_transaction_receipt() -> EVMTransactionReceipt {
+		EVMTransactionReceipt::from(alloy::rpc::types::TransactionReceipt {
+			inner: ReceiptEnvelope::Legacy(ReceiptWithBloom {
+				receipt: Receipt::default(),
+				logs_bloom: Default::default(),
+			}),
+			transaction_hash: B256::ZERO,
+			transaction_index: Some(0),
+			block_hash: Some(B256::ZERO),
+			block_number: Some(0),
+			gas_used: 0,
+			effective_gas_price: 0,
+			blob_gas_used: None,
+			blob_gas_price: None,
+			from: Address::ZERO,
+			to: Some(Address::ZERO),
+			contract_address: None,
+		})
+	}
+
+	fn create_test_evm_transaction() -> EVMTransaction {
+		let tx = alloy::consensus::TxLegacy {
+			chain_id: None,
+			nonce: 0,
+			gas_price: 0,
+			gas_limit: 0,
+			to: TxKind::Call(Address::ZERO),
+			value: U256::ZERO,
+			input: Bytes::default(),
+		};
+
+		let signature =
+			alloy::signers::Signature::from_scalars_and_parity(B256::ZERO, B256::ZERO, false);
+
+		let hash = B256::ZERO;
+
+		EVMTransaction::from(alloy::rpc::types::Transaction {
+			inner: Recovered::new_unchecked(
+				TxEnvelope::Legacy(Signed::new_unchecked(tx, signature, hash)),
+				Address::ZERO,
+			),
+			block_hash: None,
+			block_number: None,
+			transaction_index: None,
+			effective_gas_price: None,
+		})
+	}
+
+	// Create a match object
+	let evm_match = EVMMonitorMatch {
+		monitor,
+		transaction: create_test_evm_transaction(),
+		receipt: create_test_evm_transaction_receipt(),
+		network_slug: "ethereum_mainnet".to_string(),
+		matched_on: MatchConditions {
+			functions: vec![FunctionCondition {
+				signature: "dangerousFunc(bytes32 signature, uint256 value)".to_string(),
+				expression: None,
+			}],
+			events: vec![],
+			transactions: vec![],
+		},
+		matched_on_args: Some(EVMMatchArguments {
+			functions: Some(vec![EVMMatchParamsMap {
+				signature: "dangerousFunc(bytes32 signature, uint256 value)".to_string(),
+				args: Some(vec![
+					EVMMatchParamEntry {
+						name: "signature".to_string(),
+						value: "0xabcdef1234567890".to_string(),
+						kind: "bytes32".to_string(),
+						indexed: false,
+					},
+					EVMMatchParamEntry {
+						name: "value".to_string(),
+						value: "123456789".to_string(),
+						kind: "uint256".to_string(),
+						indexed: false,
+					},
+				]),
+				hex_signature: Some("0xdeadbeef".to_string()),
+			}]),
+			events: None,
+		}),
+	};
+
+	let match_wrapper = MonitorMatch::EVM(Box::new(evm_match));
+
+	// Process the match directly using handle_match
+	let result = handle_match(match_wrapper, &trigger_execution_service, &HashMap::new()).await;
+	assert!(result.is_ok(), "Handle match should succeed");
+
+	// Verify that data structure preserves both function signature and argument
+	let captured_data = data_capture.lock().unwrap();
+
+	// The key for the function signature should exist
+	assert!(
+		captured_data.contains_key("functions.0.signature"),
+		"functions.0.signature should exist in the data structure"
+	);
+
+	// Check the value is correct
+	assert_eq!(
+		captured_data.get("functions.0.signature").unwrap(),
+		"dangerousFunc(bytes32 signature, uint256 value)",
+		"Function signature value should be preserved"
+	);
+
+	// The key for the argument should also exist
+	assert!(
+		captured_data.contains_key("functions.0.args.signature"),
+		"functions.0.args.signature should exist in the data structure"
+	);
+
+	// Check that the argument value is correct
+	assert_eq!(
+		captured_data.get("functions.0.args.signature").unwrap(),
+		"0xabcdef1234567890",
+		"Function argument value should be correct"
+	);
+
+	// Verify that the values are different - no collision
+	assert_ne!(
+		captured_data.get("functions.0.signature").unwrap(),
+		captured_data.get("functions.0.args.signature").unwrap(),
+		"Function signature and argument values should be distinct"
+	);
+
+	// Also check for other expected fields
+	assert!(
+		captured_data.contains_key("transaction.hash"),
+		"Transaction hash should be present"
+	);
+	assert!(
+		captured_data.contains_key("monitor.name"),
+		"Monitor name should be present"
+	);
 
 	Ok(())
 }

--- a/tests/integration/filters/stellar/filter.rs
+++ b/tests/integration/filters/stellar/filter.rs
@@ -7,15 +7,20 @@ use std::collections::HashMap;
 
 use openzeppelin_monitor::{
 	models::{
-		BlockType, EventCondition, FunctionCondition, Monitor, MonitorMatch, StellarEvent,
-		StellarTransaction, StellarTransactionInfo, TransactionCondition, TransactionStatus,
+		BlockChainType, BlockType, EventCondition, FunctionCondition, MatchConditions, Monitor,
+		MonitorMatch, StellarBlock, StellarEvent, StellarMatchArguments, StellarMatchParamEntry,
+		StellarMatchParamsMap, StellarMonitorMatch, StellarTransaction, StellarTransactionInfo,
+		TransactionCondition, TransactionStatus, TransactionType,
 	},
 	services::filter::{handle_match, FilterError, FilterService},
 };
 
 use crate::integration::{
 	filters::common::{load_test_data, read_and_parse_json, setup_trigger_execution_service},
-	mocks::{MockStellarClientTrait, MockStellarTransportClient},
+	mocks::{
+		create_test_block, create_test_transaction, MockStellarClientTrait,
+		MockStellarTransportClient,
+	},
 };
 
 use serde_json::Value;
@@ -686,21 +691,21 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 		.withf(|trigger_name, variables, _monitor_match, _trigger_scripts| {
 			trigger_name == ["example_trigger_slack"]
 				// Monitor metadata
-				&& variables.get("monitor_name") == Some(&"Large Transfer of USDC Token".to_string())
+				&& variables.get("monitor.name") == Some(&"Large Transfer of USDC Token".to_string())
 				// Transaction variables
-				&& variables.get("transaction_hash")
+				&& variables.get("transaction.hash")
 					== Some(&"2c89fc3311bc275415ed6a764c77d7b0349cb9f4ce37fd2bbfc6604920811503".to_string())
 				// Function arguments
-				&& variables.get("function_0_signature") == Some(&"transfer(Address,Address,I128)".to_string())
-				&& variables.get("function_0_0") == Some(&"GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY".to_string())
-				&& variables.get("function_0_1") == Some(&"CC7YMFMYZM2HE6O3JT5CNTFBHVXCZTV7CEYT56IGBHR4XFNTGTN62CPT".to_string())
-				&& variables.get("function_0_2") == Some(&"2240".to_string())
+				&& variables.get("functions.0.signature") == Some(&"transfer(Address,Address,I128)".to_string())
+				&& variables.get("functions.0.args.0") == Some(&"GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY".to_string())
+				&& variables.get("functions.0.args.1") == Some(&"CC7YMFMYZM2HE6O3JT5CNTFBHVXCZTV7CEYT56IGBHR4XFNTGTN62CPT".to_string())
+				&& variables.get("functions.0.args.2") == Some(&"2240".to_string())
 				// Event arguments
-				&& variables.get("event_0_signature") == Some(&"transfer(Address,Address,String,I128)".to_string())
-				&& variables.get("event_0_0") == Some(&"GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY".to_string())
-				&& variables.get("event_0_1") == Some(&"CC7YMFMYZM2HE6O3JT5CNTFBHVXCZTV7CEYT56IGBHR4XFNTGTN62CPT".to_string())
-				&& variables.get("event_0_2") == Some(&"USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5".to_string())
-				&& variables.get("event_0_3") == Some(&"2240".to_string())
+				&& variables.get("events.0.signature") == Some(&"transfer(Address,Address,String,I128)".to_string())
+				&& variables.get("events.0.args.0") == Some(&"GDF32CQINROD3E2LMCGZUDVMWTXCJFR5SBYVRJ7WAAIAS3P7DCVWZEFY".to_string())
+				&& variables.get("events.0.args.1") == Some(&"CC7YMFMYZM2HE6O3JT5CNTFBHVXCZTV7CEYT56IGBHR4XFNTGTN62CPT".to_string())
+				&& variables.get("events.0.args.2") == Some(&"USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5".to_string())
+				&& variables.get("events.0.args.3") == Some(&"2240".to_string())
 		})
 		.once()
 		.returning(|_, _, _, _| Ok(()));
@@ -712,16 +717,16 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 				let expected_json: Value =
 					serde_json::from_str("{\"myKey1\":1234,\"myKey2\":\"Hello, world!\"}").unwrap();
 				let actual_json: Value =
-					serde_json::from_str(variables.get("function_0_0").unwrap()).unwrap();
+					serde_json::from_str(variables.get("functions.0.args.0").unwrap()).unwrap();
 
 				trigger_name == ["example_trigger_slack"]
 				// Monitor metadata
-				&& variables.get("monitor_name") == Some(&"Large Transfer of USDC Token".to_string())
+				&& variables.get("monitor.name") == Some(&"Large Transfer of USDC Token".to_string())
 				// Transaction variables
-				&& variables.get("transaction_hash")
+				&& variables.get("transaction.hash")
 					== Some(&"FAKE5a3a9153e19002517935a5df291b81a341b98ccd80f0919d78cea5ed29d8".to_string())
 				// Function arguments
-				&& variables.get("function_0_signature") == Some(&"upsert_data(Map)".to_string())
+				&& variables.get("functions.0.signature") == Some(&"upsert_data(Map)".to_string())
 				&& expected_json == actual_json
 			},
 		)
@@ -821,11 +826,11 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 				.withf(|trigger_name, variables, _monitor_match, _trigger_scripts| {
 					trigger_name == ["example_trigger_slack"]
 						// Monitor metadata
-						&& variables.get("monitor_name") == Some(&"Large Transfer of USDC Token".to_string())
+						&& variables.get("monitor.name") == Some(&"Large Transfer of USDC Token".to_string())
 						// Transaction variables
-						&& variables.get("transaction_hash") == Some(&"80fec04b989895a4222d9985fbf153d253e3e2cbc1da45ef414db96a277b99be".to_string())
+						&& variables.get("transaction.hash") == Some(&"80fec04b989895a4222d9985fbf153d253e3e2cbc1da45ef414db96a277b99be".to_string())
 						// Function signature should be present even without args
-						&& variables.get("function_0_signature") == Some(&"increment()".to_string())
+						&& variables.get("functions.0.signature") == Some(&"increment()".to_string())
 				})
 				.once()
 				.returning(|_, _, _, _| Ok(()));
@@ -842,6 +847,142 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 			panic!("Expected Stellar match");
 		}
 	}
+
+	Ok(())
+}
+
+#[tokio::test]
+async fn test_handle_match_with_key_collision() -> Result<(), Box<FilterError>> {
+	// Load test data using common utility
+	let test_data = load_test_data("stellar");
+
+	// Setup trigger execution service and capture the data structure
+	let data_capture = std::sync::Arc::new(std::sync::Mutex::new(HashMap::new()));
+	let data_capture_clone = data_capture.clone();
+
+	let mut trigger_execution_service =
+		setup_trigger_execution_service("tests/integration/fixtures/stellar/triggers/trigger.json");
+
+	// Set up expectations for execute() with custom function to capture and verify data
+	trigger_execution_service
+		.expect_execute()
+		.withf(
+			move |_triggers, variables, _monitor_match, _trigger_scripts| {
+				let mut captured = data_capture_clone.lock().unwrap();
+				*captured = variables.clone();
+				true
+			},
+		)
+		.returning(|_, _, _, _| Ok(()));
+
+	// Create test monitor with a function that has an argument called "signature"
+	let mut monitor = test_data.monitor.clone();
+	monitor.match_conditions.functions = vec![FunctionCondition {
+		signature: "riskyFunction(String signature, I128 amount)".to_string(),
+		expression: None,
+	}];
+
+	fn create_test_stellar_transaction() -> StellarTransaction {
+		match create_test_transaction(BlockChainType::Stellar) {
+			TransactionType::Stellar(transaction) => transaction,
+			_ => panic!("Expected Stellar transaction"),
+		}
+	}
+
+	fn create_test_stellar_block() -> StellarBlock {
+		match create_test_block(BlockChainType::Stellar, 1) {
+			BlockType::Stellar(block) => *block,
+			_ => panic!("Expected Stellar block"),
+		}
+	}
+
+	// Create a match object
+	let stellar_match = StellarMonitorMatch {
+		monitor,
+		transaction: create_test_stellar_transaction(),
+		network_slug: "stellar_testnet".to_string(),
+		ledger: create_test_stellar_block(),
+		matched_on: MatchConditions {
+			functions: vec![FunctionCondition {
+				signature: "riskyFunction(String signature, I128 amount)".to_string(),
+				expression: None,
+			}],
+			events: vec![],
+			transactions: vec![],
+		},
+		matched_on_args: Some(StellarMatchArguments {
+			functions: Some(vec![StellarMatchParamsMap {
+				signature: "riskyFunction(String signature, I128 amount)".to_string(),
+				args: Some(vec![
+					StellarMatchParamEntry {
+						name: "signature".to_string(),
+						value: "test_signature_value".to_string(),
+						kind: "String".to_string(),
+						indexed: false,
+					},
+					StellarMatchParamEntry {
+						name: "amount".to_string(),
+						value: "500000".to_string(),
+						kind: "I128".to_string(),
+						indexed: false,
+					},
+				]),
+			}]),
+			events: None,
+		}),
+	};
+
+	let match_wrapper = MonitorMatch::Stellar(Box::new(stellar_match));
+
+	// Process the match directly using handle_match
+	let result = handle_match(match_wrapper, &trigger_execution_service, &HashMap::new()).await;
+	assert!(result.is_ok(), "Handle match should succeed");
+
+	// Verify that data structure preserves both function signature and argument
+	let captured_data = data_capture.lock().unwrap();
+
+	// The key for the function signature should exist
+	assert!(
+		captured_data.contains_key("functions.0.signature"),
+		"functions.0.signature should exist in the data structure"
+	);
+
+	// Check the value is correct
+	assert_eq!(
+		captured_data.get("functions.0.signature").unwrap(),
+		"riskyFunction(String signature, I128 amount)",
+		"Function signature value should be preserved"
+	);
+
+	// The key for the argument should also exist
+	assert!(
+		captured_data.contains_key("functions.0.args.signature"),
+		"functions.0.args.signature should exist in the data structure"
+	);
+
+	// Check that the argument value is correct
+	assert_eq!(
+		captured_data.get("functions.0.args.signature").unwrap(),
+		"test_signature_value",
+		"Function argument value should be correct"
+	);
+
+	// Verify that the values are different - no collision
+	assert_ne!(
+		captured_data.get("functions.0.signature").unwrap(),
+		captured_data.get("functions.0.args.signature").unwrap(),
+		"Function signature and argument values should be distinct"
+	);
+
+	// Also check for other expected fields
+	assert!(
+		captured_data.contains_key("transaction.hash"),
+		"Transaction hash should be present"
+	);
+	assert!(
+		captured_data.contains_key("monitor.name"),
+		"Monitor name should be present"
+	);
 
 	Ok(())
 }

--- a/tests/integration/fixtures/evm/triggers/trigger.json
+++ b/tests/integration/fixtures/evm/triggers/trigger.json
@@ -6,7 +6,7 @@
       "slack_url": "https://hooks.slack.com/services/AAA/BBB/CCC",
       "message": {
         "title": "example_trigger_slack triggered",
-        "body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+        "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
   },
@@ -22,7 +22,7 @@
       },
       "message": {
         "title": "example_trigger_webhook triggered",
-        "body": "${monitor_name} triggered because someone called the ${function_0_signature} function with value ${function_0_value} | https://etherscan.io/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because someone called the ${functions.0.signature} function with value ${functions.0.args.0} | https://etherscan.io/tx/${transaction.hash}"
       }
     }
   },
@@ -33,7 +33,7 @@
       "discord_url": "https://discord.com/api/webhooks/123/123",
       "message": {
         "title": "example_trigger_discord triggered",
-        "body": "${monitor_name} triggered because someone called the ${function_0_signature} function with value ${function_0_value} | https://etherscan.io/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because someone called the ${functions.0.signature} function with value ${functions.0.args.0} | https://etherscan.io/tx/${transaction.hash}"
       }
     }
   },
@@ -46,7 +46,7 @@
       "disable_web_preview": true,
       "message": {
         "title": "example_trigger_telegram triggered",
-        "body": "${monitor_name} triggered because someone called the ${function_0_signature} function with value ${function_0_value} | https://etherscan.io/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because someone called the ${functions.0.signature} function with value ${functions.0.args.0} | https://etherscan.io/tx/${transaction.hash}"
       }
     }
   }

--- a/tests/integration/fixtures/stellar/triggers/trigger.json
+++ b/tests/integration/fixtures/stellar/triggers/trigger.json
@@ -6,7 +6,7 @@
       "slack_url": "https://hooks.slack.com/services/AAA/BBB/CCC",
       "message": {
         "title": "example_trigger_slack triggered",
-        "body": "${monitor_name} triggered because of a large transfer of ${function_0_2} USDC to ${function_0_1} | https://stellar.expert/explorer/testnet/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because of a large transfer of ${functions.0.args.2} USDC to ${functions.0.args.1} | https://stellar.expert/explorer/testnet/tx/${transaction.hash}"
       }
     }
   },
@@ -22,7 +22,7 @@
       },
       "message": {
         "title": "example_trigger_webhook triggered",
-        "body": "${monitor_name} triggered because someone called the ${function_0_signature} function with value ${function_0_0} | https://stellar.expert/explorer/testnet/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because someone called the ${functions.0.signature} function with value ${functions.0.args.0} | https://stellar.expert/explorer/testnet/tx/${transaction.hash}"
       }
     }
   },
@@ -33,7 +33,7 @@
       "discord_url": "https://discord.com/api/webhooks/123/123",
       "message": {
         "title": "example_trigger_discord triggered",
-        "body": "${monitor_name} triggered because someone called the ${function_0_signature} function with value ${function_0_0} | https://stellar.expert/explorer/testnet/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because someone called the ${functions.0.signature} function with value ${functions.0.args.0} | https://stellar.expert/explorer/testnet/tx/${transaction.hash}"
       }
     }
   },
@@ -46,7 +46,7 @@
       "disable_web_preview": true,
       "message": {
         "title": "example_trigger_telegram triggered",
-        "body": "${monitor_name} triggered because someone called the ${function_0_signature} function with value ${function_0_0} | https://stellar.expert/explorer/testnet/tx/${transaction_hash}"
+        "body": "${monitor.name} triggered because someone called the ${functions.0.signature} function with value ${functions.0.args.0} | https://stellar.expert/explorer/testnet/tx/${transaction.hash}"
       }
     }
   }

--- a/tests/integration/monitor/execution.rs
+++ b/tests/integration/monitor/execution.rs
@@ -101,7 +101,7 @@ fn create_test_trigger_file(path: &Path, name: &str) -> std::path::PathBuf {
 			  "slack_url": "https://hooks.slack.com/services/AA/BB/CC",
 			  "message": {
 				"title": "large_transfer_slack triggered",
-				"body": "Large transfer of ${event_0_value} USDC from ${event_0_from} to ${event_0_to} | https://etherscan.io/tx/${transaction_hash}#eventlog"
+				"body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
 			  }
 			}
 		},


### PR DESCRIPTION
# Summary

**This is a breaking change**: It requires reformatting template variables in config files.

https://linear.app/openzeppelin-development/issue/PLAT-6582/fix-signature-match-key-collission

This PR fixes https://github.com/OpenZeppelin/openzeppelin-monitor/issues/201.

When processing monitor matches in the handle_match function, we encountered a key collision problem. If a function or event had an argument named "signature", its value would overwrite the function/event signature in the template data map. This happened because we were using a flat key-value structure where both the function signature and an argument named "signature" would map to the same key.

For example, with a `function dangerousFunc(bytes32 signature)`:

- The function signature would be mapped to key `function_0_signature`
- The argument named "signature" would also map to `function_0_signature`

We restructured the data format to use a nested JSON structure:

1. Created a clear hierarchy with dot notation paths
2. Separated function/event signatures from their arguments
3. Used a consistent structure across both EVM and Stellar chains
4. The new format provides clear path separation:
5. functions.0.signature for the function signature
6. functions.0.args.signature for an argument named "signature"


## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
- [x] Add integration tests if applicable.
- [x] Add property-based tests if applicable.
- [x] Update documentation if applicable.
