### PR TITLE
chore: Refactor contract spec and minor fixes (breaking)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,14 +225,14 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1802,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -2582,7 +2582,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash 0.8.11",
+ "ahash 0.8.12",
  "allocator-api2",
 ]
 
@@ -2856,21 +2856,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2880,30 +2881,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -2911,65 +2892,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -2991,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -3338,9 +3306,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "local-channel"
@@ -3980,6 +3948,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3991,7 +3968,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.25",
+ "zerocopy",
 ]
 
 [[package]]
@@ -5528,9 +5505,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -5944,12 +5921,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8-width"
@@ -6530,16 +6501,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "ws_stream_wasm"
@@ -6581,9 +6546,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -6593,9 +6558,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6605,31 +6570,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.25",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.101",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -6685,10 +6630,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6697,9 +6653,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -1218,7 +1218,7 @@ A Monitor defines what blockchain activity to watch and what actions to take whe
   "addresses": [
     {
       "address": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-      "abi": [ ... ]
+      "contract_spec": [ ... ]
     }
   ],
   "match_conditions": {

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -204,7 +204,7 @@ This link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/example
   "addresses": [
     {
       "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-      "abi": [
+      "contract_spec": [
         {
           "anonymous": false,
           "inputs": [
@@ -427,7 +427,7 @@ This link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/example
   "addresses": [
     {
      "address": "CA6PUJLBYKZKUEKLZJMKBZLEKP2OTHANDEOWSFF44FTSYLKQPIICCJBE",
-      "abi": [
+      "contract_spec": [
         {
           "function_v0": {
             "doc": "",

--- a/docs/modules/ROOT/pages/scripts.adoc
+++ b/docs/modules/ROOT/pages/scripts.adoc
@@ -69,7 +69,7 @@ Custom filter scripts allow you to apply additional conditions to matches detect
       "monitor": {
         "addresses": [
           {
-            "abi": null,
+            "contract_spec": null,
             "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
           }
         ],
@@ -157,7 +157,7 @@ Custom filter scripts allow you to apply additional conditions to matches detect
         "addresses": [
           {
             "address": "GCXYK...",
-            "abi": null
+            "contract_spec": null
           }
         ],
         "match_conditions": {

--- a/examples/config/monitors/evm_transfer_usdc.json
+++ b/examples/config/monitors/evm_transfer_usdc.json
@@ -5,7 +5,7 @@
   "addresses": [
     {
       "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-      "abi": [
+      "contract_spec": [
         {
           "anonymous": false,
           "inputs": [

--- a/examples/config/monitors/stellar_swap_dex.json
+++ b/examples/config/monitors/stellar_swap_dex.json
@@ -7,7 +7,7 @@
   "addresses": [
     {
       "address": "CA6PUJLBYKZKUEKLZJMKBZLEKP2OTHANDEOWSFF44FTSYLKQPIICCJBE",
-      "abi": [
+      "contract_spec": [
         {
           "function_v0": {
             "doc": "",

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -21,8 +21,8 @@ use tokio::sync::{watch, Mutex};
 
 use crate::{
 	models::{
-		BlockChainType, BlockType, Monitor, MonitorMatch, Network, ProcessedBlock, ScriptLanguage,
-		TriggerConditions,
+		BlockChainType, BlockType, ContractSpec, Monitor, MonitorMatch, Network, ProcessedBlock,
+		ScriptLanguage, TriggerConditions,
 	},
 	repositories::{
 		MonitorRepositoryTrait, MonitorService, NetworkRepositoryTrait, NetworkService,
@@ -30,7 +30,7 @@ use crate::{
 	},
 	services::{
 		blockchain::{BlockChainClient, BlockFilterFactory, ClientPoolTrait},
-		filter::{handle_match, FilterService},
+		filter::{evm_helpers, handle_match, stellar_helpers, FilterService},
 		notification::NotificationService,
 		trigger::{
 			ScriptError, ScriptExecutorFactory, TriggerError, TriggerExecutionService,
@@ -164,11 +164,18 @@ pub fn create_block_handler<P: ClientPoolTrait + 'static>(
 					let matches = match network.network_type {
 						BlockChainType::EVM => match client_pools.get_evm_client(&network).await {
 							Ok(client) => {
+								let contract_specs = get_contract_specs(
+									client.as_ref(),
+									&network,
+									&applicable_monitors,
+								)
+								.await;
 								process_block(
 									client.as_ref(),
 									&network,
 									&block,
 									&applicable_monitors,
+									Some(&contract_specs),
 									&filter_service,
 									&mut shutdown_rx,
 								)
@@ -179,11 +186,18 @@ pub fn create_block_handler<P: ClientPoolTrait + 'static>(
 						BlockChainType::Stellar => {
 							match client_pools.get_stellar_client(&network).await {
 								Ok(client) => {
+									let contract_specs = get_contract_specs(
+										client.as_ref(),
+										&network,
+										&applicable_monitors,
+									)
+									.await;
 									process_block(
 										client.as_ref(),
 										&network,
 										&block,
 										&applicable_monitors,
+										Some(&contract_specs),
 										&filter_service,
 										&mut shutdown_rx,
 									)
@@ -219,6 +233,7 @@ pub async fn process_block<T>(
 	network: &Network,
 	block: &BlockType,
 	applicable_monitors: &[Monitor],
+	contract_specs: Option<&[(String, ContractSpec)]>,
 	filter_service: &FilterService,
 	shutdown_rx: &mut watch::Receiver<bool>,
 ) -> Option<Vec<MonitorMatch>>
@@ -226,12 +241,120 @@ where
 	T: BlockChainClient + BlockFilterFactory<T>,
 {
 	tokio::select! {
-		result = filter_service.filter_block(client, network, block, applicable_monitors) => {
+		result = filter_service.filter_block(client, network, block, applicable_monitors, contract_specs) => {
 			result.ok()
 		}
 		_ = shutdown_rx.changed() => {
 			tracing::info!("Shutting down block processing task");
 			None
+		}
+	}
+}
+
+/// Get contract specs for all applicable monitors
+///
+/// # Arguments
+/// * `client` - The client to use to get the contract specs
+/// * `network` - The network to get the contract specs for
+/// * `monitors` - The monitors to get the contract specs for
+///
+/// # Returns
+/// Returns a vector of contract specs
+pub async fn get_contract_specs<T>(
+	client: &T,
+	network: &Network,
+	monitors: &[Monitor],
+) -> Vec<(String, ContractSpec)>
+where
+	T: BlockChainClient + BlockFilterFactory<T>,
+{
+	match network.network_type {
+		BlockChainType::Stellar => {
+			let mut contract_specs = Vec::new();
+			let mut addresses_without_specs = Vec::new();
+			for monitor in monitors {
+				// First collect addresses that have contract specs configured in the monitor
+				for monitored_addr in &monitor.addresses {
+					if let Some(spec) = &monitored_addr.contract_spec {
+						let parsed_spec = match spec {
+							ContractSpec::Stellar(spec) => spec,
+							_ => {
+								tracing::warn!(
+									"Skipping non-Stellar contract spec for address {}",
+									monitored_addr.address
+								);
+								continue;
+							}
+						};
+
+						contract_specs.push((
+							stellar_helpers::normalize_address(&monitored_addr.address),
+							ContractSpec::Stellar(parsed_spec.clone()),
+						))
+					} else {
+						addresses_without_specs.push(monitored_addr.address.clone());
+					}
+				}
+			}
+
+			// Fetch remaining specs from chain
+			if !addresses_without_specs.is_empty() {
+				let chain_specs = futures::future::join_all(addresses_without_specs.iter().map(
+					|address| async move {
+						let spec = client.get_contract_spec(address).await;
+						(address.clone(), spec)
+					},
+				))
+				.await
+				.into_iter()
+				.filter_map(|(addr, spec)| match spec {
+					Ok(s) => Some((addr, s)),
+					Err(e) => {
+						tracing::warn!(
+							"Failed to fetch contract spec for address {}: {:?}",
+							addr,
+							e
+						);
+						None
+					}
+				})
+				.collect::<Vec<_>>();
+
+				contract_specs.extend(chain_specs);
+			}
+			contract_specs
+		}
+		BlockChainType::EVM => {
+			let mut contract_specs = Vec::new();
+			for monitor in monitors {
+				// First collect addresses that have contract specs configured in the monitor
+				for monitored_addr in &monitor.addresses {
+					if let Some(spec) = &monitored_addr.contract_spec {
+						let parsed_spec = match spec {
+							ContractSpec::EVM(spec) => spec,
+							_ => {
+								tracing::warn!(
+									"Skipping non-EVM contract spec for address {}",
+									monitored_addr.address
+								);
+								continue;
+							}
+						};
+
+						contract_specs.push((
+							format!(
+								"0x{}",
+								evm_helpers::normalize_address(&monitored_addr.address)
+							),
+							ContractSpec::EVM(parsed_spec.clone()),
+						))
+					}
+				}
+			}
+			contract_specs
+		}
+		_ => {
+			vec![]
 		}
 	}
 }

--- a/src/models/blockchain/evm/mod.rs
+++ b/src/models/blockchain/evm/mod.rs
@@ -10,8 +10,8 @@ mod transaction;
 
 pub use block::Block as EVMBlock;
 pub use monitor::{
-	EVMMonitorMatch, MatchArguments as EVMMatchArguments, MatchParamEntry as EVMMatchParamEntry,
-	MatchParamsMap as EVMMatchParamsMap,
+	ContractSpec as EVMContractSpec, EVMMonitorMatch, MatchArguments as EVMMatchArguments,
+	MatchParamEntry as EVMMatchParamEntry, MatchParamsMap as EVMMatchParamsMap,
 };
 pub use receipt::{
 	BaseLog as EVMReceiptLog, BaseReceipt as EVMBaseReceipt,

--- a/src/models/blockchain/evm/monitor.rs
+++ b/src/models/blockchain/evm/monitor.rs
@@ -1,6 +1,5 @@
-use serde::{Deserialize, Serialize};
-
 use crate::models::{EVMTransaction, EVMTransactionReceipt, MatchConditions, Monitor};
+use serde::{Deserialize, Serialize};
 
 /// Result of a successful monitor match on an EVM chain
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -61,4 +60,374 @@ pub struct MatchArguments {
 
 	/// Matched event arguments
 	pub events: Option<Vec<MatchParamsMap>>,
+}
+
+/// Contract specification for an EVM smart contract
+///
+/// This structure represents the parsed specification of an EVM smart contract,
+/// following the Ethereum Contract ABI format. It contains information about all
+/// callable functions in the contract.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+pub struct ContractSpec(alloy::json_abi::JsonAbi);
+
+/// Convert a ContractSpec to an EVMContractSpec
+impl From<crate::models::ContractSpec> for ContractSpec {
+	fn from(spec: crate::models::ContractSpec) -> Self {
+		match spec {
+			crate::models::ContractSpec::EVM(evm_spec) => Self(evm_spec.0),
+			_ => Self(alloy::json_abi::JsonAbi::new()),
+		}
+	}
+}
+
+/// Convert a JsonAbi to a ContractSpec
+impl From<alloy::json_abi::JsonAbi> for ContractSpec {
+	fn from(spec: alloy::json_abi::JsonAbi) -> Self {
+		Self(spec)
+	}
+}
+
+/// Convert a serde_json::Value to a ContractSpec
+impl From<serde_json::Value> for ContractSpec {
+	fn from(spec: serde_json::Value) -> Self {
+		let spec = serde_json::from_value(spec).unwrap_or_else(|e| {
+			tracing::error!("Error parsing contract spec: {:?}", e);
+			alloy::json_abi::JsonAbi::new()
+		});
+		Self(spec)
+	}
+}
+
+/// Display a ContractSpec
+impl std::fmt::Display for ContractSpec {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match serde_json::to_string(self) {
+			Ok(s) => write!(f, "{}", s),
+			Err(e) => {
+				tracing::error!("Error serializing contract spec: {:?}", e);
+				write!(f, "")
+			}
+		}
+	}
+}
+
+/// Dereference a ContractSpec
+impl std::ops::Deref for ContractSpec {
+	type Target = alloy::json_abi::JsonAbi;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::{
+		models::{ContractSpec as ModelsContractSpec, FunctionCondition, StellarContractSpec},
+		utils::tests::evm::{
+			monitor::MonitorBuilder, receipt::ReceiptBuilder, transaction::TransactionBuilder,
+		},
+	};
+
+	use super::*;
+	use alloy::primitives::{Address, B256, U256, U64};
+
+	#[test]
+	fn test_evm_monitor_match() {
+		let monitor = MonitorBuilder::new()
+			.name("TestMonitor")
+			.function("transfer(address,uint256)", None)
+			.build();
+
+		let transaction = TransactionBuilder::new()
+			.hash(B256::with_last_byte(1))
+			.nonce(U256::from(1))
+			.from(Address::ZERO)
+			.to(Address::ZERO)
+			.value(U256::ZERO)
+			.gas_price(U256::from(20))
+			.gas_limit(U256::from(21000))
+			.build();
+
+		let receipt = ReceiptBuilder::new()
+			.transaction_hash(B256::with_last_byte(1))
+			.transaction_index(0)
+			.from(Address::ZERO)
+			.to(Address::ZERO)
+			.gas_used(U256::from(21000))
+			.status(true)
+			.build();
+
+		let match_params = MatchParamsMap {
+			signature: "transfer(address,uint256)".to_string(),
+			args: Some(vec![
+				MatchParamEntry {
+					name: "to".to_string(),
+					value: "0x0000000000000000000000000000000000000000".to_string(),
+					kind: "address".to_string(),
+					indexed: false,
+				},
+				MatchParamEntry {
+					name: "amount".to_string(),
+					value: "1000000000000000000".to_string(),
+					kind: "uint256".to_string(),
+					indexed: false,
+				},
+			]),
+			hex_signature: Some("0xa9059cbb".to_string()),
+		};
+
+		let monitor_match = EVMMonitorMatch {
+			monitor: monitor.clone(),
+			transaction: transaction.clone(),
+			receipt: receipt.clone(),
+			network_slug: "ethereum_mainnet".to_string(),
+			matched_on: MatchConditions {
+				functions: vec![FunctionCondition {
+					signature: "transfer(address,uint256)".to_string(),
+					expression: None,
+				}],
+				events: vec![],
+				transactions: vec![],
+			},
+			matched_on_args: Some(MatchArguments {
+				functions: Some(vec![match_params]),
+				events: None,
+			}),
+		};
+
+		assert_eq!(monitor_match.monitor.name, "TestMonitor");
+		assert_eq!(monitor_match.transaction.hash, B256::with_last_byte(1));
+		assert_eq!(monitor_match.receipt.status, Some(U64::from(1)));
+		assert_eq!(monitor_match.network_slug, "ethereum_mainnet");
+		assert_eq!(monitor_match.matched_on.functions.len(), 1);
+		assert_eq!(
+			monitor_match.matched_on.functions[0].signature,
+			"transfer(address,uint256)"
+		);
+
+		let matched_args = monitor_match.matched_on_args.unwrap();
+		let function_args = matched_args.functions.unwrap();
+		assert_eq!(function_args.len(), 1);
+		assert_eq!(function_args[0].signature, "transfer(address,uint256)");
+		assert_eq!(
+			function_args[0].hex_signature,
+			Some("0xa9059cbb".to_string())
+		);
+
+		let args = function_args[0].args.as_ref().unwrap();
+		assert_eq!(args.len(), 2);
+		assert_eq!(args[0].name, "to");
+		assert_eq!(args[0].kind, "address");
+		assert_eq!(args[1].name, "amount");
+		assert_eq!(args[1].kind, "uint256");
+	}
+
+	#[test]
+	fn test_match_arguments() {
+		let from_addr = Address::ZERO;
+		let to_addr = Address::with_last_byte(1);
+		let amount = U256::from(1000000000000000000u64);
+
+		let match_args = MatchArguments {
+			functions: Some(vec![MatchParamsMap {
+				signature: "transfer(address,uint256)".to_string(),
+				args: Some(vec![
+					MatchParamEntry {
+						name: "to".to_string(),
+						value: format!("{:#x}", to_addr),
+						kind: "address".to_string(),
+						indexed: false,
+					},
+					MatchParamEntry {
+						name: "amount".to_string(),
+						value: amount.to_string(),
+						kind: "uint256".to_string(),
+						indexed: false,
+					},
+				]),
+				hex_signature: Some("0xa9059cbb".to_string()),
+			}]),
+			events: Some(vec![MatchParamsMap {
+				signature: "Transfer(address,address,uint256)".to_string(),
+				args: Some(vec![
+					MatchParamEntry {
+						name: "from".to_string(),
+						value: format!("{:#x}", from_addr),
+						kind: "address".to_string(),
+						indexed: true,
+					},
+					MatchParamEntry {
+						name: "to".to_string(),
+						value: format!("{:#x}", to_addr),
+						kind: "address".to_string(),
+						indexed: true,
+					},
+					MatchParamEntry {
+						name: "amount".to_string(),
+						value: amount.to_string(),
+						kind: "uint256".to_string(),
+						indexed: false,
+					},
+				]),
+				hex_signature: Some(
+					"0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+						.to_string(),
+				),
+			}]),
+		};
+
+		assert!(match_args.functions.is_some());
+		let functions = match_args.functions.unwrap();
+		assert_eq!(functions.len(), 1);
+		assert_eq!(functions[0].signature, "transfer(address,uint256)");
+		assert_eq!(functions[0].hex_signature, Some("0xa9059cbb".to_string()));
+
+		let function_args = functions[0].args.as_ref().unwrap();
+		assert_eq!(function_args.len(), 2);
+		assert_eq!(function_args[0].name, "to");
+		assert_eq!(function_args[0].kind, "address");
+		assert_eq!(function_args[1].name, "amount");
+		assert_eq!(function_args[1].kind, "uint256");
+
+		assert!(match_args.events.is_some());
+		let events = match_args.events.unwrap();
+		assert_eq!(events.len(), 1);
+		assert_eq!(events[0].signature, "Transfer(address,address,uint256)");
+		assert_eq!(
+			events[0].hex_signature,
+			Some("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef".to_string())
+		);
+
+		let event_args = events[0].args.as_ref().unwrap();
+		assert_eq!(event_args.len(), 3);
+		assert_eq!(event_args[0].name, "from");
+		assert!(event_args[0].indexed);
+		assert_eq!(event_args[1].name, "to");
+		assert!(event_args[1].indexed);
+		assert_eq!(event_args[2].name, "amount");
+		assert!(!event_args[2].indexed);
+	}
+
+	#[test]
+	fn test_contract_spec_from_json() {
+		let json_value = serde_json::json!([{
+			"type": "function",
+			"name": "transfer",
+			"inputs": [
+				{
+					"name": "to",
+					"type": "address",
+					"internalType": "address"
+				},
+				{
+					"name": "amount",
+					"type": "uint256",
+					"internalType": "uint256"
+				}
+			],
+			"outputs": [],
+			"stateMutability": "nonpayable"
+		}]);
+
+		let contract_spec = ContractSpec::from(json_value);
+		let functions: Vec<_> = contract_spec.0.functions().collect();
+		assert!(!functions.is_empty());
+
+		let function = &functions[0];
+		assert_eq!(function.name, "transfer");
+		assert_eq!(function.inputs.len(), 2);
+		assert_eq!(function.inputs[0].name, "to");
+		assert_eq!(function.inputs[0].ty, "address");
+		assert_eq!(function.inputs[1].name, "amount");
+		assert_eq!(function.inputs[1].ty, "uint256");
+	}
+
+	#[test]
+	fn test_contract_spec_from_invalid_json() {
+		let invalid_json = serde_json::json!({
+			"invalid": "data"
+		});
+
+		let contract_spec = ContractSpec::from(invalid_json);
+		assert!(contract_spec.0.functions.is_empty());
+	}
+
+	#[test]
+	fn test_contract_spec_display() {
+		let json_value = serde_json::json!([{
+			"type": "function",
+			"name": "transfer",
+			"inputs": [
+				{
+					"name": "to",
+					"type": "address",
+					"internalType": "address"
+				}
+			],
+			"outputs": [],
+			"stateMutability": "nonpayable"
+		}]);
+
+		let contract_spec = ContractSpec::from(json_value);
+		let display_str = format!("{}", contract_spec);
+		assert!(!display_str.is_empty());
+		assert!(display_str.contains("transfer"));
+		assert!(display_str.contains("address"));
+	}
+
+	#[test]
+	fn test_contract_spec_deref() {
+		let json_value = serde_json::json!([{
+			"type": "function",
+			"name": "transfer",
+			"inputs": [
+				{
+					"name": "to",
+					"type": "address",
+					"internalType": "address"
+				}
+			],
+			"outputs": [],
+			"stateMutability": "nonpayable"
+		}]);
+
+		let contract_spec = ContractSpec::from(json_value);
+		let functions: Vec<_> = contract_spec.functions().collect();
+		assert!(!functions.is_empty());
+		assert_eq!(functions[0].name, "transfer");
+	}
+
+	#[test]
+	fn test_contract_spec_from_models() {
+		let json_value = serde_json::json!([{
+			"type": "function",
+			"name": "transfer",
+			"inputs": [
+				{
+					"name": "to",
+					"type": "address",
+					"internalType": "address"
+				}
+			],
+			"outputs": [],
+			"stateMutability": "nonpayable"
+		}]);
+
+		let evm_spec = ContractSpec::from(json_value.clone());
+		let models_spec = ModelsContractSpec::EVM(evm_spec);
+		let converted_spec = ContractSpec::from(models_spec);
+
+		let functions: Vec<_> = converted_spec.functions().collect();
+		assert!(!functions.is_empty());
+		assert_eq!(functions[0].name, "transfer");
+		assert_eq!(functions[0].inputs.len(), 1);
+		assert_eq!(functions[0].inputs[0].name, "to");
+		assert_eq!(functions[0].inputs[0].ty, "address");
+
+		let stellar_spec = StellarContractSpec::from(vec![]);
+		let models_spec = ModelsContractSpec::Stellar(stellar_spec);
+		let converted_spec = ContractSpec::from(models_spec);
+		assert!(converted_spec.is_empty());
+	}
 }

--- a/src/models/blockchain/mod.rs
+++ b/src/models/blockchain/mod.rs
@@ -55,6 +55,16 @@ pub enum TransactionType {
 	Stellar(stellar::StellarTransaction),
 }
 
+/// Contract spec from different blockchain platforms
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum ContractSpec {
+	/// EVM contract spec
+	EVM(evm::EVMContractSpec),
+	/// Stellar contract spec
+	Stellar(stellar::StellarContractSpec),
+}
+
 /// Monitor match results from different blockchain platforms
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum MonitorMatch {

--- a/src/models/blockchain/stellar/mod.rs
+++ b/src/models/blockchain/stellar/mod.rs
@@ -14,9 +14,9 @@ pub use event::Event as StellarEvent;
 pub use monitor::{
 	ContractFunction as StellarContractFunction, ContractInput as StellarContractInput,
 	ContractSpec as StellarContractSpec, DecodedParamEntry as StellarDecodedParamEntry,
-	MatchArguments as StellarMatchArguments, MatchParamEntry as StellarMatchParamEntry,
-	MatchParamsMap as StellarMatchParamsMap, MonitorMatch as StellarMonitorMatch,
-	ParsedOperationResult as StellarParsedOperationResult,
+	FormattedContractSpec as StellarFormattedContractSpec, MatchArguments as StellarMatchArguments,
+	MatchParamEntry as StellarMatchParamEntry, MatchParamsMap as StellarMatchParamsMap,
+	MonitorMatch as StellarMonitorMatch, ParsedOperationResult as StellarParsedOperationResult,
 };
 pub use transaction::{
 	DecodedTransaction as StellarDecodedTransaction, Transaction as StellarTransaction,

--- a/src/models/blockchain/stellar/monitor.rs
+++ b/src/models/blockchain/stellar/monitor.rs
@@ -2,8 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use stellar_xdr::curr::ScSpecEntry;
 
-use crate::models::{MatchConditions, Monitor, StellarBlock, StellarTransaction};
+use crate::{
+	models::{MatchConditions, Monitor, StellarBlock, StellarTransaction},
+	services::filter::stellar_helpers::{
+		get_contract_spec_functions, get_contract_spec_with_function_input_parameters,
+	},
+};
 
 /// Result of a successful monitor match on a Stellar chain
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -96,16 +102,85 @@ pub struct DecodedParamEntry {
 	pub indexed: bool,
 }
 
-/// Contract specification for a Stellar smart contract
+/// Raw contract specification for a Stellar smart contract
 ///
-/// This structure represents the parsed specification of a Stellar smart contract,
-/// following the Stellar Contract ABI format. It contains information about all
-/// callable functions in the contract, similar to Ethereum's ABI but in Stellar's format.
-/// The spec is typically extracted from a contract's WASM bytecode.
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
-pub struct ContractSpec {
+/// This structure represents the native Stellar contract specification format, derived directly
+/// from ScSpecEntry. It contains the raw contract interface data as provided by the Stellar
+/// blockchain, including all function definitions, types, and other contract metadata in their
+/// original format.
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+pub struct ContractSpec(Vec<ScSpecEntry>);
+
+impl From<Vec<ScSpecEntry>> for ContractSpec {
+	fn from(spec: Vec<ScSpecEntry>) -> Self {
+		ContractSpec(spec)
+	}
+}
+
+/// Convert a ContractSpec to a StellarContractSpec
+impl From<crate::models::ContractSpec> for ContractSpec {
+	fn from(spec: crate::models::ContractSpec) -> Self {
+		match spec {
+			crate::models::ContractSpec::Stellar(stellar_spec) => Self(stellar_spec.0),
+			_ => Self(Vec::new()),
+		}
+	}
+}
+
+/// Convert a serde_json::Value to a StellarContractSpec
+impl From<serde_json::Value> for ContractSpec {
+	fn from(spec: serde_json::Value) -> Self {
+		let spec = serde_json::from_value(spec).unwrap_or_else(|e| {
+			tracing::error!("Error parsing contract spec: {:?}", e);
+			Vec::new()
+		});
+		Self(spec)
+	}
+}
+
+/// Display a StellarContractSpec
+impl std::fmt::Display for ContractSpec {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match serde_json::to_string(self) {
+			Ok(s) => write!(f, "{}", s),
+			Err(e) => {
+				tracing::error!("Error serializing contract spec: {:?}", e);
+				write!(f, "")
+			}
+		}
+	}
+}
+
+/// Dereference a StellarContractSpec
+impl std::ops::Deref for ContractSpec {
+	type Target = Vec<ScSpecEntry>;
+
+	fn deref(&self) -> &Self::Target {
+		&self.0
+	}
+}
+
+/// Human-readable contract specification for a Stellar smart contract
+///
+/// This structure provides a simplified, application-specific view of a Stellar contract's
+/// interface. It transforms the raw ContractSpec into a more accessible format that's easier
+/// to work with in our monitoring system. The main differences are:
+/// - Focuses on callable functions with their input parameters
+/// - Provides a cleaner, more structured representation
+/// - Optimized for our specific use case of monitoring contract interactions
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
+pub struct FormattedContractSpec {
 	/// List of callable functions defined in the contract
 	pub functions: Vec<ContractFunction>,
+}
+
+impl From<ContractSpec> for FormattedContractSpec {
+	fn from(spec: ContractSpec) -> Self {
+		let functions =
+			get_contract_spec_with_function_input_parameters(get_contract_spec_functions(spec.0));
+
+		FormattedContractSpec { functions }
+	}
 }
 
 /// Function definition within a Stellar contract specification
@@ -125,7 +200,7 @@ pub struct ContractSpec {
 ///     "signature": "transfer(Address,U64)"
 /// }
 /// ```
-#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
 pub struct ContractFunction {
 	/// Name of the function as defined in the contract
 	pub name: String,
@@ -146,7 +221,7 @@ pub struct ContractFunction {
 /// # Type Examples
 /// - Basic types: "U64", "I64", "Address", "Bool", "String"
 /// - Complex types: "Vec<Address>", "Map<String,U64>", "Bytes32"
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Default)]
 pub struct ContractInput {
 	/// Zero-based index of the parameter in the function signature
 	pub index: u32,
@@ -156,4 +231,479 @@ pub struct ContractInput {
 
 	/// Parameter type in Stellar's type system format
 	pub kind: String,
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::models::EVMContractSpec;
+	use crate::models::{
+		blockchain::stellar::block::LedgerInfo as StellarLedgerInfo,
+		blockchain::stellar::transaction::TransactionInfo as StellarTransactionInfo,
+		ContractSpec as ModelsContractSpec, FunctionCondition, MatchConditions,
+	};
+	use crate::utils::tests::builders::stellar::monitor::MonitorBuilder;
+	use serde_json::json;
+	use stellar_xdr::curr::{ScSpecEntry, ScSpecFunctionInputV0, ScSpecFunctionV0, ScSpecTypeDef};
+
+	#[test]
+	fn test_contract_spec_from_vec() {
+		let spec_entries = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+			name: "test_function".try_into().unwrap(),
+			inputs: vec![].try_into().unwrap(),
+			outputs: vec![].try_into().unwrap(),
+			doc: "Test function documentation".try_into().unwrap(),
+		})];
+
+		let contract_spec = ContractSpec::from(spec_entries.clone());
+		assert_eq!(contract_spec.0, spec_entries);
+	}
+
+	#[test]
+	fn test_contract_spec_from_json() {
+		let json_value = serde_json::json!([
+			{
+				"function_v0": {
+					"doc": "Test function documentation",
+					"name": "test_function",
+					"inputs": [
+						{
+							"doc": "",
+							"name": "from",
+							"type_": "address"
+						},
+						{
+							"doc": "",
+							"name": "to",
+							"type_": "address"
+						},
+						{
+							"doc": "",
+							"name": "amount",
+							"type_": "i128"
+						}
+					],
+					"outputs": []
+				}
+			},
+		]);
+
+		let contract_spec = ContractSpec::from(json_value);
+		assert!(!contract_spec.0.is_empty());
+		if let ScSpecEntry::FunctionV0(func) = &contract_spec.0[0] {
+			assert_eq!(func.name.to_string(), "test_function");
+			assert_eq!(func.doc.to_string(), "Test function documentation");
+		} else {
+			panic!("Expected FunctionV0 entry");
+		}
+	}
+
+	#[test]
+	fn test_contract_spec_from_invalid_json() {
+		let invalid_json = serde_json::json!({
+			"invalid": "data"
+		});
+
+		let contract_spec = ContractSpec::from(invalid_json);
+		assert!(contract_spec.0.is_empty());
+	}
+
+	#[test]
+	fn test_formatted_contract_spec_from_contract_spec() {
+		let spec_entries = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+			name: "transfer".try_into().unwrap(),
+			inputs: vec![
+				ScSpecFunctionInputV0 {
+					name: "to".try_into().unwrap(),
+					type_: ScSpecTypeDef::Address,
+					doc: "Recipient address".try_into().unwrap(),
+				},
+				ScSpecFunctionInputV0 {
+					name: "amount".try_into().unwrap(),
+					type_: ScSpecTypeDef::U64,
+					doc: "Amount to transfer".try_into().unwrap(),
+				},
+			]
+			.try_into()
+			.unwrap(),
+			outputs: vec![].try_into().unwrap(),
+			doc: "Transfer function documentation".try_into().unwrap(),
+		})];
+
+		let contract_spec = ContractSpec(spec_entries);
+		let formatted_spec = FormattedContractSpec::from(contract_spec);
+
+		assert_eq!(formatted_spec.functions.len(), 1);
+		let function = &formatted_spec.functions[0];
+		assert_eq!(function.name, "transfer");
+		assert_eq!(function.inputs.len(), 2);
+		assert_eq!(function.inputs[0].name, "to");
+		assert_eq!(function.inputs[0].kind, "Address");
+		assert_eq!(function.inputs[1].name, "amount");
+		assert_eq!(function.inputs[1].kind, "U64");
+		assert_eq!(function.signature, "transfer(Address,U64)");
+	}
+
+	#[test]
+	fn test_contract_spec_display() {
+		let spec_entries = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+			name: "test_function".try_into().unwrap(),
+			inputs: vec![].try_into().unwrap(),
+			outputs: vec![].try_into().unwrap(),
+			doc: "Test function documentation".try_into().unwrap(),
+		})];
+
+		let contract_spec = ContractSpec(spec_entries);
+		let display_str = format!("{}", contract_spec);
+		assert!(!display_str.is_empty());
+		assert!(display_str.contains("test_function"));
+	}
+
+	#[test]
+	fn test_contract_spec_with_multiple_functions() {
+		let spec_entries = vec![
+			ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+				name: "transfer".try_into().unwrap(),
+				inputs: vec![
+					ScSpecFunctionInputV0 {
+						name: "to".try_into().unwrap(),
+						type_: ScSpecTypeDef::Address,
+						doc: "Recipient address".try_into().unwrap(),
+					},
+					ScSpecFunctionInputV0 {
+						name: "amount".try_into().unwrap(),
+						type_: ScSpecTypeDef::U64,
+						doc: "Amount to transfer".try_into().unwrap(),
+					},
+				]
+				.try_into()
+				.unwrap(),
+				outputs: vec![].try_into().unwrap(),
+				doc: "Transfer function".try_into().unwrap(),
+			}),
+			ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+				name: "balance".try_into().unwrap(),
+				inputs: vec![ScSpecFunctionInputV0 {
+					name: "account".try_into().unwrap(),
+					type_: ScSpecTypeDef::Address,
+					doc: "Account to check balance for".try_into().unwrap(),
+				}]
+				.try_into()
+				.unwrap(),
+				outputs: vec![ScSpecTypeDef::U64].try_into().unwrap(),
+				doc: "Balance function".try_into().unwrap(),
+			}),
+		];
+
+		let contract_spec = ContractSpec(spec_entries);
+		let formatted_spec = FormattedContractSpec::from(contract_spec);
+
+		assert_eq!(formatted_spec.functions.len(), 2);
+
+		let transfer_fn = formatted_spec
+			.functions
+			.iter()
+			.find(|f| f.name == "transfer")
+			.expect("Transfer function not found");
+		assert_eq!(transfer_fn.signature, "transfer(Address,U64)");
+
+		let balance_fn = formatted_spec
+			.functions
+			.iter()
+			.find(|f| f.name == "balance")
+			.expect("Balance function not found");
+		assert_eq!(balance_fn.signature, "balance(Address)");
+	}
+
+	#[test]
+	fn test_monitor_match() {
+		let monitor = MonitorBuilder::new()
+			.name("TestMonitor")
+			.function("transfer(address,uint256)", None)
+			.build();
+
+		let transaction = StellarTransaction(StellarTransactionInfo {
+			status: "SUCCESS".to_string(),
+			transaction_hash: "test_hash".to_string(),
+			application_order: 1,
+			fee_bump: false,
+			envelope_xdr: Some("mock_xdr".to_string()),
+			envelope_json: Some(serde_json::json!({
+				"type": "ENVELOPE_TYPE_TX",
+				"tx": {
+					"sourceAccount": "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+					"operations": [{
+						"type": "invokeHostFunction",
+						"function": "transfer",
+						"parameters": ["GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF", "1000000"]
+					}]
+				}
+			})),
+			result_xdr: Some("mock_result".to_string()),
+			result_json: None,
+			result_meta_xdr: Some("mock_meta".to_string()),
+			result_meta_json: None,
+			diagnostic_events_xdr: None,
+			diagnostic_events_json: None,
+			ledger: 123,
+			ledger_close_time: 1234567890,
+			decoded: None,
+		});
+
+		let ledger = StellarBlock(StellarLedgerInfo {
+			hash: "test_ledger_hash".to_string(),
+			sequence: 123,
+			ledger_close_time: "2024-03-20T12:00:00Z".to_string(),
+			ledger_header: "mock_header".to_string(),
+			ledger_header_json: None,
+			ledger_metadata: "mock_metadata".to_string(),
+			ledger_metadata_json: None,
+		});
+
+		let match_params = MatchParamsMap {
+			signature: "transfer(address,uint256)".to_string(),
+			args: Some(vec![
+				MatchParamEntry {
+					name: "to".to_string(),
+					value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF".to_string(),
+					kind: "Address".to_string(),
+					indexed: false,
+				},
+				MatchParamEntry {
+					name: "amount".to_string(),
+					value: "1000000".to_string(),
+					kind: "U64".to_string(),
+					indexed: false,
+				},
+			]),
+		};
+
+		let monitor_match = MonitorMatch {
+			monitor: monitor.clone(),
+			transaction: transaction.clone(),
+			ledger: ledger.clone(),
+			network_slug: "stellar_mainnet".to_string(),
+			matched_on: MatchConditions {
+				functions: vec![FunctionCondition {
+					signature: "transfer(address,uint256)".to_string(),
+					expression: None,
+				}],
+				events: vec![],
+				transactions: vec![],
+			},
+			matched_on_args: Some(MatchArguments {
+				functions: Some(vec![match_params]),
+				events: None,
+			}),
+		};
+
+		assert_eq!(monitor_match.monitor.name, "TestMonitor");
+		assert_eq!(monitor_match.transaction.transaction_hash, "test_hash");
+		assert_eq!(monitor_match.ledger.sequence, 123);
+		assert_eq!(monitor_match.network_slug, "stellar_mainnet");
+		assert_eq!(monitor_match.matched_on.functions.len(), 1);
+		assert_eq!(
+			monitor_match.matched_on.functions[0].signature,
+			"transfer(address,uint256)"
+		);
+
+		let matched_args = monitor_match.matched_on_args.unwrap();
+		let function_args = matched_args.functions.unwrap();
+		assert_eq!(function_args.len(), 1);
+		assert_eq!(function_args[0].signature, "transfer(address,uint256)");
+
+		let args = function_args[0].args.as_ref().unwrap();
+		assert_eq!(args.len(), 2);
+		assert_eq!(args[0].name, "to");
+		assert_eq!(args[0].kind, "Address");
+		assert_eq!(args[1].name, "amount");
+		assert_eq!(args[1].kind, "U64");
+	}
+
+	#[test]
+	fn test_parsed_operation_result() {
+		let result = ParsedOperationResult {
+			contract_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+				.to_string(),
+			function_name: "transfer".to_string(),
+			function_signature: "transfer(address,uint256)".to_string(),
+			arguments: vec![
+				serde_json::json!("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"),
+				serde_json::json!("1000000"),
+			],
+		};
+
+		assert_eq!(
+			result.contract_address,
+			"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+		);
+		assert_eq!(result.function_name, "transfer");
+		assert_eq!(result.function_signature, "transfer(address,uint256)");
+		assert_eq!(result.arguments.len(), 2);
+		assert_eq!(
+			result.arguments[0],
+			"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+		);
+		assert_eq!(result.arguments[1], "1000000");
+	}
+
+	#[test]
+	fn test_decoded_param_entry() {
+		let param = DecodedParamEntry {
+			value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF".to_string(),
+			kind: "Address".to_string(),
+			indexed: false,
+		};
+
+		assert_eq!(
+			param.value,
+			"GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+		);
+		assert_eq!(param.kind, "Address");
+		assert!(!param.indexed);
+	}
+
+	#[test]
+	fn test_match_arguments() {
+		let match_args = MatchArguments {
+			functions: Some(vec![MatchParamsMap {
+				signature: "transfer(address,uint256)".to_string(),
+				args: Some(vec![
+					MatchParamEntry {
+						name: "to".to_string(),
+						value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+							.to_string(),
+						kind: "Address".to_string(),
+						indexed: false,
+					},
+					MatchParamEntry {
+						name: "amount".to_string(),
+						value: "1000000".to_string(),
+						kind: "U64".to_string(),
+						indexed: false,
+					},
+				]),
+			}]),
+			events: Some(vec![MatchParamsMap {
+				signature: "Transfer(address,address,uint256)".to_string(),
+				args: Some(vec![
+					MatchParamEntry {
+						name: "from".to_string(),
+						value: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+							.to_string(),
+						kind: "Address".to_string(),
+						indexed: true,
+					},
+					MatchParamEntry {
+						name: "to".to_string(),
+						value: "GBXGQJWVLWOYHFLVTKWV5FGHA3LNYY2JQKM7OAJAUEQFU6LPCSEFVXON"
+							.to_string(),
+						kind: "Address".to_string(),
+						indexed: true,
+					},
+					MatchParamEntry {
+						name: "amount".to_string(),
+						value: "1000000".to_string(),
+						kind: "U64".to_string(),
+						indexed: false,
+					},
+				]),
+			}]),
+		};
+
+		assert!(match_args.functions.is_some());
+		let functions = match_args.functions.unwrap();
+		assert_eq!(functions.len(), 1);
+		assert_eq!(functions[0].signature, "transfer(address,uint256)");
+
+		let function_args = functions[0].args.as_ref().unwrap();
+		assert_eq!(function_args.len(), 2);
+		assert_eq!(function_args[0].name, "to");
+		assert_eq!(function_args[0].kind, "Address");
+		assert_eq!(function_args[1].name, "amount");
+		assert_eq!(function_args[1].kind, "U64");
+
+		assert!(match_args.events.is_some());
+		let events = match_args.events.unwrap();
+		assert_eq!(events.len(), 1);
+		assert_eq!(events[0].signature, "Transfer(address,address,uint256)");
+
+		let event_args = events[0].args.as_ref().unwrap();
+		assert_eq!(event_args.len(), 3);
+		assert_eq!(event_args[0].name, "from");
+		assert!(event_args[0].indexed);
+		assert_eq!(event_args[1].name, "to");
+		assert!(event_args[1].indexed);
+		assert_eq!(event_args[2].name, "amount");
+		assert!(!event_args[2].indexed);
+	}
+
+	#[test]
+	fn test_contract_spec_deref() {
+		let spec_entries = vec![ScSpecEntry::FunctionV0(ScSpecFunctionV0 {
+			name: "transfer".try_into().unwrap(),
+			inputs: vec![].try_into().unwrap(),
+			outputs: vec![].try_into().unwrap(),
+			doc: "Test function documentation".try_into().unwrap(),
+		})];
+
+		let contract_spec = ContractSpec(spec_entries.clone());
+		assert_eq!(contract_spec.len(), 1);
+		if let ScSpecEntry::FunctionV0(func) = &contract_spec[0] {
+			assert_eq!(func.name.to_string(), "transfer");
+		} else {
+			panic!("Expected FunctionV0 entry");
+		}
+	}
+
+	#[test]
+	fn test_contract_spec_from_models() {
+		let json_value = serde_json::json!([
+				{
+					"function_v0": {
+						"doc": "",
+						"name": "transfer",
+						"inputs": [
+							{
+								"doc": "",
+								"name": "from",
+								"type_": "address"
+							},
+							{
+								"doc": "",
+								"name": "to",
+								"type_": "address"
+							},
+							{
+								"doc": "",
+								"name": "amount",
+								"type_": "i128"
+							}
+						],
+						"outputs": []
+					}
+				},
+			]
+		);
+
+		let stellar_spec = ContractSpec::from(json_value.clone());
+		let models_spec = ModelsContractSpec::Stellar(stellar_spec);
+		let converted_spec = ContractSpec::from(models_spec);
+		let formatted_spec = FormattedContractSpec::from(converted_spec);
+
+		assert!(!formatted_spec.functions.is_empty());
+		assert_eq!(formatted_spec.functions[0].name, "transfer");
+		assert_eq!(formatted_spec.functions[0].inputs.len(), 3);
+		assert_eq!(formatted_spec.functions[0].inputs[0].name, "from");
+		assert_eq!(formatted_spec.functions[0].inputs[0].kind, "Address");
+		assert_eq!(formatted_spec.functions[0].inputs[1].name, "to");
+		assert_eq!(formatted_spec.functions[0].inputs[1].kind, "Address");
+		assert_eq!(formatted_spec.functions[0].inputs[2].name, "amount");
+		assert_eq!(formatted_spec.functions[0].inputs[2].kind, "I128");
+
+		let evm_spec = EVMContractSpec::from(json!({}));
+		let models_spec = ModelsContractSpec::EVM(evm_spec);
+		let converted_spec = ContractSpec::from(models_spec);
+		assert!(converted_spec.is_empty());
+	}
 }

--- a/src/models/config/monitor_config.rs
+++ b/src/models/config/monitor_config.rs
@@ -225,7 +225,7 @@ mod tests {
 			"addresses": [
 				{
 					"address": "0x0000000000000000000000000000000000000000",
-					"abi": null
+					"contract_spec": null
 				}
 			],
             "description": "Test monitor configuration",
@@ -289,7 +289,7 @@ mod tests {
 			"addresses": [
 				{
 					"address": "0x0000000000000000000000000000000000000000",
-					"abi": null
+					"contract_spec": null
 				}
 			],
             "description": "Test monitor configuration",
@@ -318,7 +318,7 @@ mod tests {
 			"addresses": [
 				{
 					"address": "0x0000000000000000000000000000000000000000",
-					"abi": null
+					"contract_spec": null
 				}
 			],
             "description": "Test monitor configuration",

--- a/src/models/config/trigger_config.rs
+++ b/src/models/config/trigger_config.rs
@@ -180,7 +180,9 @@ impl ConfigLoader for Trigger {
 					})?;
 
 				// Validate each trigger before adding it
-				for (name, trigger) in file_triggers.triggers {
+				for (name, mut trigger) in file_triggers.triggers {
+					// Resolve secrets before validating
+					trigger = trigger.resolve_secrets().await?;
 					if let Err(validation_error) = trigger.validate() {
 						return Err(ConfigError::validation_error(
 							format!(

--- a/src/models/core/mod.rs
+++ b/src/models/core/mod.rs
@@ -10,7 +10,7 @@ mod network;
 mod trigger;
 
 pub use monitor::{
-	AddressWithABI, EventCondition, FunctionCondition, MatchConditions, Monitor, ScriptLanguage,
+	AddressWithSpec, EventCondition, FunctionCondition, MatchConditions, Monitor, ScriptLanguage,
 	TransactionCondition, TransactionStatus, TriggerConditions,
 };
 pub use network::{Network, RpcUrl};

--- a/src/models/core/monitor.rs
+++ b/src/models/core/monitor.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::models::blockchain::ContractSpec;
+
 /// Configuration for monitoring specific blockchain activity.
 ///
 /// A Monitor defines what blockchain activity to watch for through a combination of:
@@ -20,8 +22,8 @@ pub struct Monitor {
 	/// Whether this monitor is currently paused
 	pub paused: bool,
 
-	/// Contract addresses to monitor, optionally with their ABIs
-	pub addresses: Vec<AddressWithABI>,
+	/// Contract addresses to monitor, optionally with their contract specs
+	pub addresses: Vec<AddressWithSpec>,
 
 	/// Conditions that should trigger this monitor
 	pub match_conditions: MatchConditions,
@@ -35,12 +37,12 @@ pub struct Monitor {
 
 /// Contract address with optional ABI for decoding transactions and events
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
-pub struct AddressWithABI {
+pub struct AddressWithSpec {
 	/// Contract address in the network's native format
 	pub address: String,
 
-	/// Optional ABI for decoding contract interactions
-	pub abi: Option<serde_json::Value>,
+	/// Optional contract spec for decoding contract interactions
+	pub contract_spec: Option<ContractSpec>,
 }
 
 /// Collection of conditions that can trigger a monitor

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -13,23 +13,27 @@ mod core;
 mod security;
 
 // Re-export blockchain types
-pub use blockchain::{BlockChainType, BlockType, MonitorMatch, ProcessedBlock, TransactionType};
+pub use blockchain::{
+	BlockChainType, BlockType, ContractSpec, MonitorMatch, ProcessedBlock, TransactionType,
+};
 
 pub use blockchain::evm::{
-	EVMBaseReceipt, EVMBaseTransaction, EVMBlock, EVMMatchArguments, EVMMatchParamEntry,
-	EVMMatchParamsMap, EVMMonitorMatch, EVMReceiptLog, EVMTransaction, EVMTransactionReceipt,
+	EVMBaseReceipt, EVMBaseTransaction, EVMBlock, EVMContractSpec, EVMMatchArguments,
+	EVMMatchParamEntry, EVMMatchParamsMap, EVMMonitorMatch, EVMReceiptLog, EVMTransaction,
+	EVMTransactionReceipt,
 };
 
 pub use blockchain::stellar::{
 	StellarBlock, StellarContractFunction, StellarContractInput, StellarContractSpec,
-	StellarDecodedParamEntry, StellarDecodedTransaction, StellarEvent, StellarLedgerInfo,
-	StellarMatchArguments, StellarMatchParamEntry, StellarMatchParamsMap, StellarMonitorMatch,
-	StellarParsedOperationResult, StellarTransaction, StellarTransactionInfo,
+	StellarDecodedParamEntry, StellarDecodedTransaction, StellarEvent,
+	StellarFormattedContractSpec, StellarLedgerInfo, StellarMatchArguments, StellarMatchParamEntry,
+	StellarMatchParamsMap, StellarMonitorMatch, StellarParsedOperationResult, StellarTransaction,
+	StellarTransactionInfo,
 };
 
 // Re-export core types
 pub use core::{
-	AddressWithABI, EventCondition, FunctionCondition, MatchConditions, Monitor, Network,
+	AddressWithSpec, EventCondition, FunctionCondition, MatchConditions, Monitor, Network,
 	NotificationMessage, RpcUrl, ScriptLanguage, TransactionCondition, TransactionStatus, Trigger,
 	TriggerConditions, TriggerType, TriggerTypeConfig,
 };

--- a/src/services/blockchain/client.rs
+++ b/src/services/blockchain/client.rs
@@ -5,7 +5,10 @@
 
 use async_trait::async_trait;
 
-use crate::{models::BlockType, services::filter::BlockFilter};
+use crate::{
+	models::{BlockType, ContractSpec},
+	services::filter::BlockFilter,
+};
 
 /// Defines the core interface for blockchain clients
 ///
@@ -36,6 +39,17 @@ pub trait BlockChainClient: Send + Sync + Clone {
 		start_block: u64,
 		end_block: Option<u64>,
 	) -> Result<Vec<BlockType>, anyhow::Error>;
+
+	/// Retrieves the contract spec for a given contract ID
+	///
+	/// # Arguments
+	/// * `contract_id` - The ID of the contract to retrieve the spec for
+	///
+	/// # Returns
+	/// * `Result<ContractSpec, anyhow::Error>` - The contract spec or an error
+	async fn get_contract_spec(&self, _contract_id: &str) -> Result<ContractSpec, anyhow::Error> {
+		Err(anyhow::anyhow!("get_contract_spec not implemented"))
+	}
 }
 
 /// Defines the factory interface for creating block filters

--- a/src/services/blockchain/clients/stellar/client.rs
+++ b/src/services/blockchain/clients/stellar/client.rs
@@ -12,8 +12,8 @@ use tracing::instrument;
 
 use crate::{
 	models::{
-		BlockType, Network, StellarBlock, StellarContractSpec, StellarEvent, StellarTransaction,
-		StellarTransactionInfo,
+		BlockType, ContractSpec, Network, StellarBlock, StellarContractSpec, StellarEvent,
+		StellarTransaction, StellarTransactionInfo,
 	},
 	services::{
 		blockchain::{
@@ -24,7 +24,6 @@ use crate::{
 		filter::{
 			stellar_helpers::{
 				get_contract_code_ledger_key, get_contract_instance_ledger_key, get_contract_spec,
-				get_contract_spec_functions, get_contract_spec_with_function_input_parameters,
 				get_wasm_code_from_ledger_entry_data, get_wasm_hash_from_ledger_entry_data,
 			},
 			StellarBlockFilter,
@@ -92,18 +91,6 @@ pub trait StellarClientTrait {
 		start_sequence: u32,
 		end_sequence: Option<u32>,
 	) -> Result<Vec<StellarEvent>, anyhow::Error>;
-
-	/// Retrieves the contract spec for a given contract ID
-	///
-	/// # Arguments
-	/// * `contract_id` - The ID of the contract to retrieve the spec for
-	///
-	/// # Returns
-	/// * `Result<StellarContractSpec, anyhow::Error>` - The contract spec or error
-	async fn get_contract_spec(
-		&self,
-		contract_id: &str,
-	) -> Result<StellarContractSpec, anyhow::Error>;
 }
 
 #[async_trait]
@@ -283,92 +270,6 @@ impl<T: Send + Sync + Clone + BlockchainTransport> StellarClientTrait for Stella
 		}
 		Ok(events)
 	}
-
-	/// Retrieves the contract spec for a given contract ID
-	///
-	/// # Arguments
-	/// * `contract_id` - The ID of the contract to retrieve the spec for
-	///
-	/// # Returns
-	/// * `Result<StellarContractSpec, anyhow::Error>` - The contract spec or error
-	#[instrument(skip(self), fields(contract_id))]
-	async fn get_contract_spec(
-		&self,
-		contract_id: &str,
-	) -> Result<StellarContractSpec, anyhow::Error> {
-		// Get contract wasm code from contract ID
-		let contract_instance_ledger_key = get_contract_instance_ledger_key(contract_id)
-			.map_err(|e| anyhow::anyhow!("Failed to get contract instance ledger key: {}", e))?;
-
-		let contract_instance_ledger_key_xdr = contract_instance_ledger_key
-			.to_xdr_base64(Limits::none())
-			.map_err(|e| {
-				anyhow::anyhow!(
-					"Failed to convert contract instance ledger key to XDR: {}",
-					e
-				)
-			})?;
-
-		let params = json!({
-			"keys": [contract_instance_ledger_key_xdr],
-			"xdrFormat": "base64"
-		});
-
-		let response = self
-			.http_client
-			.send_raw_request("getLedgerEntries", Some(params))
-			.await
-			.with_context(|| format!("Failed to get contract wasm code for {}", contract_id))?;
-
-		let contract_data_xdr_base64 = match response["result"]["entries"][0]["xdr"].as_str() {
-			Some(xdr) => xdr,
-			None => {
-				return Err(anyhow::anyhow!("Failed to get contract data XDR"));
-			}
-		};
-
-		let wasm_hash = get_wasm_hash_from_ledger_entry_data(contract_data_xdr_base64)
-			.map_err(|e| anyhow::anyhow!("Failed to get wasm hash: {}", e))?;
-
-		let contract_code_ledger_key = get_contract_code_ledger_key(wasm_hash.as_str())
-			.map_err(|e| anyhow::anyhow!("Failed to get contract code ledger key: {}", e))?;
-
-		let contract_code_ledger_key_xdr = contract_code_ledger_key
-			.to_xdr_base64(Limits::none())
-			.map_err(|e| {
-			anyhow::anyhow!("Failed to convert contract code ledger key to XDR: {}", e)
-		})?;
-
-		let params = json!({
-			"keys": [contract_code_ledger_key_xdr],
-			"xdrFormat": "base64"
-		});
-
-		let response = self
-			.http_client
-			.send_raw_request("getLedgerEntries", Some(params))
-			.await
-			.with_context(|| format!("Failed to get contract wasm code for {}", contract_id))?;
-
-		let contract_code_xdr_base64 = match response["result"]["entries"][0]["xdr"].as_str() {
-			Some(xdr) => xdr,
-			None => {
-				return Err(anyhow::anyhow!("Failed to get contract code XDR"));
-			}
-		};
-
-		let wasm_code = get_wasm_code_from_ledger_entry_data(contract_code_xdr_base64)
-			.map_err(|e| anyhow::anyhow!("Failed to get wasm code: {}", e))?;
-
-		let contract_spec = get_contract_spec(wasm_code.as_str())
-			.map_err(|e| anyhow::anyhow!("Failed to get contract spec: {}", e))?;
-
-		let functions = get_contract_spec_with_function_input_parameters(
-			get_contract_spec_functions(contract_spec),
-		);
-
-		Ok(StellarContractSpec { functions })
-	}
 }
 
 impl<T: Send + Sync + Clone + BlockchainTransport> BlockFilterFactory<Self> for StellarClient<T> {
@@ -492,5 +393,86 @@ impl<T: Send + Sync + Clone + BlockchainTransport> BlockChainClient for StellarC
 			}
 		}
 		Ok(blocks)
+	}
+
+	/// Retrieves the contract spec for a given contract ID
+	///
+	/// # Arguments
+	/// * `contract_id` - The ID of the contract to retrieve the spec for
+	///
+	/// # Returns
+	/// * `Result<ContractSpec, anyhow::Error>` - The contract spec or error
+	#[instrument(skip(self), fields(contract_id))]
+	async fn get_contract_spec(&self, contract_id: &str) -> Result<ContractSpec, anyhow::Error> {
+		// Get contract wasm code from contract ID
+		let contract_instance_ledger_key = get_contract_instance_ledger_key(contract_id)
+			.map_err(|e| anyhow::anyhow!("Failed to get contract instance ledger key: {}", e))?;
+
+		let contract_instance_ledger_key_xdr = contract_instance_ledger_key
+			.to_xdr_base64(Limits::none())
+			.map_err(|e| {
+				anyhow::anyhow!(
+					"Failed to convert contract instance ledger key to XDR: {}",
+					e
+				)
+			})?;
+
+		let params = json!({
+			"keys": [contract_instance_ledger_key_xdr],
+			"xdrFormat": "base64"
+		});
+
+		let response = self
+			.http_client
+			.send_raw_request("getLedgerEntries", Some(params))
+			.await
+			.with_context(|| format!("Failed to get contract wasm code for {}", contract_id))?;
+
+		let contract_data_xdr_base64 = match response["result"]["entries"][0]["xdr"].as_str() {
+			Some(xdr) => xdr,
+			None => {
+				return Err(anyhow::anyhow!("Failed to get contract data XDR"));
+			}
+		};
+
+		let wasm_hash = get_wasm_hash_from_ledger_entry_data(contract_data_xdr_base64)
+			.map_err(|e| anyhow::anyhow!("Failed to get wasm hash: {}", e))?;
+
+		let contract_code_ledger_key = get_contract_code_ledger_key(wasm_hash.as_str())
+			.map_err(|e| anyhow::anyhow!("Failed to get contract code ledger key: {}", e))?;
+
+		let contract_code_ledger_key_xdr = contract_code_ledger_key
+			.to_xdr_base64(Limits::none())
+			.map_err(|e| {
+			anyhow::anyhow!("Failed to convert contract code ledger key to XDR: {}", e)
+		})?;
+
+		let params = json!({
+			"keys": [contract_code_ledger_key_xdr],
+			"xdrFormat": "base64"
+		});
+
+		let response = self
+			.http_client
+			.send_raw_request("getLedgerEntries", Some(params))
+			.await
+			.with_context(|| format!("Failed to get contract wasm code for {}", contract_id))?;
+
+		let contract_code_xdr_base64 = match response["result"]["entries"][0]["xdr"].as_str() {
+			Some(xdr) => xdr,
+			None => {
+				return Err(anyhow::anyhow!("Failed to get contract code XDR"));
+			}
+		};
+
+		let wasm_code = get_wasm_code_from_ledger_entry_data(contract_code_xdr_base64)
+			.map_err(|e| anyhow::anyhow!("Failed to get wasm code: {}", e))?;
+
+		let contract_spec = get_contract_spec(wasm_code.as_str())
+			.map_err(|e| anyhow::anyhow!("Failed to get contract spec: {}", e))?;
+
+		Ok(ContractSpec::Stellar(StellarContractSpec::from(
+			contract_spec,
+		)))
 	}
 }

--- a/src/services/filter/filters/mod.rs
+++ b/src/services/filter/filters/mod.rs
@@ -18,7 +18,7 @@ pub mod stellar {
 use async_trait::async_trait;
 
 use crate::{
-	models::{BlockType, Monitor, MonitorMatch, Network},
+	models::{BlockType, ContractSpec, Monitor, MonitorMatch, Network},
 	services::{blockchain::BlockFilterFactory, filter::error::FilterError},
 };
 pub use evm::filter::EVMBlockFilter;
@@ -37,6 +37,7 @@ pub trait BlockFilter {
 		network: &Network,
 		block: &BlockType,
 		monitors: &[Monitor],
+		contract_specs: Option<&[(String, ContractSpec)]>,
 	) -> Result<Vec<MonitorMatch>, FilterError>;
 }
 
@@ -64,8 +65,11 @@ impl FilterService {
 		network: &Network,
 		block: &BlockType,
 		monitors: &[Monitor],
+		contract_specs: Option<&[(String, ContractSpec)]>,
 	) -> Result<Vec<MonitorMatch>, FilterError> {
 		let filter = T::filter();
-		filter.filter_block(client, network, block, monitors).await
+		filter
+			.filter_block(client, network, block, monitors, contract_specs)
+			.await
 	}
 }

--- a/src/services/filter/filters/stellar/helpers.rs
+++ b/src/services/filter/filters/stellar/helpers.rs
@@ -20,8 +20,8 @@ use stellar_xdr::curr::{
 };
 
 use crate::models::{
-	StellarContractFunction, StellarContractInput, StellarContractSpec, StellarDecodedParamEntry,
-	StellarParsedOperationResult,
+	StellarContractFunction, StellarContractInput, StellarDecodedParamEntry,
+	StellarFormattedContractSpec, StellarParsedOperationResult,
 };
 
 /// Represents all possible Stellar smart contract types
@@ -572,7 +572,7 @@ fn get_function_signature_from_spec_entry(entry: &ScSpecEntry) -> String {
 /// A string representing the function signature in the format "function_name(type1,type2,...)"
 pub fn get_function_signature(
 	invoke_op: &InvokeHostFunctionOp,
-	contract_spec: Option<&StellarContractSpec>,
+	contract_spec: Option<&StellarFormattedContractSpec>,
 ) -> String {
 	match &invoke_op.host_function {
 		HostFunction::InvokeContract(args) => {
@@ -640,8 +640,11 @@ pub fn get_function_signature(
 /// * An optional StellarContractSpec if a matching contract was found
 pub fn process_invoke_host_function(
 	invoke_op: &InvokeHostFunctionOp,
-	contract_specs: Option<&[(String, StellarContractSpec)]>,
-) -> (StellarParsedOperationResult, Option<StellarContractSpec>) {
+	contract_specs: Option<&[(String, StellarFormattedContractSpec)]>,
+) -> (
+	StellarParsedOperationResult,
+	Option<StellarFormattedContractSpec>,
+) {
 	match &invoke_op.host_function {
 		HostFunction::InvokeContract(args) => {
 			let contract_address = match &args.contract_address {
@@ -2302,7 +2305,7 @@ mod tests {
 			auth: vec![].try_into().unwrap(),
 		};
 
-		let contract_spec = StellarContractSpec {
+		let contract_spec = StellarFormattedContractSpec {
 			functions: vec![StellarContractFunction {
 				name: "process_request".to_string(),
 				signature: "process_request(Address,Vec<Request>)".to_string(),

--- a/src/services/notification/mod.rs
+++ b/src/services/notification/mod.rs
@@ -257,9 +257,9 @@ mod tests {
 	use super::*;
 	use crate::{
 		models::{
-			AddressWithABI, EVMMonitorMatch, EVMTransaction, EVMTransactionReceipt, EventCondition,
-			FunctionCondition, MatchConditions, Monitor, MonitorMatch, ScriptLanguage,
-			TransactionCondition, TriggerType,
+			AddressWithSpec, EVMMonitorMatch, EVMTransaction, EVMTransactionReceipt,
+			EventCondition, FunctionCondition, MatchConditions, Monitor, MonitorMatch,
+			ScriptLanguage, TransactionCondition, TriggerType,
 		},
 		utils::tests::builders::{evm::monitor::MonitorBuilder, trigger::TriggerBuilder},
 	};
@@ -269,7 +269,7 @@ mod tests {
 		event_conditions: Vec<EventCondition>,
 		function_conditions: Vec<FunctionCondition>,
 		transaction_conditions: Vec<TransactionCondition>,
-		addresses: Vec<AddressWithABI>,
+		addresses: Vec<AddressWithSpec>,
 	) -> Monitor {
 		let mut builder = MonitorBuilder::new()
 			.name("test")

--- a/src/services/trigger/script/executor.rs
+++ b/src/services/trigger/script/executor.rs
@@ -241,8 +241,9 @@ mod tests {
 	use super::*;
 	use crate::{
 		models::{
-			AddressWithABI, EVMMonitorMatch, EVMTransaction, EVMTransactionReceipt, EventCondition,
-			FunctionCondition, MatchConditions, Monitor, MonitorMatch, TransactionCondition,
+			AddressWithSpec, EVMMonitorMatch, EVMTransaction, EVMTransactionReceipt,
+			EventCondition, FunctionCondition, MatchConditions, Monitor, MonitorMatch,
+			TransactionCondition,
 		},
 		utils::tests::evm::monitor::MonitorBuilder,
 	};
@@ -267,7 +268,7 @@ mod tests {
 		event_conditions: Vec<EventCondition>,
 		function_conditions: Vec<FunctionCondition>,
 		transaction_conditions: Vec<TransactionCondition>,
-		addresses: Vec<AddressWithABI>,
+		addresses: Vec<AddressWithSpec>,
 	) -> Monitor {
 		let mut builder = MonitorBuilder::new()
 			.name("test")
@@ -283,8 +284,12 @@ mod tests {
 			builder = builder.transaction(transaction.status, transaction.expression);
 		}
 
-		builder =
-			builder.addresses_with_abi(addresses.into_iter().map(|a| (a.address, a.abi)).collect());
+		builder = builder.addresses_with_spec(
+			addresses
+				.into_iter()
+				.map(|a| (a.address, a.contract_spec))
+				.collect(),
+		);
 
 		builder.build()
 	}

--- a/src/utils/monitor/execution.rs
+++ b/src/utils/monitor/execution.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides functionality to execute monitors against specific block numbers on blockchain networks.
 use crate::{
-	bootstrap::has_active_monitors,
+	bootstrap::{get_contract_specs, has_active_monitors},
 	models::{BlockChainType, ScriptLanguage},
 	repositories::{
 		MonitorRepositoryTrait, MonitorService, NetworkRepositoryTrait, NetworkService,
@@ -162,10 +162,19 @@ pub async fn execute_monitor<
 					)
 				})?;
 
+				let contract_specs =
+					get_contract_specs(&*client, &network, &[monitor.clone()]).await;
+
 				tracing::debug!(block = %block_number, "Filtering block");
 				config
 					.filter_service
-					.filter_block(&*client, &network, block, &[monitor.clone()])
+					.filter_block(
+						&*client,
+						&network,
+						block,
+						&[monitor.clone()],
+						Some(&contract_specs),
+					)
 					.await
 					.map_err(|e| {
 						MonitorExecutionError::execution_error(
@@ -212,9 +221,18 @@ pub async fn execute_monitor<
 					)
 				})?;
 
+				let contract_specs =
+					get_contract_specs(&*client, &network, &[monitor.clone()]).await;
+
 				config
 					.filter_service
-					.filter_block(&*client, &network, block, &[monitor.clone()])
+					.filter_block(
+						&*client,
+						&network,
+						block,
+						&[monitor.clone()],
+						Some(&contract_specs),
+					)
 					.await
 					.map_err(|e| {
 						MonitorExecutionError::execution_error(

--- a/tests/integration/blockchain/clients/stellar/client.rs
+++ b/tests/integration/blockchain/clients/stellar/client.rs
@@ -6,8 +6,8 @@ use mockall::predicate;
 use mockito::Server;
 use openzeppelin_monitor::{
 	models::{
-		BlockType, StellarBlock, StellarEvent, StellarLedgerInfo, StellarTransaction,
-		StellarTransactionInfo,
+		BlockType, ContractSpec, StellarBlock, StellarEvent, StellarFormattedContractSpec,
+		StellarLedgerInfo, StellarTransaction, StellarTransactionInfo,
 	},
 	services::blockchain::{BlockChainClient, StellarClient, StellarClientTrait},
 };
@@ -383,10 +383,16 @@ async fn test_get_contract_spec() {
 
 	assert!(result.is_ok(), "Should successfully get contract spec");
 	let spec = result.unwrap();
-	assert!(
-		!spec.functions.is_empty(),
-		"Contract spec should have at least one function"
-	);
+	match spec {
+		ContractSpec::Stellar(spec) => {
+			let stellar_spec = StellarFormattedContractSpec::from(spec);
+			assert!(
+				!stellar_spec.functions.is_empty(),
+				"Contract spec should have at least one function"
+			);
+		}
+		_ => panic!("Expected Stellar contract spec"),
+	}
 
 	mock.assert_async().await;
 	instance_mock.assert_async().await;

--- a/tests/integration/blockchain/transports/stellar/transport.rs
+++ b/tests/integration/blockchain/transports/stellar/transport.rs
@@ -1,6 +1,6 @@
 use mockall::predicate;
 use openzeppelin_monitor::{
-	models::BlockType,
+	models::{BlockType, ContractSpec, StellarFormattedContractSpec},
 	services::blockchain::{BlockChainClient, StellarClient, StellarClientTrait},
 };
 use serde_json::{json, Value};
@@ -449,10 +449,16 @@ async fn test_get_contract_spec_success() {
 
 	assert!(result.is_ok());
 	let spec = result.unwrap();
-	assert!(
-		!spec.functions.is_empty(),
-		"Should have at least one function in spec"
-	);
+	match spec {
+		ContractSpec::Stellar(stellar_spec) => {
+			let stellar_spec = StellarFormattedContractSpec::from(stellar_spec);
+			assert!(
+				!stellar_spec.functions.is_empty(),
+				"Should have at least one function in spec"
+			);
+		}
+		_ => panic!("Expected Stellar contract spec"),
+	}
 }
 
 #[tokio::test]

--- a/tests/integration/filters/common.rs
+++ b/tests/integration/filters/common.rs
@@ -3,10 +3,11 @@
 //! Provides shared functionality for loading test fixtures and setting up
 //! test environments for both EVM and Stellar chain tests.
 
+use alloy::json_abi::JsonAbi;
 use openzeppelin_monitor::{
 	models::{
-		BlockType, EVMTransactionReceipt, Monitor, Network, StellarContractSpec, StellarEvent,
-		StellarTransaction, Trigger,
+		BlockType, ContractSpec, EVMContractSpec, EVMTransactionReceipt, Monitor, Network,
+		StellarContractSpec, StellarEvent, StellarTransaction, Trigger,
 	},
 	repositories::{
 		MonitorService, NetworkService, RepositoryError, TriggerRepositoryTrait, TriggerService,
@@ -14,6 +15,7 @@ use openzeppelin_monitor::{
 	services::notification::NotificationService,
 };
 use std::{collections::HashMap, fs};
+use stellar_xdr::curr::ScSpecEntry;
 
 use crate::integration::mocks::{
 	MockMonitorRepository, MockNetworkRepository, MockTriggerExecutionService,
@@ -30,7 +32,7 @@ pub struct TestData {
 	pub receipts: Vec<EVMTransactionReceipt>,
 	pub stellar_transactions: Vec<StellarTransaction>,
 	pub stellar_events: Vec<StellarEvent>,
-	pub stellar_contract_spec: Option<StellarContractSpec>,
+	pub contract_spec: Option<ContractSpec>,
 }
 
 pub fn load_test_data(chain: &str) -> TestData {
@@ -57,13 +59,14 @@ pub fn load_test_data(chain: &str) -> TestData {
 		Vec::new()
 	};
 
-	let stellar_contract_spec: Option<StellarContractSpec> = if chain == "stellar" {
-		Some(read_and_parse_json(&format!(
-			"{}/contract_spec.json",
-			base_path
+	let contract_spec: Option<ContractSpec> = if chain == "stellar" {
+		Some(ContractSpec::Stellar(StellarContractSpec::from(
+			read_and_parse_json::<Vec<ScSpecEntry>>(&format!("{}/contract_spec.json", base_path)),
 		)))
 	} else {
-		None
+		Some(ContractSpec::EVM(EVMContractSpec::from(
+			read_and_parse_json::<JsonAbi>(&format!("{}/contract_spec.json", base_path)),
+		)))
 	};
 
 	TestData {
@@ -73,7 +76,7 @@ pub fn load_test_data(chain: &str) -> TestData {
 		receipts,
 		stellar_transactions,
 		stellar_events,
-		stellar_contract_spec,
+		contract_spec,
 	}
 }
 

--- a/tests/integration/filters/evm/filter.rs
+++ b/tests/integration/filters/evm/filter.rs
@@ -14,8 +14,8 @@ use std::collections::HashMap;
 
 use openzeppelin_monitor::{
 	models::{
-		BlockType, EventCondition, FunctionCondition, Monitor, MonitorMatch, TransactionCondition,
-		TransactionStatus,
+		BlockType, ContractSpec, EventCondition, FunctionCondition, Monitor, MonitorMatch,
+		TransactionCondition, TransactionStatus,
 	},
 	services::{
 		blockchain::EvmClient,
@@ -119,6 +119,7 @@ async fn test_monitor_events_with_no_expressions() -> Result<(), Box<FilterError
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await?;
 
@@ -166,6 +167,7 @@ async fn test_monitor_events_with_expressions() -> Result<(), Box<FilterError>> 
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await?;
 
@@ -226,6 +228,12 @@ async fn test_monitor_functions_with_no_expressions() -> Result<(), Box<FilterEr
 
 	let monitor = make_monitor_with_functions(test_data.monitor, false);
 
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string(),
+		contract_spec.clone(),
+	);
+
 	// Run filter_block with the test data
 	let matches = filter_service
 		.filter_block(
@@ -233,6 +241,7 @@ async fn test_monitor_functions_with_no_expressions() -> Result<(), Box<FilterEr
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -271,6 +280,12 @@ async fn test_monitor_functions_with_expressions() -> Result<(), Box<FilterError
 
 	let monitor = make_monitor_with_functions(test_data.monitor, true);
 
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string(),
+		contract_spec.clone(),
+	);
+
 	// Run filter_block with the test data
 	let matches = filter_service
 		.filter_block(
@@ -278,6 +293,7 @@ async fn test_monitor_functions_with_expressions() -> Result<(), Box<FilterError
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -336,6 +352,7 @@ async fn test_monitor_transactions_with_no_expressions() -> Result<(), Box<Filte
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await?;
 
@@ -379,6 +396,7 @@ async fn test_monitor_transactions_with_expressions() -> Result<(), Box<FilterEr
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await?;
 
@@ -415,12 +433,19 @@ async fn test_monitor_with_multiple_conditions() -> Result<(), Box<FilterError>>
 	let mock_transport = setup_mock_transport(test_data.clone());
 	let client = EvmClient::new_with_transport(mock_transport);
 
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string(),
+		contract_spec.clone(),
+	);
+
 	let matches = filter_service
 		.filter_block(
 			&client,
 			&test_data.network,
 			&test_data.blocks[0],
 			&[test_data.monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -480,6 +505,7 @@ async fn test_monitor_error_cases() -> Result<(), Box<FilterError>> {
 			&test_data.network,
 			&invalid_block,
 			&[test_data.monitor],
+			None,
 		)
 		.await;
 
@@ -505,6 +531,12 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 	let mut trigger_execution_service =
 		setup_trigger_execution_service("tests/integration/fixtures/evm/triggers/trigger.json")
 			.await;
+
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48".to_string(),
+		contract_spec.clone(),
+	);
 
 	// Set up expectations for execute()
 	trigger_execution_service.expect_execute()
@@ -536,6 +568,7 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 			&test_data.network,
 			&test_data.blocks[0],
 			&[test_data.monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -576,6 +609,12 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 	monitor.match_conditions.events = vec![];
 	monitor.match_conditions.transactions = vec![];
 
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"0xf18206b2289cf6ce15cddbee9c6f6a0f059efb56".to_string(),
+		contract_spec.clone(),
+	);
+
 	// Run filter_block with the test data
 	let matches = filter_service
 		.filter_block(
@@ -583,6 +622,7 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 			&test_data.network,
 			test_data.blocks.last().unwrap(), // last block contains increment() transaction
 			&[monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 

--- a/tests/integration/filters/stellar/filter.rs
+++ b/tests/integration/filters/stellar/filter.rs
@@ -7,10 +7,11 @@ use std::collections::HashMap;
 
 use openzeppelin_monitor::{
 	models::{
-		AddressWithABI, BlockChainType, BlockType, EventCondition, FunctionCondition,
-		MatchConditions, Monitor, MonitorMatch, StellarBlock, StellarEvent, StellarMatchArguments,
-		StellarMatchParamEntry, StellarMatchParamsMap, StellarMonitorMatch, StellarTransaction,
-		StellarTransactionInfo, TransactionCondition, TransactionStatus, TransactionType,
+		AddressWithSpec, BlockChainType, BlockType, ContractSpec, EventCondition,
+		FunctionCondition, MatchConditions, Monitor, MonitorMatch, StellarBlock, StellarEvent,
+		StellarMatchArguments, StellarMatchParamEntry, StellarMatchParamsMap, StellarMonitorMatch,
+		StellarTransaction, StellarTransactionInfo, TransactionCondition, TransactionStatus,
+		TransactionType,
 	},
 	services::filter::{handle_match, FilterError, FilterService},
 };
@@ -23,7 +24,7 @@ use crate::integration::{
 	},
 };
 
-use serde_json::{json, Value};
+use serde_json::Value;
 
 fn make_monitor_with_events(mut monitor: Monitor, include_expression: bool) -> Monitor {
 	monitor.match_conditions.functions = vec![];
@@ -107,7 +108,7 @@ async fn test_monitor_events_with_no_expressions() -> Result<(), Box<FilterError
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(test_data.contract_spec.clone().unwrap()));
 
 	// Run filter_block with the test data
 	let matches = filter_service
@@ -116,6 +117,7 @@ async fn test_monitor_events_with_no_expressions() -> Result<(), Box<FilterError
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await?;
 
@@ -179,7 +181,7 @@ async fn test_monitor_events_with_expressions() -> Result<(), Box<FilterError>> 
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(test_data.contract_spec.clone().unwrap()));
 
 	// Run filter_block with the test data
 	let matches = filter_service
@@ -188,6 +190,7 @@ async fn test_monitor_events_with_expressions() -> Result<(), Box<FilterError>> 
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await?;
 
@@ -263,6 +266,11 @@ async fn test_monitor_functions_with_no_expressions() -> Result<(), Box<FilterEr
 		read_and_parse_json("tests/integration/fixtures/stellar/events.json");
 	let transactions: Vec<StellarTransactionInfo> =
 		read_and_parse_json("tests/integration/fixtures/stellar/transactions.json");
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA".to_string(),
+		contract_spec.clone(),
+	);
 
 	let mut mock_client = MockStellarClientTrait::<MockStellarTransportClient>::new();
 	let decoded_transactions: Vec<StellarTransaction> = transactions
@@ -283,7 +291,7 @@ async fn test_monitor_functions_with_no_expressions() -> Result<(), Box<FilterEr
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(contract_spec.clone()));
 
 	// Run filter_block with the test data
 	let matches = filter_service
@@ -292,6 +300,7 @@ async fn test_monitor_functions_with_no_expressions() -> Result<(), Box<FilterEr
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -337,6 +346,11 @@ async fn test_monitor_functions_with_expressions() -> Result<(), Box<FilterError
 		read_and_parse_json("tests/integration/fixtures/stellar/events.json");
 	let transactions: Vec<StellarTransactionInfo> =
 		read_and_parse_json("tests/integration/fixtures/stellar/transactions.json");
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA".to_string(),
+		contract_spec.clone(),
+	);
 
 	let mut mock_client = MockStellarClientTrait::<MockStellarTransportClient>::new();
 	let decoded_transactions: Vec<StellarTransaction> = transactions
@@ -357,7 +371,7 @@ async fn test_monitor_functions_with_expressions() -> Result<(), Box<FilterError
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(contract_spec.clone()));
 
 	// Run filter_block with the test data
 	let matches = filter_service
@@ -366,6 +380,7 @@ async fn test_monitor_functions_with_expressions() -> Result<(), Box<FilterError
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -450,7 +465,7 @@ async fn test_monitor_transactions_with_expressions() -> Result<(), Box<FilterEr
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(test_data.contract_spec.clone().unwrap()));
 
 	// Run filter_block with the test data
 	let matches = filter_service
@@ -459,6 +474,7 @@ async fn test_monitor_transactions_with_expressions() -> Result<(), Box<FilterEr
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await?;
 
@@ -520,7 +536,7 @@ async fn test_monitor_transactions_with_no_expressions() -> Result<(), Box<Filte
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(test_data.contract_spec.clone().unwrap()));
 
 	// Run filter_block with the test data
 	let matches = filter_service
@@ -529,6 +545,7 @@ async fn test_monitor_transactions_with_no_expressions() -> Result<(), Box<Filte
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await?;
 
@@ -565,6 +582,15 @@ async fn test_monitor_with_multiple_conditions() -> Result<(), Box<FilterError>>
 		read_and_parse_json("tests/integration/fixtures/stellar/events.json");
 	let transactions: Vec<StellarTransactionInfo> =
 		read_and_parse_json("tests/integration/fixtures/stellar/transactions.json");
+	let contract_spec = test_data.contract_spec.unwrap();
+	let transfer_contract_with_spec: (String, ContractSpec) = (
+		"CBIELTK6YBZJU5UP2WWQEUCYKLPU6AUNZ2BQ4WWFEIE3USCIHMXQDAMA".to_string(),
+		contract_spec.clone(),
+	);
+	let upsert_contract_with_spec: (String, ContractSpec) = (
+		"CBWRWC2IFNRXKAW2HG5473V5U25OMUKVIE3BFZBIWOOD3VLEIBUIOQG6".to_string(),
+		contract_spec.clone(),
+	);
 
 	let mut mock_client = MockStellarClientTrait::<MockStellarTransportClient>::new();
 	let decoded_transactions: Vec<StellarTransaction> = transactions
@@ -585,7 +611,7 @@ async fn test_monitor_with_multiple_conditions() -> Result<(), Box<FilterError>>
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(contract_spec.clone()));
 
 	// Run filter_block with the test data
 	let matches = filter_service
@@ -594,6 +620,7 @@ async fn test_monitor_with_multiple_conditions() -> Result<(), Box<FilterError>>
 			&test_data.network,
 			&test_data.blocks[0],
 			&[test_data.monitor],
+			Some(&[transfer_contract_with_spec, upsert_contract_with_spec]),
 		)
 		.await?;
 
@@ -650,10 +677,7 @@ async fn test_monitor_with_multiple_conditions() -> Result<(), Box<FilterError>>
 			if let Some(functions) = &args.functions {
 				assert!(!functions.is_empty(), "Should have function arguments");
 				let function = &functions[0];
-				assert_eq!(
-					function.signature,
-					"upsert_data(Map<String,Union<U32, String>>)"
-				);
+				assert_eq!(function.signature, "upsert_data(Map<String,String>)");
 			}
 		}
 	}
@@ -676,6 +700,7 @@ async fn test_monitor_error_cases() -> Result<(), Box<FilterError>> {
 			&test_data.network,
 			&invalid_block,
 			&[test_data.monitor],
+			None,
 		)
 		.await;
 
@@ -700,6 +725,12 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 	let transactions: Vec<StellarTransactionInfo> =
 		read_and_parse_json("tests/integration/fixtures/stellar/transactions.json");
 
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"CBWRWC2IFNRXKAW2HG5473V5U25OMUKVIE3BFZBIWOOD3VLEIBUIOQG6".to_string(),
+		contract_spec.clone(),
+	);
+
 	let mut mock_client = MockStellarClientTrait::<MockStellarTransportClient>::new();
 	let decoded_transactions: Vec<StellarTransaction> = transactions
 		.iter()
@@ -719,7 +750,7 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(contract_spec.clone()));
 
 	let mut trigger_execution_service =
 		setup_trigger_execution_service("tests/integration/fixtures/stellar/triggers/trigger.json")
@@ -764,7 +795,7 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 				&& variables.get("transaction.hash")
 					== Some(&"FAKE5a3a9153e19002517935a5df291b81a341b98ccd80f0919d78cea5ed29d8".to_string())
 				// Function arguments
-				&& variables.get("functions.0.signature") == Some(&"upsert_data(Map<String,Union<U32, String>>)".to_string())
+				&& variables.get("functions.0.signature") == Some(&"upsert_data(Map<String,String>)".to_string())
 				&& expected_json == actual_json
 			},
 		)
@@ -777,6 +808,7 @@ async fn test_handle_match() -> Result<(), Box<FilterError>> {
 			&test_data.network,
 			&test_data.blocks[0],
 			&[test_data.monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -814,6 +846,11 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 		read_and_parse_json("tests/integration/fixtures/stellar/events.json");
 	let transactions: Vec<StellarTransactionInfo> =
 		read_and_parse_json("tests/integration/fixtures/stellar/transactions.json");
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"CDMZ6LU66KEMLKI3EJBIGXTZ4KZ2CRTSHZETMY3QQZBWRKVKB5EIOHTX".to_string(),
+		contract_spec.clone(),
+	);
 
 	let mut mock_client = MockStellarClientTrait::<MockStellarTransportClient>::new();
 	let decoded_transactions: Vec<StellarTransaction> = transactions
@@ -834,7 +871,7 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(contract_spec.clone()));
 
 	// Run filter_block with the test data
 	let matches = filter_service
@@ -843,6 +880,7 @@ async fn test_handle_match_with_no_args() -> Result<(), Box<FilterError>> {
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -1042,6 +1080,12 @@ async fn test_filter_with_contract_spec() -> Result<(), Box<FilterError>> {
 	let transactions: Vec<StellarTransactionInfo> =
 		read_and_parse_json("tests/integration/fixtures/stellar/transactions.json");
 
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"CDMZ6LU66KEMLKI3EJBIGXTZ4KZ2CRTSHZETMY3QQZBWRKVKB5EIOHTX".to_string(),
+		contract_spec.clone(),
+	);
+
 	let mut mock_client = MockStellarClientTrait::<MockStellarTransportClient>::new();
 	let decoded_transactions: Vec<StellarTransaction> = transactions
 		.iter()
@@ -1062,7 +1106,7 @@ async fn test_filter_with_contract_spec() -> Result<(), Box<FilterError>> {
 	// Expect contract spec to be called
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(contract_spec.clone()));
 
 	// Create a monitor that requires contract spec validation
 	let mut monitor = test_data.monitor.clone();
@@ -1080,6 +1124,7 @@ async fn test_filter_with_contract_spec() -> Result<(), Box<FilterError>> {
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 
@@ -1149,6 +1194,7 @@ async fn test_filter_with_invalid_contract_spec() -> Result<(), Box<FilterError>
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			None,
 		)
 		.await;
 
@@ -1169,6 +1215,11 @@ async fn test_filter_with_abi_in_config() -> Result<(), Box<FilterError>> {
 		read_and_parse_json("tests/integration/fixtures/stellar/events.json");
 	let transactions: Vec<StellarTransactionInfo> =
 		read_and_parse_json("tests/integration/fixtures/stellar/transactions.json");
+	let contract_spec = test_data.contract_spec.unwrap();
+	let contract_with_spec: (String, ContractSpec) = (
+		"CDMZ6LU66KEMLKI3EJBIGXTZ4KZ2CRTSHZETMY3QQZBWRKVKB5EIOHTX".to_string(),
+		contract_spec.clone(),
+	);
 
 	let mut mock_client = MockStellarClientTrait::<MockStellarTransportClient>::new();
 	let decoded_transactions: Vec<StellarTransaction> = transactions
@@ -1200,19 +1251,9 @@ async fn test_filter_with_abi_in_config() -> Result<(), Box<FilterError>> {
 	monitor.match_conditions.transactions = vec![];
 
 	// Add ABI to the monitor's address configuration
-	monitor.addresses = vec![AddressWithABI {
-		address: "CDMZ6LU66KEMLKI3EJBIGXTZ4KZ2CRTSHZETMY3QQZBWRKVKB5EIOHTX".to_string(),
-		abi: Some(json!([{
-			  "function_v0": {
-				"doc": "Increment increments an internal counter, and returns the value.",
-				"name": "increment",
-				"inputs": [],
-				"outputs": [
-				  "u32"
-				]
-			  }
-			}
-		])),
+	monitor.addresses = vec![AddressWithSpec {
+		address: contract_with_spec.0.clone(),
+		contract_spec: Some(contract_with_spec.1.clone()),
 	}];
 
 	// Run filter_block with the test data
@@ -1222,6 +1263,7 @@ async fn test_filter_with_abi_in_config() -> Result<(), Box<FilterError>> {
 			&test_data.network,
 			&test_data.blocks[0],
 			&[monitor],
+			Some(&[contract_with_spec]),
 		)
 		.await?;
 

--- a/tests/integration/fixtures/evm/contract_spec.json
+++ b/tests/integration/fixtures/evm/contract_spec.json
@@ -1,0 +1,58 @@
+[
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "Transfer",
+        "type": "event"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "value",
+                "type": "uint256"
+            }
+        ],
+        "name": "transfer",
+        "outputs": [
+            {
+                "internalType": "bool",
+                "name": "",
+                "type": "bool"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "increment",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    }
+]

--- a/tests/integration/fixtures/evm/monitors/monitor.json
+++ b/tests/integration/fixtures/evm/monitors/monitor.json
@@ -7,7 +7,7 @@
   "addresses": [
     {
       "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-      "abi": [
+      "contract_spec": [
         {
           "anonymous": false,
           "inputs": [
@@ -1398,7 +1398,7 @@
     },
     {
       "address": "0xf18206B2289CF6CE15CDDBee9C6f6a0F059EfB56",
-      "abi": [
+      "contract_spec": [
         {
           "inputs": [],
           "name": "increment",

--- a/tests/integration/fixtures/stellar/contract_spec.json
+++ b/tests/integration/fixtures/stellar/contract_spec.json
@@ -1,41 +1,53 @@
-{
-    "functions": [
-        {
+[
+    {
+        "function_v0": {
+            "doc": "",
             "name": "transfer",
-            "signature": "transfer(Address,Address,I128)",
             "inputs": [
                 {
-                    "index": 0,
+                    "doc": "",
                     "name": "from",
-                    "kind": "Address"
+                    "type_": "address"
                 },
                 {
-                    "index": 1,
+                    "doc": "",
                     "name": "to",
-                    "kind": "Address"
+                    "type_": "address"
                 },
                 {
-                    "index": 2,
+                    "doc": "",
                     "name": "amount",
-                    "kind": "I128"
+                    "type_": "i128"
                 }
-            ]
-        },
-        {
+            ],
+            "outputs": []
+        }
+    },
+    {
+        "function_v0": {
+            "doc": "",
             "name": "upsert_data",
-            "signature": "upsert_data(Map<String,Union<U32, String>>)",
             "inputs": [
                 {
-                    "index": 0,
+                    "doc": "",
                     "name": "data",
-                    "kind": "Map"
+                    "type_": {
+                        "map": {
+                            "key_type": "string",
+                            "value_type": "string"
+                        }
+                    }
                 }
-            ]
-        },
-        {
-            "name": "increment",
-            "signature": "increment()",
-            "inputs": []
+            ],
+            "outputs": []
         }
-    ]
-}
+    },
+    {
+        "function_v0": {
+            "doc": "",
+            "name": "increment",
+            "inputs": [],
+            "outputs": []
+        }
+    }
+]

--- a/tests/integration/fixtures/stellar/monitors/monitor.json
+++ b/tests/integration/fixtures/stellar/monitors/monitor.json
@@ -31,7 +31,7 @@
         "expression": "amount > 1000"
       },
       {
-        "signature": "upsert_data(Map<String,Union<U32,String>>)",
+        "signature": "upsert_data(Map<String,String>)",
         "expression": "data.myKey1 >= 1234 AND data.myKey2 == 'Hello, world!'"
       }
     ],

--- a/tests/integration/mocks/clients.rs
+++ b/tests/integration/mocks/clients.rs
@@ -13,8 +13,8 @@ use std::{marker::PhantomData, sync::Arc};
 
 use openzeppelin_monitor::{
 	models::{
-		BlockType, EVMReceiptLog, EVMTransactionReceipt, Network, StellarContractSpec,
-		StellarEvent, StellarTransaction,
+		BlockType, ContractSpec, EVMReceiptLog, EVMTransactionReceipt, Network, StellarEvent,
+		StellarTransaction,
 	},
 	services::{
 		blockchain::{
@@ -87,6 +87,10 @@ mock! {
 			start_block: u64,
 			end_block: Option<u64>,
 		) -> Result<Vec<BlockType>, anyhow::Error>;
+		async fn get_contract_spec(
+			&self,
+			contract_id: &str,
+		) -> Result<ContractSpec, anyhow::Error>;
 	}
 
 	#[async_trait]
@@ -103,10 +107,7 @@ mock! {
 			end_sequence: Option<u32>,
 		) -> Result<Vec<StellarEvent>, anyhow::Error>;
 
-		async fn get_contract_spec(
-			&self,
-			contract_id: &str,
-		) -> Result<StellarContractSpec, anyhow::Error>;
+
 	}
 
 	impl<T: Send + Sync + Clone + 'static> Clone for StellarClientTrait<T> {

--- a/tests/integration/monitor/execution.rs
+++ b/tests/integration/monitor/execution.rs
@@ -436,7 +436,7 @@ async fn test_execute_monitor_stellar() {
 		.return_once(move |_, _| Ok(test_data.stellar_events.clone()));
 	mock_client
 		.expect_get_contract_spec()
-		.returning(move |_| Ok(test_data.stellar_contract_spec.clone().unwrap()));
+		.returning(move |_| Ok(test_data.contract_spec.clone().unwrap()));
 
 	mock_pool
 		.expect_get_stellar_client()

--- a/tests/properties/filters/stellar/filter.rs
+++ b/tests/properties/filters/stellar/filter.rs
@@ -4,8 +4,8 @@
 use base64::Engine;
 use openzeppelin_monitor::{
 	models::{
-		Monitor, StellarContractFunction, StellarContractInput, StellarContractSpec,
-		StellarDecodedTransaction, StellarMatchArguments, StellarMatchParamEntry,
+		Monitor, StellarContractFunction, StellarContractInput, StellarDecodedTransaction,
+		StellarFormattedContractSpec, StellarMatchArguments, StellarMatchParamEntry,
 		StellarTransaction, StellarTransactionInfo, TransactionStatus,
 	},
 	services::{
@@ -802,7 +802,7 @@ proptest! {
 		// Create contract spec matching the function
 		let contract_specs = vec![(
 			contract_address.clone(),
-			StellarContractSpec {
+			StellarFormattedContractSpec {
 				functions: vec![StellarContractFunction {
 					signature: function_signature.clone(),
 					name: function_name.to_string(),

--- a/tests/properties/strategies.rs
+++ b/tests/properties/strategies.rs
@@ -1,7 +1,7 @@
 use email_address::EmailAddress;
 use openzeppelin_monitor::{
 	models::{
-		AddressWithABI, BlockChainType, EventCondition, FunctionCondition, MatchConditions,
+		AddressWithSpec, BlockChainType, EventCondition, FunctionCondition, MatchConditions,
 		Monitor, Network, NotificationMessage, RpcUrl, ScriptLanguage, SecretString, SecretValue,
 		TransactionCondition, TransactionStatus, Trigger, TriggerConditions, TriggerType,
 		TriggerTypeConfig,
@@ -33,8 +33,12 @@ pub fn monitor_strategy(
 		"[a-zA-Z0-9_]{1,10}".prop_map(|s| s.to_string()),
 		proptest::arbitrary::any::<bool>(),
 		proptest::collection::vec(
-			("[a-zA-Z0-9_]{1,10}".prop_map(|s| s.to_string()))
-				.prop_map(|address| AddressWithABI { address, abi: None }),
+			("[a-zA-Z0-9_]{1,10}".prop_map(|s| s.to_string())).prop_map(|address| {
+				AddressWithSpec {
+					address,
+					contract_spec: None,
+				}
+			}),
 			MIN_COLLECTION_SIZE..MAX_ADDRESSES,
 		),
 		match_conditions_strategy(),


### PR DESCRIPTION
# Summary

https://linear.app/openzeppelin-development/issue/PLAT-6609/reduce-rpc-calls-for-contract-spec

- Refactors `abi` to `contract-spec` to generalise for future extensions
- Fetches contract specs for EVM and Stellar at startup rather than per-block
- Adds tests
- Ensures existing env variables are overridden at startup
- Resolves secrets for triggers when using `load_all`

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
- [x] Add integration tests if applicable.
- [x] Add property-based tests if applicable.
- [x] Update documentation if applicable.
