### PR TITLE
chore: Reduce RPC calls for EVM by using `eth_getLogs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a0be470ab41e3aaed6c54dbb2b6224d3048de467d8009cf9d5d32a8b8957ef7"
+checksum = "2b064bd1cea105e70557a258cd2b317731896753ec08edf51da2d1fced587b05"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a4fbb5e716faa10fc4e7a122307afcf55bae7272fc69286ee3eee881f757c66"
+checksum = "32c3f3bc4f2a6b725970cd354e78e9738ea1e8961a91898f57bf6317970b1915"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -327,9 +327,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42c04d03d9ee6b6768cad687df5a360fc58714f39a37c971b907a8965717636d"
+checksum = "dda014fb5591b8d8d24cab30f52690117d238e52254c6fb40658e91ea2ccd6c3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -341,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0ff39ab8bf0d23caa41ec1898d80ad1bcb037c94a048141ac4a961980164e65"
+checksum = "9668ce1176f0b87a5e5fc805b3d198954f495de2e99b70a44bed691ba2b0a9d8"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22c3699f23cea35d97a0a911b42c3cfd54dd95233df09307f5ebe52e0a74ad6e"
+checksum = "2f7b2f7010581f29bcace81776cf2f0e022008d05a7d326884763f16f3044620"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -450,9 +450,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c5a4e3f60f0b53b5dbd13904694e775a23ff98a43d6dd640b753b72669b993"
+checksum = "c7f723856b1c4ad5473f065650ab9be557c96fbc77e89180fbdac003e904a8d6"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -475,9 +475,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea71d308c1f3e42172c7fe9dccc6e63d97fa0cfd21d21f73c04d5e2640826f64"
+checksum = "ca1e31b50f4ed9a83689ae97263d366b15b935a67c4acb5dd46d5b1c3b27e8e6"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd432f53775e6ef85cfc8a3c90f174786bdc15d5cac379dcea01bd0e6f93edc"
+checksum = "879afc0f4a528908c8fe6935b2ab0bc07f77221a989186f71583f7592831689e"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2dea138d01f0e9739dee905a9e40a0f2347dd217360d813b6b7967ee8c0a8e"
+checksum = "ec185bac9d32df79c1132558a450d48f6db0bfb5adef417dbb1a0258153f879b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -555,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c1e1dc8a0a368a62455b526a037557b1e57c7fda652748e5e2c66db517906ed"
+checksum = "b2d918534afe9cc050eabd8309c107dafd161aa77357782eca4f218bef08a660"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b322e679094ec8876d05e69f75f0c16b056514422ed79187bac1ee42ac432c75"
+checksum = "9d77a92001c6267261a5e493d33db794b2206ebebf7c2dfbbe3825ebaec6a96d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -644,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97da6111d0232cc890aa4d334b5e427aa25491cf34adbe9806fa440a6f32650f"
+checksum = "a15e30dcada47c04820b64f63de2423506c5c74f9ab59b115277ef5ad595a6fc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -672,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835291d2f5423e02f755872b329c0bae97743936f596749f6fb6f0cf4de1324e"
+checksum = "4aa10e26554ad7f79a539a6a8851573aedec5289f1f03244aad0bdbc324bfe5c"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-anvil",
@@ -688,9 +688,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ce5c36f947103fa98278c20f60dac4c35c11bc2a15a0e255845345c471af4d"
+checksum = "d6cd4346521aa1e2e76963bbf0c1d311223f6eb565269359a6f9232c9044d1f7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -700,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c8536c15442b001046dcaff415067600231261e7c53767e74e69d15f72f651"
+checksum = "7a5a8f1efd77116915dad61092f9ef9295accd0b0b251062390d9c4e81599344"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -711,9 +711,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74029c8c08c3332779c6a5b98f32a6a47d6e61c847a3d18cffcc56c8c65016c2"
+checksum = "07c142af843da7422e5e979726dcfeb78064949fdc6cb651457cc95034806a52"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -721,9 +721,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79e3df17a03b9e1ee61a40ef38deb5cd9b4fcd916642a23f29b78783c5fd335"
+checksum = "246c225f878dbcb8ad405949a30c403b3bb43bdf974f7f0331b276f835790a5e"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da690eafe37fe096037f8820b6bf2382f3ea68120d06a4253e4ac725a7e652dd"
+checksum = "bc1323310d87f9d950fb3ff58d943fdf832f5e10e6f902f405c0eaa954ffbaf1"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -758,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a337d99df8adaaf6ec2707bf8ee410c927b89dd64cf9fe67558a18f4917d10d7"
+checksum = "d57f1b7da0af516ad2c02233ed1274527f9b0536dbda300acea2e8a1e7ac20c8"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -772,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d2182b8ce80589c173cd847989f728a1bd9cfc0df6dab404f39a4125930052"
+checksum = "5d4f4239235c4afdd8fa930a757ed81816799ddcc93d4e33cd0dae3b44f83f3e"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -784,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261be2da2ef0bbbf80eed153c995822725cbef193e49eb251e2bf72cac29dbaf"
+checksum = "d05ace2ef3da874544c3ffacfd73261cdb1405d8631765deb991436a53ec6069"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fdf929ce72d18aa40974ecaa2cd77c5062a0baa105fdb95e6aa5609642d7210"
+checksum = "67fdabad99ad3c71384867374c60bcd311fc1bb90ea87f5f9c779fd8c7ec36aa"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -810,9 +810,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94910e0d75f086d4ed15d6a884170f648c28d06e4a8516156ea90204c0560595"
+checksum = "acb3f4e72378566b189624d54618c8adf07afbcf39d5f368f4486e35a66725b3"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -900,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4f3654d5195c0c3f502bfd6ed299ea9eb5cb275d7a88d04ce0d189bca416b2"
+checksum = "6964d85cd986cfc015b96887b89beed9e06d0d015b75ee2b7bfbd64341aab874"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -923,9 +923,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a9372fba202370973748d76c2891344cbacfb012d44a8ed62135ba53d4408e"
+checksum = "ef7c5ea7bda4497abe4ea92dcb8c76e9f052c178f3c82aa6976bcb264675f73c"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -938,9 +938,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc96665d4e52d55b48998f955bb7253e2b41b1d96200c47ca5b187f0239e602"
+checksum = "7c506a002d77e522ccab7b7068089a16e24694ea04cb89c0bfecf3cc3603fccf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -958,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334b1e456e62cf561d80feda0604e1f80e898d29a1fab426ca25020e7628fa59"
+checksum = "09ff1bb1182601fa5e7b0f8bac03dcd496441ed23859387731462b17511c6680"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",

--- a/docs/modules/ROOT/pages/rpc.adoc
+++ b/docs/modules/ROOT/pages/rpc.adoc
@@ -278,7 +278,7 @@ graph TD
 * Fetching block data (per block): `eth_getBlockByNumber`
 * Fetching block logs (per block): `eth_getLogs`
 * Fetching transaction receipt (only when needed):
-** When monitor condition requires receipt-specific fields (e.g., gas_used)
+** When monitor condition requires receipt-specific fields (e.g., `gas_used`)
 ** When monitoring transaction status and no logs are present to validate status
 
 *Stellar*

--- a/docs/modules/ROOT/pages/rpc.adoc
+++ b/docs/modules/ROOT/pages/rpc.adoc
@@ -278,8 +278,8 @@ graph TD
 * Fetching block data (per block): `eth_getBlockByNumber`
 * Fetching block logs (per block): `eth_getLogs`
 * Fetching transaction receipt (only when needed):
-  * When monitor condition requires receipt-specific fields (e.g., gas_used)
-  * When monitoring transaction status and no logs are present to validate status
+** When monitor condition requires receipt-specific fields (e.g., gas_used)
+** When monitoring transaction status and no logs are present to validate status
 
 *Stellar*
 

--- a/docs/modules/ROOT/pages/rpc.adoc
+++ b/docs/modules/ROOT/pages/rpc.adoc
@@ -250,7 +250,8 @@ graph TD
         B[Network Init] -->|net_version| D
         D -->|eth_blockNumber| E[For every block in range]
         E -->|eth_getBlockByNumber| G1[Process Block]
-        G1 -->|For every transaction| J[Get Transaction Receipt]
+        G1 -->|eth_getLogs| H[Get Block Logs]
+        H -->|Only when needed| J[Get Transaction Receipt]
         J -->|eth_getTransactionReceipt| I[Complete]
     end
 
@@ -275,7 +276,10 @@ graph TD
 * RPC Client initialization (per active network): `net_version`
 * Fetching the latest block number (per cron iteration): `eth_blockNumber`
 * Fetching block data (per block): `eth_getBlockByNumber`
-* Fetching transaction receipt (per transaction in block): `eth_getTransactionReceipt`
+* Fetching block logs (per block): `eth_getLogs`
+* Fetching transaction receipt (only when needed):
+  * When monitor condition requires receipt-specific fields (e.g., gas_used)
+  * When monitoring transaction status and no logs are present to validate status
 
 *Stellar*
 

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -521,16 +521,14 @@ mod tests {
 	use super::*;
 	use crate::{
 		models::{
-			EVMMonitorMatch, EVMTransaction, EVMTransactionReceipt, MatchConditions, Monitor,
-			MonitorMatch, ScriptLanguage, StellarBlock, StellarMonitorMatch, StellarTransaction,
-			StellarTransactionInfo, TriggerConditions,
+			EVMMonitorMatch, EVMReceiptLog, EVMTransaction, EVMTransactionReceipt, MatchConditions,
+			Monitor, MonitorMatch, ScriptLanguage, StellarBlock, StellarMonitorMatch,
+			StellarTransaction, StellarTransactionInfo, TriggerConditions,
 		},
-		utils::tests::builders::evm::monitor::MonitorBuilder,
+		utils::tests::{builders::evm::monitor::MonitorBuilder, evm::receipt::ReceiptBuilder},
 	};
 	use alloy::{
-		consensus::{
-			transaction::Recovered, Receipt, ReceiptEnvelope, ReceiptWithBloom, Signed, TxEnvelope,
-		},
+		consensus::{transaction::Recovered, Signed, TxEnvelope},
 		primitives::{Address, Bytes, TxKind, B256, U256},
 	};
 	use std::io::Write;
@@ -561,23 +559,11 @@ mod tests {
 	}
 
 	fn create_test_evm_transaction_receipt() -> EVMTransactionReceipt {
-		EVMTransactionReceipt::from(alloy::rpc::types::TransactionReceipt {
-			inner: ReceiptEnvelope::Legacy(ReceiptWithBloom {
-				receipt: Receipt::default(),
-				logs_bloom: Default::default(),
-			}),
-			transaction_hash: B256::ZERO,
-			transaction_index: Some(0),
-			block_hash: Some(B256::ZERO),
-			block_number: Some(0),
-			gas_used: 0,
-			effective_gas_price: 0,
-			blob_gas_used: None,
-			blob_gas_price: None,
-			from: Address::ZERO,
-			to: Some(Address::ZERO),
-			contract_address: None,
-		})
+		ReceiptBuilder::new().build()
+	}
+
+	fn create_test_evm_logs() -> Vec<EVMReceiptLog> {
+		ReceiptBuilder::new().build().logs.clone()
 	}
 
 	fn create_test_evm_transaction() -> EVMTransaction {
@@ -628,7 +614,8 @@ mod tests {
 			BlockChainType::EVM => MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 				monitor: create_test_monitor("test", vec![], false, script_path),
 				transaction: create_test_evm_transaction(),
-				receipt: create_test_evm_transaction_receipt(),
+				receipt: Some(create_test_evm_transaction_receipt()),
+				logs: Some(create_test_evm_logs()),
 				network_slug: "ethereum_mainnet".to_string(),
 				matched_on: MatchConditions {
 					functions: vec![],
@@ -662,7 +649,8 @@ mod tests {
 			BlockChainType::EVM => MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 				monitor,
 				transaction: create_test_evm_transaction(),
-				receipt: create_test_evm_transaction_receipt(),
+				receipt: Some(create_test_evm_transaction_receipt()),
+				logs: Some(create_test_evm_logs()),
 				network_slug: "ethereum_mainnet".to_string(),
 				matched_on: MatchConditions {
 					functions: vec![],

--- a/src/models/blockchain/evm/monitor.rs
+++ b/src/models/blockchain/evm/monitor.rs
@@ -1,4 +1,6 @@
-use crate::models::{EVMTransaction, EVMTransactionReceipt, MatchConditions, Monitor};
+use crate::models::{
+	EVMReceiptLog, EVMTransaction, EVMTransactionReceipt, MatchConditions, Monitor,
+};
 use serde::{Deserialize, Serialize};
 
 /// Result of a successful monitor match on an EVM chain
@@ -11,7 +13,10 @@ pub struct EVMMonitorMatch {
 	pub transaction: EVMTransaction,
 
 	/// Transaction receipt with execution results
-	pub receipt: EVMTransactionReceipt,
+	pub receipt: Option<EVMTransactionReceipt>,
+
+	/// Transaction logs
+	pub logs: Option<Vec<EVMReceiptLog>>,
 
 	/// Network slug that the transaction was sent from
 	pub network_slug: String,
@@ -180,7 +185,8 @@ mod tests {
 		let monitor_match = EVMMonitorMatch {
 			monitor: monitor.clone(),
 			transaction: transaction.clone(),
-			receipt: receipt.clone(),
+			receipt: Some(receipt.clone()),
+			logs: Some(receipt.logs.clone()),
 			network_slug: "ethereum_mainnet".to_string(),
 			matched_on: MatchConditions {
 				functions: vec![FunctionCondition {
@@ -198,7 +204,10 @@ mod tests {
 
 		assert_eq!(monitor_match.monitor.name, "TestMonitor");
 		assert_eq!(monitor_match.transaction.hash, B256::with_last_byte(1));
-		assert_eq!(monitor_match.receipt.status, Some(U64::from(1)));
+		assert_eq!(
+			monitor_match.receipt.as_ref().unwrap().status,
+			Some(U64::from(1))
+		);
 		assert_eq!(monitor_match.network_slug, "ethereum_mainnet");
 		assert_eq!(monitor_match.matched_on.functions.len(), 1);
 		assert_eq!(

--- a/src/models/blockchain/evm/receipt.rs
+++ b/src/models/blockchain/evm/receipt.rs
@@ -130,6 +130,15 @@ impl From<BaseReceipt> for TransactionReceipt {
 	}
 }
 
+impl From<Vec<BaseLog>> for TransactionReceipt {
+	fn from(logs: Vec<BaseLog>) -> Self {
+		Self(BaseReceipt {
+			logs,
+			..Default::default()
+		})
+	}
+}
+
 impl From<AlloyTransactionReceipt> for TransactionReceipt {
 	fn from(receipt: AlloyTransactionReceipt) -> Self {
 		let inner_receipt = match &receipt.inner {

--- a/src/services/blockchain/clients/evm/client.rs
+++ b/src/services/blockchain/clients/evm/client.rs
@@ -83,13 +83,14 @@ pub trait EvmClientTrait {
 	/// # Arguments
 	/// * `from_block` - Starting block number
 	/// * `to_block` - Ending block number
-	///
+	/// * `addresses` - Optional list of addresses to filter logs by
 	/// # Returns
 	/// * `Result<Vec<Log>, anyhow::Error>` - Collection of matching logs or error
 	async fn get_logs_for_blocks(
 		&self,
 		from_block: u64,
 		to_block: u64,
+		addresses: Option<Vec<String>>,
 	) -> Result<Vec<EVMReceiptLog>, anyhow::Error>;
 }
 
@@ -137,7 +138,7 @@ impl<T: Send + Sync + Clone + BlockchainTransport> EvmClientTrait for EvmClient<
 	/// # Arguments
 	/// * `from_block` - Starting block number
 	/// * `to_block` - Ending block number
-	///
+	/// * `addresses` - Optional list of addresses to filter logs by
 	/// # Returns
 	/// * `Result<Vec<EVMReceiptLog>, anyhow::Error>` - Collection of matching logs or error
 	#[instrument(skip(self), fields(from_block, to_block))]
@@ -145,11 +146,13 @@ impl<T: Send + Sync + Clone + BlockchainTransport> EvmClientTrait for EvmClient<
 		&self,
 		from_block: u64,
 		to_block: u64,
+		addresses: Option<Vec<String>>,
 	) -> Result<Vec<EVMReceiptLog>, anyhow::Error> {
 		// Convert parameters to JSON-RPC format
 		let params = json!([{
 			"fromBlock": format!("0x{:x}", from_block),
-			"toBlock": format!("0x{:x}", to_block)
+			"toBlock": format!("0x{:x}", to_block),
+			"address": addresses
 		}])
 		.as_array()
 		.with_context(|| "Failed to create JSON-RPC params array")?

--- a/src/services/filter/filters/evm/filter.rs
+++ b/src/services/filter/filters/evm/filter.rs
@@ -672,6 +672,10 @@ impl<T: BlockChainClient + EvmClientTrait> BlockFilter for EVMBlockFilter<T> {
 		let current_block_number = evm_block.number.unwrap_or(U64::from(0)).to::<u64>();
 
 		// Get logs for the block
+		// We use this to get all the logs for a single block.
+		// We could further optimize by getting logs for a range of blocks and calling this in the parent function
+		// However, due to limitations by certain RPC providers (e.g. Quicknode only allows a block range of 5),
+		// it's safer to just fetch the logs for a single block at a time as it's more reliable.
 		let all_block_logs = client
 			.get_logs_for_blocks(current_block_number, current_block_number, None)
 			.await?;

--- a/src/services/filter/filters/evm/filter.rs
+++ b/src/services/filter/filters/evm/filter.rs
@@ -52,7 +52,7 @@ impl<T> EVMBlockFilter<T> {
 		&self,
 		tx_status: &TransactionStatus,
 		transaction: &EVMTransaction,
-		tx_receipt: &EVMTransactionReceipt,
+		tx_receipt: &Option<EVMTransactionReceipt>,
 		monitor: &Monitor,
 		matched_transactions: &mut Vec<TransactionCondition>,
 	) {
@@ -139,13 +139,19 @@ impl<T> EVMBlockFilter<T> {
 							},
 							EVMMatchParamEntry {
 								name: "gas_used".to_string(),
-								value: tx_receipt.gas_used.unwrap_or_default().to_string(),
+								value: tx_receipt
+									.as_ref()
+									.map(|r| r.gas_used.unwrap_or_default().to_string())
+									.unwrap_or_default(),
 								kind: "uint256".to_string(),
 								indexed: false,
 							},
 							EVMMatchParamEntry {
 								name: "transaction_index".to_string(),
-								value: tx_receipt.transaction_index.0.to_string(),
+								value: tx_receipt
+									.as_ref()
+									.map(|r| r.transaction_index.0.to_string())
+									.unwrap_or_default(),
 								kind: "uint64".to_string(),
 								indexed: false,
 							},
@@ -177,6 +183,7 @@ impl<T> EVMBlockFilter<T> {
 	/// the monitor's function conditions.
 	///
 	/// # Arguments
+	/// * `contract_specs` - List of contract specifications
 	/// * `transaction` - The transaction containing the function call
 	/// * `monitor` - Monitor containing function match conditions
 	/// * `matched_functions` - Vector to store matching functions
@@ -316,20 +323,20 @@ impl<T> EVMBlockFilter<T> {
 	/// the monitor's event conditions.
 	///
 	/// # Arguments
-	/// * `receipt` - Transaction receipt containing event logs
+	/// * `logs` - Transaction receipt containing event logs
 	/// * `monitor` - Monitor containing event match conditions
 	/// * `matched_events` - Vector to store matching events
 	/// * `matched_on_args` - Arguments from matched events
 	/// * `involved_addresses` - Addresses involved in matched events
 	pub async fn find_matching_events_for_transaction(
 		&self,
-		receipt: &EVMTransactionReceipt,
+		logs: &[EVMReceiptLog],
 		monitor: &Monitor,
 		matched_events: &mut Vec<EventCondition>,
 		matched_on_args: &mut EVMMatchArguments,
 		involved_addresses: &mut Vec<String>,
 	) {
-		for log in &receipt.logs {
+		for log in logs {
 			// Find the specific monitored address that matches the log address
 			let matching_monitored_addr = monitor
 				.addresses
@@ -603,6 +610,25 @@ impl<T> EVMBlockFilter<T> {
 
 		decoded_log
 	}
+
+	/// Checks if a monitor has any transaction conditions that require a receipt
+	fn needs_receipt(&self, monitor: &Monitor, logs: &[EVMReceiptLog]) -> bool {
+		monitor
+			.match_conditions
+			.transactions
+			.iter()
+			.any(|condition| {
+				// If the status is not Any, and there are no logs, we need a receipt to validate the transaction most likely failed
+				let status_needs_receipt =
+					condition.status != TransactionStatus::Any && logs.is_empty();
+				// If the expression contains gas_used, we need a receipt to get the gas used
+				let gas_used_in_expr = condition
+					.clone()
+					.expression
+					.is_some_and(|expr| expr.contains("gas_used"));
+				status_needs_receipt || gas_used_in_expr
+			})
+	}
 }
 
 #[async_trait]
@@ -643,44 +669,18 @@ impl<T: BlockChainClient + EvmClientTrait> BlockFilter for EVMBlockFilter<T> {
 			evm_block.number.unwrap_or(U64::from(0))
 		);
 
-		// Process all transaction receipts in parallel
-		let receipt_futures: Vec<_> = evm_block
-			.transactions
-			.iter()
-			.map(|transaction| {
-				let tx_hash = b256_to_string(transaction.hash);
-				// Capture transaction hash in the closure for better error context
-				async move { client.get_transaction_receipt(tx_hash.clone()).await }
-			})
-			.collect();
+		let current_block_number = evm_block.number.unwrap_or(U64::from(0)).to::<u64>();
 
-		let receipt_results = futures::future::join_all(receipt_futures).await;
+		// Get logs for the block
+		let all_block_logs = client
+			.get_logs_for_blocks(current_block_number, current_block_number, None)
+			.await?;
 
-		// Partition receipts into successful and failed
-		let mut receipts = Vec::new();
-		for result in receipt_results.into_iter() {
-			match result {
-				Ok(receipt) => receipts.push(receipt),
-				Err(e) => {
-					FilterError::network_error(
-						format!(
-							"Failed to get a receipt for block {}",
-							evm_block.number.unwrap_or(U64::from(0))
-						),
-						Some(e.into()),
-						None,
-					);
-				}
-			}
-		}
-
-		if receipts.is_empty() {
-			tracing::debug!(
-				"No transactions found for block {}",
-				evm_block.number.unwrap_or(U64::from(0))
-			);
-			return Ok(vec![]);
-		}
+		tracing::debug!(
+			"Found {} logs for block {}",
+			all_block_logs.len(),
+			current_block_number
+		);
 
 		let mut matching_results = Vec::new();
 
@@ -694,7 +694,15 @@ impl<T: BlockChainClient + EvmClientTrait> BlockFilter for EVMBlockFilter<T> {
 			})
 			.collect::<Vec<(String, EVMContractSpec)>>();
 
-		tracing::debug!("Processing {} monitor(s)", monitors.len());
+		// Group logs by transaction hash
+		let mut logs_by_tx: std::collections::HashMap<String, Vec<EVMReceiptLog>> =
+			std::collections::HashMap::new();
+		for log in all_block_logs.clone() {
+			let tx_hash = b256_to_string(log.transaction_hash.unwrap_or_default());
+			logs_by_tx.entry(tx_hash).or_default().push(log);
+		}
+
+		tracing::debug!("Processing {} transactions with logs", logs_by_tx.len());
 
 		for monitor in monitors {
 			tracing::debug!("Processing monitor: {:?}", monitor.name);
@@ -703,159 +711,175 @@ impl<T: BlockChainClient + EvmClientTrait> BlockFilter for EVMBlockFilter<T> {
 				.iter()
 				.map(|a| a.address.clone())
 				.collect();
-			// Check each receipt and transaction for matches
-			tracing::debug!("Processing {} receipt(s)", receipts.len());
-			for receipt in &receipts {
-				let matching_transaction = evm_block
-					.transactions
-					.iter()
-					.find(|tx| tx.hash == receipt.transaction_hash);
 
-				if let Some(transaction) = matching_transaction {
-					// Reset matched_on_args for each transaction
-					let mut matched_on_args = EVMMatchArguments {
-						events: Some(Vec::new()),
-						functions: Some(Vec::new()),
-					};
+			// Check if this monitor needs a receipt
+			let should_fetch_receipt = self.needs_receipt(monitor, &all_block_logs);
 
-					// Get transaction status from receipt
-					let tx_status = if receipt.status.map(|s| s.to::<u64>() == 1).unwrap_or(false) {
+			// Process all transactions in the block
+			for transaction in &evm_block.transactions {
+				let tx_hash = b256_to_string(transaction.hash);
+				let empty_logs = Vec::new();
+				let logs = logs_by_tx.get(&tx_hash).unwrap_or(&empty_logs);
+				let tx_hash_str = tx_hash.clone();
+
+				let receipt = if should_fetch_receipt {
+					Some(client.get_transaction_receipt(tx_hash_str).await?)
+				} else {
+					None
+				};
+
+				// Reset matched_on_args for each transaction
+				let mut matched_on_args = EVMMatchArguments {
+					events: Some(Vec::new()),
+					functions: Some(Vec::new()),
+				};
+
+				// Get transaction status from receipt
+				let tx_status = if let Some(receipt) = receipt.clone() {
+					if receipt.status.map(|s| s.to::<u64>() == 1).unwrap_or(false) {
 						TransactionStatus::Success
 					} else {
 						TransactionStatus::Failure
+					}
+				} else {
+					// Transaction receipt is only fetched when:
+					// 1. The monitor has conditions requiring receipt data (e.g., gas_used)
+					// 2. We need to verify transaction status and have no logs
+					// Otherwise, we can assume success since failed transactions don't emit logs
+					TransactionStatus::Success
+				};
+
+				// Collect all involved addresses from receipt logs, transaction.to, and transaction.from
+				let mut involved_addresses = Vec::new();
+				// Add transaction addresses
+				if let Some(from) = transaction.from {
+					involved_addresses.push(h160_to_string(from));
+				}
+				if let Some(to) = transaction.to {
+					involved_addresses.push(h160_to_string(to));
+				}
+
+				let mut matched_events = Vec::<EventCondition>::new();
+				let mut matched_transactions = Vec::<TransactionCondition>::new();
+				let mut matched_functions = Vec::<FunctionCondition>::new();
+
+				// Check transaction match conditions
+				self.find_matching_transaction(
+					&tx_status,
+					transaction,
+					&receipt.clone(),
+					monitor,
+					&mut matched_transactions,
+				);
+
+				// Check for event match conditions
+				self.find_matching_events_for_transaction(
+					logs,
+					monitor,
+					&mut matched_events,
+					&mut matched_on_args,
+					&mut involved_addresses,
+				)
+				.await;
+
+				// Check function match conditions
+				self.find_matching_functions_for_transaction(
+					&contract_specs,
+					transaction,
+					monitor,
+					&mut matched_functions,
+					&mut matched_on_args,
+				);
+
+				// Remove duplicates
+				involved_addresses.sort_unstable();
+				involved_addresses.dedup();
+
+				let has_address_match = monitored_addresses.iter().any(|addr| {
+					involved_addresses
+						.iter()
+						.map(|a| normalize_address(a))
+						.collect::<Vec<String>>()
+						.contains(&normalize_address(addr))
+				});
+
+				// Only proceed if we have a matching address
+				if has_address_match {
+					let monitor_conditions = &monitor.match_conditions;
+					let has_event_match =
+						!monitor_conditions.events.is_empty() && !matched_events.is_empty();
+					let has_function_match =
+						!monitor_conditions.functions.is_empty() && !matched_functions.is_empty();
+					let has_transaction_match = !monitor_conditions.transactions.is_empty()
+						&& !matched_transactions.is_empty();
+
+					let should_match: bool = match (
+						monitor_conditions.events.is_empty(),
+						monitor_conditions.functions.is_empty(),
+						monitor_conditions.transactions.is_empty(),
+					) {
+						// Case 1: No conditions defined, match everything
+						(true, true, true) => true,
+
+						// Case 2: Only transaction conditions defined
+						(true, true, false) => has_transaction_match,
+
+						// Case 3: No transaction conditions, match based on events/functions
+						(_, _, true) => has_event_match || has_function_match,
+
+						// Case 4: Transaction conditions exist, they must be satisfied along
+						// with events/functions
+						_ => (has_event_match || has_function_match) && has_transaction_match,
 					};
 
-					// Collect all involved addresses from receipt logs, transaction.to, and
-					// transaction.from
-					let mut involved_addresses = Vec::new();
-					// Add transaction addresses
-					if let Some(from) = transaction.from {
-						involved_addresses.push(h160_to_string(from));
-					}
-					if let Some(to) = transaction.to {
-						involved_addresses.push(h160_to_string(to));
-					}
-					let mut matched_events = Vec::<EventCondition>::new();
-					let mut matched_transactions = Vec::<TransactionCondition>::new();
-					let mut matched_functions = Vec::<FunctionCondition>::new();
-
-					// Check transaction match conditions
-					self.find_matching_transaction(
-						&tx_status,
-						transaction,
-						receipt,
-						monitor,
-						&mut matched_transactions,
-					);
-
-					// Check for event match conditions
-					self.find_matching_events_for_transaction(
-						receipt,
-						monitor,
-						&mut matched_events,
-						&mut matched_on_args,
-						&mut involved_addresses,
-					)
-					.await;
-
-					// Check function match conditions
-					self.find_matching_functions_for_transaction(
-						&contract_specs,
-						transaction,
-						monitor,
-						&mut matched_functions,
-						&mut matched_on_args,
-					);
-
-					// Remove duplicates
-					involved_addresses.sort_unstable();
-					involved_addresses.dedup();
-
-					let has_address_match = monitored_addresses.iter().any(|addr| {
-						involved_addresses
-							.iter()
-							.map(|a| normalize_address(a))
-							.collect::<Vec<String>>()
-							.contains(&normalize_address(addr))
-					});
-
-					// Only proceed if we have a matching address
-					if has_address_match {
-						let monitor_conditions = &monitor.match_conditions;
-						let has_event_match =
-							!monitor_conditions.events.is_empty() && !matched_events.is_empty();
-						let has_function_match = !monitor_conditions.functions.is_empty()
-							&& !matched_functions.is_empty();
-						let has_transaction_match = !monitor_conditions.transactions.is_empty()
-							&& !matched_transactions.is_empty();
-
-						let should_match = match (
-							monitor_conditions.events.is_empty(),
-							monitor_conditions.functions.is_empty(),
-							monitor_conditions.transactions.is_empty(),
-						) {
-							// Case 1: No conditions defined, match everything
-							(true, true, true) => true,
-
-							// Case 2: Only transaction conditions defined
-							(true, true, false) => has_transaction_match,
-
-							// Case 3: No transaction conditions, match based on events/functions
-							(_, _, true) => has_event_match || has_function_match,
-
-							// Case 4: Transaction conditions exist, they must be satisfied along
-							// with events/functions
-							_ => (has_event_match || has_function_match) && has_transaction_match,
-						};
-
-						if should_match {
-							matching_results.push(MonitorMatch::EVM(Box::new(EVMMonitorMatch {
-								monitor: Monitor {
-									// Omit ABI from monitor since we do not need it here
-									addresses: monitor
-										.addresses
-										.iter()
-										.map(|addr| AddressWithSpec {
-											contract_spec: None,
-											..addr.clone()
-										})
-										.collect(),
-									..monitor.clone()
+					if should_match {
+						matching_results.push(MonitorMatch::EVM(Box::new(EVMMonitorMatch {
+							monitor: Monitor {
+								// Omit ABI from monitor since we do not need it here
+								addresses: monitor
+									.addresses
+									.iter()
+									.map(|addr| AddressWithSpec {
+										contract_spec: None,
+										..addr.clone()
+									})
+									.collect(),
+								..monitor.clone()
+							},
+							transaction: transaction.clone(),
+							receipt,
+							logs: Some(logs.clone()),
+							network_slug: network.slug.clone(),
+							matched_on: MatchConditions {
+								events: matched_events
+									.clone()
+									.into_iter()
+									.filter(|_| has_event_match)
+									.collect(),
+								functions: matched_functions
+									.clone()
+									.into_iter()
+									.filter(|_| has_function_match)
+									.collect(),
+								transactions: matched_transactions
+									.clone()
+									.into_iter()
+									.filter(|_| has_transaction_match)
+									.collect(),
+							},
+							matched_on_args: Some(EVMMatchArguments {
+								events: if has_event_match {
+									matched_on_args.events.clone()
+								} else {
+									None
 								},
-								transaction: transaction.clone(),
-								receipt: receipt.clone(),
-								network_slug: network.slug.clone(),
-								matched_on: MatchConditions {
-									events: matched_events
-										.clone()
-										.into_iter()
-										.filter(|_| has_event_match)
-										.collect(),
-									functions: matched_functions
-										.clone()
-										.into_iter()
-										.filter(|_| has_function_match)
-										.collect(),
-									transactions: matched_transactions
-										.clone()
-										.into_iter()
-										.filter(|_| has_transaction_match)
-										.collect(),
+								functions: if has_function_match {
+									matched_on_args.functions.clone()
+								} else {
+									None
 								},
-								matched_on_args: Some(EVMMatchArguments {
-									events: if has_event_match {
-										matched_on_args.events.clone()
-									} else {
-										None
-									},
-									functions: if has_function_match {
-										matched_on_args.functions.clone()
-									} else {
-										None
-									},
-								}),
-							})));
-						}
+							}),
+						})));
 					}
 				}
 			}
@@ -1009,7 +1033,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&TransactionBuilder::new().build(),
-			&receipt,
+			&Some(receipt),
 			&monitor,
 			&mut matched,
 		);
@@ -1040,7 +1064,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&TransactionBuilder::new().build(),
-			&receipt_success,
+			&Some(receipt_success),
 			&monitor,
 			&mut matched,
 		);
@@ -1055,7 +1079,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Failure,
 			&TransactionBuilder::new().build(),
-			&receipt_failure,
+			&Some(receipt_failure),
 			&monitor,
 			&mut matched,
 		);
@@ -1087,7 +1111,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_1,
-			&tx_receipt_1,
+			&Some(tx_receipt_1),
 			&monitor,
 			&mut matched,
 		);
@@ -1106,7 +1130,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_2,
-			&tx_receipt_2,
+			&Some(tx_receipt_2),
 			&monitor,
 			&mut matched,
 		);
@@ -1140,7 +1164,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1160,7 +1184,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1194,7 +1218,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1214,7 +1238,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1245,7 +1269,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1266,7 +1290,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1297,7 +1321,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1317,7 +1341,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1347,7 +1371,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1367,7 +1391,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1397,7 +1421,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1417,7 +1441,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1445,7 +1469,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1463,7 +1487,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1491,7 +1515,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1509,7 +1533,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1538,7 +1562,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1557,7 +1581,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1585,7 +1609,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_matching,
-			&tx_receipt_matching,
+			&Some(tx_receipt_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1603,7 +1627,7 @@ mod tests {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx_non_matching,
-			&tx_receipt_non_matching,
+			&Some(tx_receipt_non_matching),
 			&monitor,
 			&mut matched,
 		);
@@ -1972,7 +1996,7 @@ mod tests {
 
 		filter
 			.find_matching_events_for_transaction(
-				&receipt,
+				&receipt.logs,
 				&monitor,
 				&mut matched_events,
 				&mut matched_on_args,
@@ -2029,7 +2053,7 @@ mod tests {
 
 		filter
 			.find_matching_events_for_transaction(
-				&receipt,
+				&receipt.logs,
 				&monitor,
 				&mut matched_events,
 				&mut matched_on_args,
@@ -2059,7 +2083,7 @@ mod tests {
 
 		filter
 			.find_matching_events_for_transaction(
-				&receipt_no_match,
+				&receipt_no_match.logs,
 				&monitor,
 				&mut matched_events,
 				&mut matched_on_args,
@@ -2105,7 +2129,7 @@ mod tests {
 
 		filter
 			.find_matching_events_for_transaction(
-				&receipt,
+				&receipt.logs,
 				&monitor,
 				&mut matched_events,
 				&mut matched_on_args,

--- a/src/services/notification/mod.rs
+++ b/src/services/notification/mod.rs
@@ -331,7 +331,8 @@ mod tests {
 		MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 			monitor: create_test_monitor(vec![], vec![], vec![], vec![]),
 			transaction: create_test_evm_transaction(),
-			receipt: EVMTransactionReceipt::default(),
+			receipt: Some(EVMTransactionReceipt::default()),
+			logs: Some(vec![]),
 			network_slug: "evm_mainnet".to_string(),
 			matched_on: MatchConditions {
 				functions: vec![],

--- a/src/services/notification/script.rs
+++ b/src/services/notification/script.rs
@@ -140,7 +140,8 @@ mod tests {
 		MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 			monitor: create_test_monitor("test_monitor", vec!["ethereum_mainnet"], false, vec![]),
 			transaction: create_test_evm_transaction(),
-			receipt: EVMTransactionReceipt::default(),
+			receipt: Some(EVMTransactionReceipt::default()),
+			logs: Some(vec![]),
 			network_slug: "ethereum_mainnet".to_string(),
 			matched_on: MatchConditions::default(),
 			matched_on_args: None,

--- a/src/services/trigger/script/executor.rs
+++ b/src/services/trigger/script/executor.rs
@@ -241,16 +241,14 @@ mod tests {
 	use super::*;
 	use crate::{
 		models::{
-			AddressWithSpec, EVMMonitorMatch, EVMTransaction, EVMTransactionReceipt,
+			AddressWithSpec, EVMMonitorMatch, EVMReceiptLog, EVMTransaction, EVMTransactionReceipt,
 			EventCondition, FunctionCondition, MatchConditions, Monitor, MonitorMatch,
 			TransactionCondition,
 		},
-		utils::tests::evm::monitor::MonitorBuilder,
+		utils::tests::evm::{monitor::MonitorBuilder, receipt::ReceiptBuilder},
 	};
 	use alloy::{
-		consensus::{
-			transaction::Recovered, Receipt, ReceiptEnvelope, ReceiptWithBloom, Signed, TxEnvelope,
-		},
+		consensus::{transaction::Recovered, Signed, TxEnvelope},
 		primitives::{Address, Bytes, TxKind, B256, U256},
 	};
 	use std::{fs, path::Path, time::Instant};
@@ -295,23 +293,11 @@ mod tests {
 	}
 
 	fn create_test_evm_transaction_receipt() -> EVMTransactionReceipt {
-		EVMTransactionReceipt::from(alloy::rpc::types::TransactionReceipt {
-			inner: ReceiptEnvelope::Legacy(ReceiptWithBloom {
-				receipt: Receipt::default(),
-				logs_bloom: Default::default(),
-			}),
-			transaction_hash: B256::ZERO,
-			transaction_index: Some(0),
-			block_hash: Some(B256::ZERO),
-			block_number: Some(0),
-			gas_used: 0,
-			effective_gas_price: 0,
-			blob_gas_used: None,
-			blob_gas_price: None,
-			from: Address::ZERO,
-			to: Some(Address::ZERO),
-			contract_address: None,
-		})
+		ReceiptBuilder::new().build()
+	}
+
+	fn create_test_evm_logs() -> Vec<EVMReceiptLog> {
+		ReceiptBuilder::new().build().logs.clone()
 	}
 
 	fn create_test_evm_transaction() -> EVMTransaction {
@@ -346,7 +332,8 @@ mod tests {
 		MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 			monitor: create_test_monitor(vec![], vec![], vec![], vec![]),
 			transaction: create_test_evm_transaction(),
-			receipt: create_test_evm_transaction_receipt(),
+			receipt: Some(create_test_evm_transaction_receipt()),
+			logs: Some(create_test_evm_logs()),
 			network_slug: "evm_mainnet".to_string(),
 			matched_on: MatchConditions {
 				functions: vec![],

--- a/tests/integration/blockchain/clients/evm/client.rs
+++ b/tests/integration/blockchain/clients/evm/client.rs
@@ -64,11 +64,17 @@ async fn test_get_logs_for_blocks() {
 	}];
 
 	mock.expect_get_logs_for_blocks()
-		.with(predicate::eq(1u64), predicate::eq(2u64))
+		.with(
+			predicate::eq(1u64),
+			predicate::eq(2u64),
+			predicate::eq(Some(vec!["0x123".to_string()])),
+		)
 		.times(1)
-		.returning(move |_, _| Ok(expected_logs.clone()));
+		.returning(move |_, _, _| Ok(expected_logs.clone()));
 
-	let result = mock.get_logs_for_blocks(1, 2).await;
+	let result = mock
+		.get_logs_for_blocks(1, 2, Some(vec!["0x123".to_string()]))
+		.await;
 	assert!(result.is_ok());
 	assert_eq!(result.unwrap().len(), 1);
 }

--- a/tests/integration/blockchain/transports/evm/transport.rs
+++ b/tests/integration/blockchain/transports/evm/transport.rs
@@ -42,7 +42,8 @@ async fn test_get_logs_for_blocks_implementation() {
 	// Expected request parameters
 	let expected_params = json!([{
 		"fromBlock": "0x1",
-		"toBlock": "0xa"
+		"toBlock": "0xa",
+		"address": vec!["0x1234567890123456789012345678901234567890"]
 	}]);
 
 	// Mock response with some test logs
@@ -70,7 +71,15 @@ async fn test_get_logs_for_blocks_implementation() {
 		.returning(move |_: &str, _: Option<Vec<Value>>| Ok(mock_response.clone()));
 
 	let client = EvmClient::<MockEVMTransportClient>::new_with_transport(mock_evm);
-	let result = client.get_logs_for_blocks(1, 10).await;
+	let result = client
+		.get_logs_for_blocks(
+			1,
+			10,
+			Some(vec![
+				"0x1234567890123456789012345678901234567890".to_string()
+			]),
+		)
+		.await;
 
 	assert!(result.is_ok());
 	let logs = result.unwrap();
@@ -99,7 +108,7 @@ async fn test_get_logs_for_blocks_missing_result() {
 		.returning(move |_: &str, _: Option<Vec<Value>>| Ok(mock_response.clone()));
 
 	let client = EvmClient::<MockEVMTransportClient>::new_with_transport(mock_evm);
-	let result = client.get_logs_for_blocks(1, 10).await;
+	let result = client.get_logs_for_blocks(1, 10, None).await;
 
 	assert!(result.is_err());
 	let err = result.unwrap_err();
@@ -122,7 +131,7 @@ async fn test_get_logs_for_blocks_invalid_format() {
 		.returning(move |_: &str, _: Option<Vec<Value>>| Ok(mock_response.clone()));
 
 	let client = EvmClient::<MockEVMTransportClient>::new_with_transport(mock_evm);
-	let result = client.get_logs_for_blocks(1, 10).await;
+	let result = client.get_logs_for_blocks(1, 10, None).await;
 
 	assert!(result.is_err());
 	let err = result.unwrap_err();
@@ -138,7 +147,7 @@ async fn test_get_logs_for_blocks_alloy_error() {
 		.returning(|_: &str, _: Option<Vec<Value>>| Err(anyhow::anyhow!("Alloy error")));
 
 	let client = EvmClient::<MockEVMTransportClient>::new_with_transport(mock_evm);
-	let result = client.get_logs_for_blocks(1, 10).await;
+	let result = client.get_logs_for_blocks(1, 10, None).await;
 
 	assert!(result.is_err());
 }

--- a/tests/integration/mocks/clients.rs
+++ b/tests/integration/mocks/clients.rs
@@ -60,6 +60,7 @@ mock! {
 			&self,
 			from_block: u64,
 			to_block: u64,
+			addresses: Option<Vec<String>>,
 		) -> Result<Vec<EVMReceiptLog>,  anyhow::Error>;
 	}
 

--- a/tests/integration/mocks/models.rs
+++ b/tests/integration/mocks/models.rs
@@ -1,11 +1,11 @@
 use mockito::{Mock, Server};
 use openzeppelin_monitor::{
 	models::{
-		BlockChainType, BlockType, EVMBlock, EVMTransaction, EVMTransactionReceipt, Network,
-		StellarBlock, StellarLedgerInfo, StellarTransaction, StellarTransactionInfo,
+		BlockChainType, BlockType, EVMBlock, EVMReceiptLog, EVMTransaction, EVMTransactionReceipt,
+		Network, StellarBlock, StellarLedgerInfo, StellarTransaction, StellarTransactionInfo,
 		TransactionType,
 	},
-	utils::tests::builders::network::NetworkBuilder,
+	utils::tests::{builders::network::NetworkBuilder, evm::receipt::ReceiptBuilder},
 };
 use serde_json::json;
 
@@ -160,21 +160,9 @@ pub fn create_test_transaction(chain: BlockChainType) -> TransactionType {
 }
 
 pub fn create_test_evm_transaction_receipt() -> EVMTransactionReceipt {
-	EVMTransactionReceipt::from(alloy::rpc::types::TransactionReceipt {
-		inner: alloy::consensus::ReceiptEnvelope::Legacy(alloy::consensus::ReceiptWithBloom {
-			receipt: alloy::consensus::Receipt::default(),
-			logs_bloom: alloy::primitives::Bloom::default(),
-		}),
-		transaction_hash: alloy::primitives::B256::ZERO,
-		transaction_index: Some(0),
-		block_hash: Some(alloy::primitives::B256::ZERO),
-		block_number: Some(0),
-		gas_used: 0,
-		effective_gas_price: 0,
-		blob_gas_used: None,
-		blob_gas_price: None,
-		from: alloy::primitives::Address::ZERO,
-		to: Some(alloy::primitives::Address::ZERO),
-		contract_address: None,
-	})
+	ReceiptBuilder::new().build()
+}
+
+pub fn create_test_evm_logs() -> Vec<EVMReceiptLog> {
+	ReceiptBuilder::new().build().logs.clone()
 }

--- a/tests/integration/notifications/discord.rs
+++ b/tests/integration/notifications/discord.rs
@@ -9,7 +9,9 @@ use openzeppelin_monitor::{
 use serde_json::json;
 use std::collections::HashMap;
 
-use crate::integration::mocks::{create_test_evm_transaction_receipt, create_test_transaction};
+use crate::integration::mocks::{
+	create_test_evm_logs, create_test_evm_transaction_receipt, create_test_transaction,
+};
 
 fn create_test_monitor(name: &str) -> Monitor {
 	MonitorBuilder::new()
@@ -29,7 +31,8 @@ fn create_test_evm_match(monitor: Monitor) -> MonitorMatch {
 	MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 		monitor,
 		transaction,
-		receipt: create_test_evm_transaction_receipt(),
+		receipt: Some(create_test_evm_transaction_receipt()),
+		logs: Some(create_test_evm_logs()),
 		network_slug: "ethereum_mainnet".to_string(),
 		matched_on: MatchConditions::default(),
 		matched_on_args: None,

--- a/tests/integration/notifications/script.rs
+++ b/tests/integration/notifications/script.rs
@@ -8,7 +8,9 @@ use openzeppelin_monitor::{
 };
 use std::collections::HashMap;
 
-use crate::integration::mocks::{create_test_evm_transaction_receipt, create_test_transaction};
+use crate::integration::mocks::{
+	create_test_evm_logs, create_test_evm_transaction_receipt, create_test_transaction,
+};
 
 fn create_test_monitor(name: &str) -> Monitor {
 	MonitorBuilder::new()
@@ -28,7 +30,8 @@ fn create_test_evm_match(monitor: Monitor) -> MonitorMatch {
 	MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 		monitor,
 		transaction,
-		receipt: create_test_evm_transaction_receipt(),
+		receipt: Some(create_test_evm_transaction_receipt()),
+		logs: Some(create_test_evm_logs()),
 		network_slug: "ethereum_mainnet".to_string(),
 		matched_on: MatchConditions::default(),
 		matched_on_args: None,

--- a/tests/integration/notifications/slack.rs
+++ b/tests/integration/notifications/slack.rs
@@ -9,7 +9,9 @@ use openzeppelin_monitor::{
 use serde_json::json;
 use std::collections::HashMap;
 
-use crate::integration::mocks::{create_test_evm_transaction_receipt, create_test_transaction};
+use crate::integration::mocks::{
+	create_test_evm_logs, create_test_evm_transaction_receipt, create_test_transaction,
+};
 
 fn create_test_monitor(name: &str) -> Monitor {
 	MonitorBuilder::new()
@@ -29,7 +31,8 @@ fn create_test_evm_match(monitor: Monitor) -> MonitorMatch {
 	MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 		monitor,
 		transaction,
-		receipt: create_test_evm_transaction_receipt(),
+		receipt: Some(create_test_evm_transaction_receipt()),
+		logs: Some(create_test_evm_logs()),
 		network_slug: "ethereum_mainnet".to_string(),
 		matched_on: MatchConditions::default(),
 		matched_on_args: None,

--- a/tests/integration/notifications/webhook.rs
+++ b/tests/integration/notifications/webhook.rs
@@ -9,7 +9,9 @@ use openzeppelin_monitor::{
 use serde_json::json;
 use std::collections::HashMap;
 
-use crate::integration::mocks::{create_test_evm_transaction_receipt, create_test_transaction};
+use crate::integration::mocks::{
+	create_test_evm_logs, create_test_evm_transaction_receipt, create_test_transaction,
+};
 
 fn create_test_monitor(name: &str) -> Monitor {
 	MonitorBuilder::new()
@@ -29,7 +31,8 @@ fn create_test_evm_match(monitor: Monitor) -> MonitorMatch {
 	MonitorMatch::EVM(Box::new(EVMMonitorMatch {
 		monitor,
 		transaction,
-		receipt: create_test_evm_transaction_receipt(),
+		receipt: Some(create_test_evm_transaction_receipt()),
+		logs: Some(create_test_evm_logs()),
 		network_slug: "ethereum_mainnet".to_string(),
 		matched_on: MatchConditions::default(),
 		matched_on_args: None,

--- a/tests/properties/filters/evm/filter.rs
+++ b/tests/properties/filters/evm/filter.rs
@@ -503,7 +503,7 @@ proptest! {
 			filter.find_matching_transaction(
 				&status,
 				&tx,
-				&ReceiptBuilder::new().build(),
+				&Some(ReceiptBuilder::new().build()),
 				&monitor,
 				&mut matched_transactions
 			);
@@ -550,7 +550,7 @@ proptest! {
 		filter.find_matching_transaction(
 			&TransactionStatus::Success,
 			&tx,
-			&ReceiptBuilder::new().build(),
+			&Some(ReceiptBuilder::new().build()),
 			&monitor,
 			&mut matched_transactions
 		);


### PR DESCRIPTION
# Summary

https://linear.app/openzeppelin-development/issue/PLAT-6612/reduce-evm-calls-by-using-eth-getlogs-instead-of-eth


The monitor has been optimised to reduce unnecessary RPC calls by implementing a smarter transaction receipt fetching strategy:

* **Previously:** Fetched transaction receipts for every transaction in a block
* **Now:** Only fetches transaction receipts when necessary:
  * When monitoring conditions require receipt-specific fields (e.g., `gas_used`)
  * When monitoring transaction status and no logs are present to validate status

This optimisation significantly reduces RPC calls by:
* Fetching block logs in bulk instead of individual transaction receipts
* Eliminating redundant receipt fetches for transactions that don't need them
* Maintaining the same monitoring capabilities while reducing API usage

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
- [x] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [x] Update documentation if applicable.
