### PR TITLE
docs: Add Midnight documentation

### DIFF
--- a/config/triggers/scripts/custom_notification.sh
+++ b/config/triggers/scripts/custom_notification.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+################################################################################
+# Custom Notification Script
+#
+# This script validates JSON input and logs validation results to stderr.
+#
+# Input: JSON object containing:
+#   - monitor_match: The monitor match data
+#   - args: Additional arguments passed to the script (optional)
+#
+# Arguments:
+#   --verbose: Enables detailed logging of the processing
+#
+# Note: Only stderr output is monitored. If the script returns a non-zero exit code, the error will be logged.
+################################################################################
+
+# Enable error handling
+set -e
+
+main() {
+    # Read JSON input from stdin
+    input_json=$(cat)
+
+    # Parse arguments from the input JSON and initialize verbose flag
+    verbose=false
+    args=$(echo "$input_json" | jq -r '.args[]? // empty')
+    if [ ! -z "$args" ]; then
+        while IFS= read -r arg; do
+            if [ "$arg" = "--verbose" ]; then
+                verbose=true
+                echo "Verbose mode enabled"
+            fi
+        done <<< "$args"
+    fi
+
+    # Extract the monitor match data from the input
+    monitor_data=$(echo "$input_json" | jq -r '.monitor_match')
+
+    # Validate input
+    if [ -z "$input_json" ]; then
+        echo "No input JSON provided"
+        exit 1
+    fi
+
+    # Validate JSON structure
+    if ! echo "$input_json" | jq . >/dev/null 2>&1; then
+        echo "Invalid JSON input"
+        exit 1
+    fi
+
+    if [ "$verbose" = true ]; then
+        echo "Input JSON received:"
+        echo "$input_json" | jq '.'
+        echo "Monitor match data:"
+        echo "$monitor_data" | jq '.'
+    fi
+
+    # Process args if they exist
+    args_data=$(echo "$input_json" | jq -r '.args')
+    if [ "$args_data" != "null" ]; then
+        echo "Args: $args_data"
+    fi
+
+    # If we made it here, everything worked
+    echo "Verbose mode: $verbose"
+
+}
+
+# Call main function
+main

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -18,6 +18,7 @@ In the rapidly evolving world of blockchain technology, effective monitoring is 
 
 - EVM
 - Stellar
+- Midnight
 
 **Supported Triggers (OOTB):**
 
@@ -62,6 +63,7 @@ graph TD
         BC[BlockchainClient]
         EVM[EVMClient]
         STL[StellarClient]
+        MDN[MidnightClient]
     end
 
     subgraph Processing Pipeline
@@ -88,6 +90,7 @@ graph TD
     %% Client Connections
     BC --> EVM
     BC --> STL
+    BC --> MDN
     EVM -->|RPC Calls| ETH
     EVM -->|RPC Calls| POL
     EVM -->|RPC Calls| BSC
@@ -102,8 +105,6 @@ graph TD
     NS --> Telegram
     NS --> Webhook
     NS --> Script
-
-    style STL fill:#f0f0f0
 
     classDef rpc fill:#e1f5fe,stroke:#01579b
     classDef storage fill:#fff3e0,stroke:#ef6c00
@@ -1103,7 +1104,8 @@ The monitor uses a structured JSON format with nested objects for template varia
 
 [NOTE]
 ====
-Transaction-related variables (`transaction.from`, `transaction.to`, `transaction.value`) are not available for Stellar networks.
+* Transaction-related variables (`transaction.from`, `transaction.to`, `transaction.value`) are not available for Stellar networks.
+* Due to the privacy-focused design of the Midnight network, monitoring specific transaction details or function/event arguments is not supported.
 ====
 
 ==== Message Formatting
@@ -1221,6 +1223,7 @@ A Monitor defines what blockchain activity to watch and what actions to take whe
       "contract_spec": [ ... ]
     }
   ],
+  "chain_configurations": [...],
   "match_conditions": {
     "functions": [
       {
@@ -1288,7 +1291,7 @@ Match events emitted by monitored contracts:
 ----
 
 ===== Transaction Conditions
-Match transaction properties. The available fields and expression syntax depend on the network type (EVM/Stellar)
+Match transaction properties. The available fields and expression syntax depend on the network type:
 
 [source,json]
 ----
@@ -1452,6 +1455,48 @@ Match transaction properties. The available fields and expression syntax depend 
 |triggers
 |Array[String]
 |IDs of triggers to execute when conditions match
+
+|chain_configurations
+|Array[Object]
+|Chain-specific configuration settings for the monitor
+|===
+
+==== Chain-Specific Configurations
+
+The monitor supports optional chain-specific configuration settings through the `chain_configurations` field. This allows you to provide additional settings that are specific to certain blockchain networks without modifying the core monitor structure.
+
+[source,json]
+----
+{
+  "chain_configurations": [
+    {
+      "midnight": {
+        "viewing_keys": [
+          {
+            "type": "environment",
+            "value": "MIDNIGHT_VIEWING_KEY"
+          }
+        ]
+      }
+    }
+  ]
+}
+----
+
+===== Available Chain Configurations
+
+[cols="1,2"]
+|===
+|Chain Type |Configuration
+
+|EVM
+|Currently no specific configuration required
+
+|Stellar
+|Currently no specific configuration required
+
+|Midnight
+|Requires viewing keys for decrypting private CoinInfo
 |===
 
 ==== Matching Rules

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -498,7 +498,7 @@ This link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/example
 
 [NOTE]
 ====
-* The `abi` field is optional for Stellar contracts. If not provided, the monitor will automatically fetch the contract's SEP-48 interface from the chain.
+* The `contract_spec` field is optional for Stellar contracts. If not provided, the monitor will automatically fetch the contract's SEP-48 interface from the chain.
 * You can find the contract specification through Stellar contract explorer tool. For example: link:https://lab.stellar.org/smart-contracts/contract-explorer?$=network$id=mainnet&label=Mainnet&horizonUrl=https:////horizon.stellar.org&rpcUrl=https:////mainnet.sorobanrpc.com&passphrase=Public%20Global%20Stellar%20Network%20/;%20September%202015;&smartContracts$explorer$contractId=CA6PUJLBYKZKUEKLZJMKBZLEKP2OTHANDEOWSFF44FTSYLKQPIICCJBE;;[Stellar DEX Contract Interface^]
 ====
 
@@ -564,6 +564,155 @@ The monitor will now:
 
 * Adjust the swap threshold by modifying the `expression` value.
 * Monitor additional dex swaps by creating new monitor configurations.
+* xref:index.adoc#testing_your_configuration[Test the Monitor] configuration against a block number
+* xref:index.adoc#secret_management[Configure secure secret management] for sensitive data using environment variables or Hashicorp Cloud Vault
+* Explore other examples in the link:https://github.com/OpenZeppelin/openzeppelin-monitor/tree/main/examples/config/monitors[`examples/config/monitors` directory].
+
+
+=== Monitoring Bulletin Post (Midnight):
+
+==== 1. Network Configuration:
+
+Create the Midnight testnet network configuration:
+
+[source,bash]
+----
+cp examples/config/networks/examples/midnight_testnet.json config/networks/midnight_testnet.json
+----
+
+The link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/examples/config/networks/midnight_testnet.json[default configuration^] should work, but you may want to update the RPC URL to your preferred provider.
+
+[source,json]
+----
+{
+  "network_type": "Midnight",
+  "slug": "midnight_testnet",
+  "name": "Midnight Testnet",
+  "rpc_urls": [
+    {
+      "type_": "rpc",
+      "url": {
+        "type": "plain",
+        "value": "YOUR_RPC_URL_HERE"
+      },
+      "weight": 100
+    }
+  ],
+  "chain_id": 0,
+  "block_time_ms": 6000,
+  "confirmation_blocks": 2,
+  "cron_schedule": "0 */1 * * * *",
+  "max_past_blocks": 13,
+  "store_blocks": false
+}
+----
+
+==== 2. Monitor Configuration:
+
+Create the bulletin board post monitor configuration:
+
+[source,bash]
+----
+cp examples/config/monitors/midnight_testnet_bulletin_post.json config/monitors/midnight_testnet_bulletin_post.json
+----
+
+This link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/examples/config/monitors/midnight_testnet_bulletin_post.json[configuration^] monitors `post` transactions to a specific bulletin board contract. You can customize the notification channels by modifying the `triggers` array.
+
+[source,json]
+----
+{
+  "name": "Bulletin post",
+  "paused": false,
+  "networks": [
+    "midnight_testnet"
+  ],
+  "addresses": [
+    {
+      "address": "020200048fe17c5b2ae77e7154ff983dc37f18736a61aaef774c7a997935e84abe8361"
+    }
+  ],
+  "match_conditions": {
+    "functions": [
+      {
+        "signature": "post()",
+        "expression": null
+      }
+    ],
+    "events": [],
+    "transactions": []
+  },
+  "trigger_conditions": [],
+  "triggers": [
+    "midnight_bulletin_post_slack"
+  ]
+}
+----
+
+[NOTE]
+====
+* Event and transaction monitoring is currently not supported
+* Due to the privacy-focused design of the network:
+  ** Transaction details cannot be monitored
+  ** Function and event arguments cannot be monitored
+* Function signatures are simplified:
+  ** All argument variations are treated identically. For example `post`, `post()`, and `post(x, y, z)` are equivalent
+====
+
+==== 3. Notification Configuration:
+
+===== For Slack Notifications:
+
+[source,bash]
+----
+cp examples/config/triggers/slack_notifications.json config/triggers/slack_notifications.json
+----
+
+Update the webhook URL in the link:https://github.com/OpenZeppelin/openzeppelin-monitor/blob/main/examples/config/triggers/slack_notifications.json[configuration^].
+
+[source,json]
+----
+{
+   "midnight_bulletin_post_slack": {
+    "name": "Bulletin Post Slack Notification",
+    "trigger_type": "slack",
+    "config": {
+      "slack_url": {
+        "type": "plain",
+        "value": "https://hooks.slack.com/services/A/B/C"
+      },
+      "message": {
+        "title": "midnight_bulletin_post_slack triggered",
+        "body": "A call to ${functions.0.signature} was made to the bulletin board | ${transaction.hash}"
+      }
+    }
+  }
+}
+----
+
+==== 4. Run the Monitor:
+
+**Local Deployment**
+
+[source,bash]
+----
+./openzeppelin-monitor
+----
+
+**Docker Deployment**
+
+[source,bash]
+----
+cargo make docker-compose-up
+----
+
+The monitor will now:
+
+1. Check for new Midnight blocks every minute.
+2. Watch for `post` calls to a bulletin board contract.
+3. Send notifications via Slack when a new post occurs.
+
+==== 5. Next Steps:
+
 * xref:index.adoc#testing_your_configuration[Test the Monitor] configuration against a block number
 * xref:index.adoc#secret_management[Configure secure secret management] for sensitive data using environment variables or Hashicorp Cloud Vault
 * Explore other examples in the link:https://github.com/OpenZeppelin/openzeppelin-monitor/tree/main/examples/config/monitors[`examples/config/monitors` directory].

--- a/docs/modules/ROOT/pages/rpc.adoc
+++ b/docs/modules/ROOT/pages/rpc.adoc
@@ -243,13 +243,9 @@ As the number of blocks being processed increases, the number of RPC calls grows
 [mermaid,width=100%]
 ....
 graph TD
-    subgraph Common Operations
-        A[Main] --> D[Process New Blocks]
-    end
-
     subgraph EVM Network Calls
-        B[Network Init] -->|net_version| D
-        D -->|eth_blockNumber| E[For every block in range]
+        B[Network Init] -->|net_version| D1[Process New Blocks]
+        D1 -->|eth_blockNumber| E[For every block in range]
         E -->|eth_getBlockByNumber| G1[Process Block]
         G1 -->|eth_getLogs| H[Get Block Logs]
         H -->|Only when needed| J[Get Transaction Receipt]
@@ -257,8 +253,8 @@ graph TD
     end
 
     subgraph Stellar Network Calls
-        C[Network Init] -->|getNetwork| D
-        D -->|getLatestLedger| F[In batches of 200 blocks]
+        C[Network Init] -->|getNetwork| D2[Process New Blocks]
+        D2 -->|getLatestLedger| F[In batches of 200 blocks]
         F -->|getLedgers| G2[Process Block]
         G2 -->|For each monitored contract without ABI| M[Fetch Contract Spec]
         M -->|getLedgerEntries| N[Get WASM Hash]
@@ -269,6 +265,15 @@ graph TD
         P -->|getEvents| L2[Get Events]
         L1 --> Q[Complete]
         L2 --> Q
+    end
+
+    subgraph Midnight Network Calls
+        D3[Network Init] -->|system_chainType| D4[Process New Blocks]
+        D4 -->|chain_getHeader| E1[Get Latest Block]
+        E1 -->|For each block| F1[Get Block Data]
+        F1 -->|chain_getBlockHash| G3[Get Block Hash]
+        G3 -->|midnight_jsonBlock| H1[Get Full Block]
+        H1 --> I1[Complete]
     end
 ....
 
@@ -295,10 +300,11 @@ graph TD
 
 *Midnight*
 
-* RPC Client initialization (per active network): `system_chain`
+* RPC Client initialization (per active network): `system_chainType`
 * Fetching the latest block number (per cron iteration): `chain_getHeader`
-* Fetching block data (per block): `chain_getBlockHash` and `midnight_jsonBlock`
-* Fetching transaction receipt (per transaction in block): ``
+* Fetching block data (per block):
+  ** `chain_getBlockHash` - Gets the block hash for a specific block number
+  ** `midnight_jsonBlock` - Gets the full block data using the block hash
 
 
 == Best Practices

--- a/docs/modules/ROOT/pages/scripts.adoc
+++ b/docs/modules/ROOT/pages/scripts.adoc
@@ -122,17 +122,17 @@ Custom filter scripts allow you to apply additional conditions to matches detect
       },
       "logs": [
          {
-            "address": "0xd1f2586790a5bd6da1e443441df53af6ec213d83",
+            "address": "0x...",
             "topics": [
-                "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef",
-                "0x00000000000000000000000060af8cf92e5aa9ead4a592d657cd6debecfbc616",
-                "0x000000000000000000000000d1f2586790a5bd6da1e443441df53af6ec213d83"
+                "0x...",
+                "0x...",
+                "0x..."
             ],
-            "data": "0x00000000000000000000000000000000000000000000106015728793d21f77ac",
-            "blockNumber": "0x1451aca",
-            "transactionHash": "0xa39d1b9b3edda74414bd6ffaf6596f8ea12cf0012fd9a930f71ed69df6ff34d0",
+            "data": "0x...",
+            "blockNumber": "0x...",
+            "transactionHash": "0x...",
             "transactionIndex": "0x0",
-            "blockHash": "0x9432868b7fc57e85f0435ca3047f6a76add86f804b3c1af85647520061e30f80",
+            "blockHash": "0x...",
             "logIndex": "0x2",
             "removed": false
           },
@@ -248,6 +248,89 @@ Custom filter scripts allow you to apply additional conditions to matches detect
   }
 }
 ----
+
+  * Midnight
++
+[source,json]
+----
+{
+  "args": [
+    "--verbose"
+  ],
+  "monitor_match": {
+    "Midnight": {
+      "matched_on": {
+        "events": [],
+        "functions": [
+          {
+            "expression": null,
+            "signature": "post"
+          }
+        ],
+        "transactions": []
+      },
+      "matched_on_args": {
+        "events": null,
+        "functions": [
+          {
+            "args": null,
+            "hex_signature": "post",
+            "signature": "post"
+          }
+        ]
+      },
+      "monitor": {
+        "addresses": [
+          {
+            "address": "020200048...",
+            "contract_spec": null
+          }
+        ],
+        "match_conditions": {
+          "events": [],
+          "functions": [
+            {
+              "expression": null,
+              "signature": "post()"
+            }
+          ],
+          "transactions": []
+        },
+        "name": "Bulletin post",
+        "networks": [
+          "midnight_testnet"
+        ],
+        "paused": false,
+        "trigger_conditions": [],
+        "triggers": [
+          "midnight_post_slack",
+          "midnight_post_script"
+        ]
+      },
+      "network_slug": "midnight_testnet",
+      "transaction": {
+        "identifiers": [
+          "00000000cef...",
+          "00000000cf2...",
+          "00000000b3e..."
+        ],
+        "operations": [
+          {
+            "Call": {
+              "address": "020200048...",
+              "entry_point": "706f7374"
+            }
+          },
+          "GuaranteedCoins"
+        ],
+        "status": true,
+        "tx_hash": "e3c56..."
+      }
+    }
+  }
+}
+----
+
 
 === Script Output Requirements
 

--- a/docs/modules/ROOT/pages/structure.adoc
+++ b/docs/modules/ROOT/pages/structure.adoc
@@ -15,6 +15,7 @@ The main source code directory contains the core implementation files organized 
 ** `blockchain/`: Platform-specific implementations
 *** `evm/`: Ethereum Virtual Machine specific types
 *** `stellar/`: Stellar blockchain specific types
+*** `midnight/`: Midnight blockchain specific types
 ** `config/`: Configuration loading and validation
 ** `core/`: Core domain models
 ** `security/`: Security and secret management
@@ -29,14 +30,17 @@ The main source code directory contains the core implementation files organized 
 *** `transports/`: Transport clients
 **** `evm/`: Ethereum Virtual Machine transport client
 **** `stellar/`: Stellar transport client
+**** `midnight/`: Midnight transport client
 *** `clients/`: Client implementations
 **** `evm/`: Ethereum Virtual Machine client
 **** `stellar/`: Stellar client
+**** `midnight/`: Midnight client
 ** `blockwatcher/`: Block monitoring and processing
 ** `filter/`: Transaction and event filtering
 *** `filters/`: Filter implementations
 **** `evm/`: Ethereum Virtual Machine filter
 **** `stellar/`: Stellar filter
+**** `midnight/`: Midnight filter
 ** `notification/`: Alert handling
 ** `trigger/`: Trigger evaluation and execution
 **** `script/`: Script execution utilities
@@ -53,6 +57,7 @@ The main source code directory contains the core implementation files organized 
 *** `builders/`: Test builder patterns implementing fluent interfaces for creating test fixtures
 **** `evm/`: Builder implementations specific to Ethereum Virtual Machine (EVM) testing
 **** `stellar/`: Builder implementations specific to Stellar blockchain testing
+**** `midnight/`: Builder implementations specific to Midnight blockchain testing
 
 == Configuration and Data
 

--- a/examples/config/monitors/midnight_testnet_bulletin_post.json
+++ b/examples/config/monitors/midnight_testnet_bulletin_post.json
@@ -1,0 +1,38 @@
+{
+  "name": "Bulletin post",
+  "paused": false,
+  "networks": [
+    "midnight_testnet"
+  ],
+  "addresses": [
+    {
+      "address": "020200048fe17c5b2ae77e7154ff983dc37f18736a61aaef774c7a997935e84abe8361"
+    }
+  ],
+  "chain_configurations": [
+    {
+      "midnight": {
+        "viewing_keys": [
+          {
+            "type": "environment",
+            "value": "MIDNIGHT_VIEWING_KEY"
+          }
+        ]
+      }
+    }
+  ],
+  "match_conditions": {
+    "functions": [
+      {
+        "signature": "post()",
+        "expression": null
+      }
+    ],
+    "events": [],
+    "transactions": []
+  },
+  "trigger_conditions": [],
+  "triggers": [
+    "midnight_bulletin_post_slack"
+  ]
+}

--- a/examples/config/networks/midnight_testnet.json
+++ b/examples/config/networks/midnight_testnet.json
@@ -1,0 +1,21 @@
+{
+  "network_type": "Midnight",
+  "slug": "midnight_testnet",
+  "name": "Midnight Testnet",
+  "rpc_urls": [
+    {
+      "type_": "rpc",
+      "url": {
+        "type": "plain",
+        "value": "https://rpc.testnet-02.midnight.network"
+      },
+      "weight": 100
+    }
+  ],
+  "chain_id": 0,
+  "block_time_ms": 6000,
+  "confirmation_blocks": 2,
+  "cron_schedule": "0 */1 * * * *",
+  "max_past_blocks": 13,
+  "store_blocks": false
+}

--- a/examples/config/triggers/slack_notifications.json
+++ b/examples/config/triggers/slack_notifications.json
@@ -40,5 +40,19 @@
         "body": "${monitor.name} triggered because of a large swap of ${functions.0.args.out_min} tokens | https://stellar.expert/explorer/public/tx/${transaction.hash}"
       }
     }
+  },
+  "midnight_bulletin_post_slack": {
+    "name": "Bulletin Post Slack Notification",
+    "trigger_type": "slack",
+    "config": {
+      "slack_url": {
+        "type": "plain",
+        "value": "https://hooks.slack.com/services/A/B/C"
+      },
+      "message": {
+        "title": "midnight_bulletin_post_slack triggered",
+        "body": "A call to ${functions.0.signature} was made to the bulletin board | ${transaction.hash}"
+      }
+    }
   }
 }

--- a/src/models/security/secret.rs
+++ b/src/models/security/secret.rs
@@ -295,7 +295,7 @@ impl AsRef<str> for SecretString {
 impl fmt::Display for SecretValue {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
-			SecretValue::Plain(secret) => write!(f, "{}", secret.as_str()),
+			SecretValue::Plain(_) => write!(f, "<secret string>"),
 			SecretValue::Environment(env_var) => write!(f, "{}", env_var),
 			SecretValue::HashicorpCloudVault(name) => write!(f, "{}", name),
 		}


### PR DESCRIPTION
# Summary

https://linear.app/openzeppelin-development/issue/PLAT-6496/add-documentation

- Adds Antora documentation for Midnight
- Adds Midnight network and monitor examples
- Updates RPC call list for Midnight
- Modifies `SecretValue` Display implementation to hide `plain` secret when logged directly

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
- [ ] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [x] Update documentation if applicable.
