### PR TITLE
chore: Remove sequence and union from string formatting

### DIFF
--- a/src/services/filter/filters/stellar/helpers.rs
+++ b/src/services/filter/filters/stellar/helpers.rs
@@ -458,23 +458,23 @@ impl fmt::Display for StellarType {
 			StellarType::Union(types) => {
 				write!(
 					f,
-					"Union<{}>",
+					"{}",
 					types
 						.iter()
 						.map(|t| t.to_string())
 						.collect::<Vec<_>>()
-						.join(", ")
+						.join(",")
 				)
 			}
 			StellarType::Sequence(types) => {
 				write!(
 					f,
-					"Sequence<{}>",
+					"{}",
 					types
 						.iter()
 						.map(|t| t.to_string())
 						.collect::<Vec<_>>()
-						.join(", ")
+						.join(",")
 				)
 			}
 		}
@@ -2154,7 +2154,7 @@ mod tests {
 		}));
 		assert_eq!(
 			StellarType::from(tuple_udt).to_string(),
-			"Tuple<Sequence<Request, U64>>"
+			"Tuple<Request,U64>"
 		);
 
 		// Test nested UDT in Vec
@@ -2333,7 +2333,7 @@ mod tests {
 		// Test without contract spec - should show concrete types
 		assert_eq!(
 			get_function_signature(&invoke_op, None),
-			"process_request(Address,Vec<Map<String,Union<I128, String>>>)"
+			"process_request(Address,Vec<Map<String,I128,String>>)"
 		);
 	}
 


### PR DESCRIPTION
# Summary

https://linear.app/openzeppelin-development/issue/PLAT-6652/fix-stellar-internal-type-comparisons-in-signature

When handling contract signatures from external sources, we face a mismatch between how users provide signatures (based on contract specifications) and our internal type system representation:

**User-provided signature (from contract spec):**
`"swap_chained(address,vec<tuple<vec<address>,bytes32,address>>,address,u128,u128)"`

**Internal representation needed for processing:**
`"swap_chained(address,vec<tuple<sequence<vec<address>,bytes32,address>>>,address,u128,u128)"`

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
- [ ] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [ ] Update documentation if applicable.
