### PR TITLE
fix: Risk of key collision for monitor custom scripts

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -274,6 +274,7 @@ docker compose logs -f
 
 ==== Configuration References
 
+* Monitor, network, and trigger names **must be unique** across all configurations files
 * Monitor's `networks` array must contain valid network `slug` values from network configuration files
 * Monitor's `triggers` array must contain valid trigger configuration keys
 * Example valid references:
@@ -624,7 +625,7 @@ A Network configuration defines connection details and operational parameters fo
 
 |name
 |String
-|Human-readable network name
+|**Unique** Human-readable network name
 
 |rpc_urls
 |Array[Object]
@@ -726,7 +727,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 
 |name
 |String
-|Human-readable name for the notification
+|**Unique** Human-readable name for the notification
 
 |trigger_type
 |String
@@ -779,7 +780,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 
 |name
 |String
-|Human-readable name for the notification
+|**Unique** Human-readable name for the notification
 
 |trigger_type
 |String
@@ -856,7 +857,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 
 |name
 |String
-|Human-readable name for the notification
+|**Unique** Human-readable name for the notification
 
 |trigger_type
 |String
@@ -917,7 +918,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 
 |name
 |String
-|Human-readable name for the notification
+|**Unique** Human-readable name for the notification
 
 |trigger_type
 |String
@@ -963,7 +964,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 
 |name
 |String
-|Human-readable name for the notification
+|**Unique** Human-readable name for the notification
 
 |trigger_type
 |String
@@ -1013,7 +1014,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
 
 |name
 |String
-|Human-readable name for the notification
+|**Unique** Human-readable name for the notification
 
 |trigger_type
 |String
@@ -1427,7 +1428,7 @@ Match transaction properties. The available fields and expression syntax depend 
 
 |name
 |String
-|Unique identifier for this monitor
+|**Unique** identifier for this monitor
 
 |networks
 |Array[String]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -621,7 +621,7 @@ A Network configuration defines connection details and operational parameters fo
 
 |slug
 |String
-|Unique identifier for the network
+|**Unique** identifier for the network
 
 |name
 |String

--- a/src/bootstrap/mod.rs
+++ b/src/bootstrap/mod.rs
@@ -37,6 +37,7 @@ use crate::{
 			TriggerExecutionServiceTrait,
 		},
 	},
+	utils::normalize_string,
 };
 
 /// Type alias for handling ServiceResult
@@ -495,7 +496,8 @@ async fn run_trigger_filters(
 			let script_content = trigger_scripts
 				.get(&format!(
 					"{}|{}",
-					monitor_name, trigger_condition.script_path
+					normalize_string(&monitor_name),
+					trigger_condition.script_path
 				))
 				.ok_or_else(|| {
 					ScriptError::execution_error("Script content not found".to_string(), None, None)

--- a/src/models/config/mod.rs
+++ b/src/models/config/mod.rs
@@ -14,6 +14,7 @@ mod network_config;
 mod trigger_config;
 
 pub use error::ConfigError;
+
 /// Common interface for loading configuration files
 #[async_trait]
 pub trait ConfigLoader: Sized {
@@ -46,4 +47,14 @@ pub trait ConfigLoader: Sized {
 
 	/// Resolve all secrets in the configuration
 	async fn resolve_secrets(&self) -> Result<Self, ConfigError>;
+
+	/// Validate uniqueness of the configuration
+	///
+	/// Returns Ok(()) if valid, or an error message if found duplicate names.
+	fn validate_uniqueness(
+		instances: &[&Self],
+		current_instance: &Self,
+		filename: &str,
+		path: &Path,
+	) -> Result<(), ConfigError>;
 }

--- a/src/models/config/mod.rs
+++ b/src/models/config/mod.rs
@@ -54,7 +54,6 @@ pub trait ConfigLoader: Sized {
 	fn validate_uniqueness(
 		instances: &[&Self],
 		current_instance: &Self,
-		filename: &str,
-		path: &Path,
+		file_path: &str,
 	) -> Result<(), ConfigError>;
 }

--- a/src/models/config/mod.rs
+++ b/src/models/config/mod.rs
@@ -49,6 +49,10 @@ pub trait ConfigLoader: Sized {
 	async fn resolve_secrets(&self) -> Result<Self, ConfigError>;
 
 	/// Validate uniqueness of the configuration
+	/// # Arguments
+	/// * `instances` - The instances to validate uniqueness against
+	/// * `current_instance` - The current instance to validate uniqueness for
+	/// * `file_path` - The path to the file containing the current instance (for logging purposes)
 	///
 	/// Returns Ok(()) if valid, or an error message if found duplicate names.
 	fn validate_uniqueness(

--- a/src/models/config/monitor_config.rs
+++ b/src/models/config/monitor_config.rs
@@ -79,7 +79,7 @@ impl ConfigLoader for Monitor {
 			if pairs
 				.iter()
 				.any(|(_, existing_monitor): &(String, Monitor)| {
-					existing_monitor.name == monitor.name
+					existing_monitor.name.to_lowercase() == monitor.name.to_lowercase()
 				}) {
 				return Err(ConfigError::validation_error(
 					format!("Duplicate monitor name found: '{}'", monitor.name),
@@ -627,7 +627,7 @@ mod tests {
         }"#;
 
 		let valid_config_2 = r#"{
-            "name": "TestMonitor",
+            "name": "Testmonitor",
 			"networks": ["ethereum_mainnet"],
 			"paused": false,
 			"addresses": [

--- a/src/models/config/monitor_config.rs
+++ b/src/models/config/monitor_config.rs
@@ -9,6 +9,7 @@ use std::{collections::HashMap, fs, path::Path};
 use crate::{
 	models::{config::error::ConfigError, ConfigLoader, Monitor},
 	services::trigger::validate_script_config,
+	utils::normalize_string,
 };
 
 #[async_trait]
@@ -79,7 +80,7 @@ impl ConfigLoader for Monitor {
 			if pairs
 				.iter()
 				.any(|(_, existing_monitor): &(String, Monitor)| {
-					existing_monitor.name.to_lowercase() == monitor.name.to_lowercase()
+					normalize_string(&existing_monitor.name) == normalize_string(&monitor.name)
 				}) {
 				return Err(ConfigError::validation_error(
 					format!("Duplicate monitor name found: '{}'", monitor.name),

--- a/src/models/config/monitor_config.rs
+++ b/src/models/config/monitor_config.rs
@@ -79,7 +79,7 @@ impl ConfigLoader for Monitor {
 			let existing_monitors: Vec<&Monitor> =
 				pairs.iter().map(|(_, monitor)| monitor).collect();
 			// Check monitor name uniqueness before pushing
-			Self::validate_uniqueness(&existing_monitors, &monitor, &name, &path)?;
+			Self::validate_uniqueness(&existing_monitors, &monitor, &path.display().to_string())?;
 
 			pairs.push((name, monitor));
 		}
@@ -212,8 +212,7 @@ impl ConfigLoader for Monitor {
 	fn validate_uniqueness(
 		instances: &[&Self],
 		current_instance: &Self,
-		filename: &str,
-		path: &Path,
+		file_path: &str,
 	) -> Result<(), ConfigError> {
 		// Check monitor name uniqueness before pushing
 		if instances.iter().any(|existing_monitor| {
@@ -227,8 +226,7 @@ impl ConfigLoader for Monitor {
 						"monitor_name".to_string(),
 						current_instance.name.to_string(),
 					),
-					("filename".to_string(), filename.to_string()),
-					("path".to_string(), path.display().to_string()),
+					("path".to_string(), file_path.to_string()),
 				])),
 			))
 		} else {

--- a/src/models/config/network_config.rs
+++ b/src/models/config/network_config.rs
@@ -113,7 +113,7 @@ impl ConfigLoader for Network {
 			let existing_networks: Vec<&Network> =
 				pairs.iter().map(|(_, network)| network).collect();
 			// Check network name uniqueness before pushing
-			Self::validate_uniqueness(&existing_networks, &network, &name, &path)?;
+			Self::validate_uniqueness(&existing_networks, &network, &path.display().to_string())?;
 
 			pairs.push((name, network));
 		}
@@ -321,8 +321,7 @@ impl ConfigLoader for Network {
 	fn validate_uniqueness(
 		instances: &[&Self],
 		current_instance: &Self,
-		filename: &str,
-		path: &Path,
+		file_path: &str,
 	) -> Result<(), ConfigError> {
 		let fields = [
 			("name", &current_instance.name),
@@ -343,8 +342,7 @@ impl ConfigLoader for Network {
 					None,
 					Some(HashMap::from([
 						(format!("network_{}", field_name), field_value.to_string()),
-						("filename".to_string(), filename.to_string()),
-						("path".to_string(), path.display().to_string()),
+						("path".to_string(), file_path.to_string()),
 					])),
 				));
 			}

--- a/src/models/config/network_config.rs
+++ b/src/models/config/network_config.rs
@@ -113,7 +113,7 @@ impl ConfigLoader for Network {
 			if pairs
 				.iter()
 				.any(|(_, existing_network): &(String, Network)| {
-					existing_network.name == network.name
+					existing_network.name.to_lowercase() == network.name.to_lowercase()
 				}) {
 				return Err(ConfigError::validation_error(
 					format!("Duplicate network name found: '{}'", network.name),
@@ -580,7 +580,7 @@ mod tests {
 		let file_path_2 = temp_dir.path().join("duplicate_network_2.json");
 
 		let network_config_1 = r#"{
-			"name": "TestNetwork",
+			"name": "Testnetwork",
 			"slug": "test_network",
 			"network_type": "EVM",
 			"rpc_urls": [

--- a/src/models/config/network_config.rs
+++ b/src/models/config/network_config.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, path::Path, str::FromStr};
 
 use crate::{
 	models::{config::error::ConfigError, BlockChainType, ConfigLoader, Network, SecretValue},
-	utils::get_cron_interval_ms,
+	utils::{get_cron_interval_ms, normalize_string},
 };
 
 impl Network {
@@ -113,7 +113,7 @@ impl ConfigLoader for Network {
 			if pairs
 				.iter()
 				.any(|(_, existing_network): &(String, Network)| {
-					existing_network.name.to_lowercase() == network.name.to_lowercase()
+					normalize_string(&existing_network.name) == normalize_string(&network.name)
 				}) {
 				return Err(ConfigError::validation_error(
 					format!("Duplicate network name found: '{}'", network.name),

--- a/src/models/config/trigger_config.rs
+++ b/src/models/config/trigger_config.rs
@@ -203,7 +203,11 @@ impl ConfigLoader for Trigger {
 					let existing_triggers: Vec<&Trigger> =
 						trigger_pairs.iter().map(|(_, trigger)| trigger).collect();
 					// Check trigger name uniqueness before pushing
-					Self::validate_uniqueness(&existing_triggers, &trigger, &name, &file_path)?;
+					Self::validate_uniqueness(
+						&existing_triggers,
+						&trigger,
+						&file_path.display().to_string(),
+					)?;
 
 					trigger_pairs.push((name, trigger));
 				}
@@ -665,8 +669,7 @@ impl ConfigLoader for Trigger {
 	fn validate_uniqueness(
 		instances: &[&Self],
 		current_instance: &Self,
-		filename: &str,
-		path: &Path,
+		file_path: &str,
 	) -> Result<(), ConfigError> {
 		// Check trigger name uniqueness before pushing
 		if instances.iter().any(|existing_trigger| {
@@ -680,8 +683,7 @@ impl ConfigLoader for Trigger {
 						"trigger_name".to_string(),
 						current_instance.name.to_string(),
 					),
-					("filename".to_string(), filename.to_string()),
-					("path".to_string(), path.display().to_string()),
+					("path".to_string(), file_path.to_string()),
 				])),
 			))
 		} else {

--- a/src/models/config/trigger_config.rs
+++ b/src/models/config/trigger_config.rs
@@ -203,7 +203,7 @@ impl ConfigLoader for Trigger {
 					if trigger_pairs
 						.iter()
 						.any(|(_, existing_trigger): &(String, Trigger)| {
-							existing_trigger.name == trigger.name
+							existing_trigger.name.to_lowercase() == trigger.name.to_lowercase()
 						}) {
 						return Err(ConfigError::validation_error(
 							format!("Duplicate trigger name found: '{}'", trigger.name),
@@ -1468,7 +1468,7 @@ mod tests {
 
 		let trigger_config_2 = r#"{
 			"test_trigger_2": {
-				"name": "TestTrigger",
+				"name": "testTrigger",
 				"trigger_type": "discord",
 				"config": {
 					"discord_url": {
@@ -1488,7 +1488,7 @@ mod tests {
 
 		let result: Result<HashMap<String, Trigger>, ConfigError> =
 			Trigger::load_all(Some(temp_dir.path())).await;
-		println!("RESULT: {:?}", result);
+
 		assert!(result.is_err());
 		if let Err(ConfigError::ValidationError(err)) = result {
 			assert!(err.message.contains("Duplicate trigger name found"));

--- a/src/models/config/trigger_config.rs
+++ b/src/models/config/trigger_config.rs
@@ -198,6 +198,22 @@ impl ConfigLoader for Trigger {
 							])),
 						));
 					}
+
+					// Check trigger name uniqueness before pushing
+					if trigger_pairs
+						.iter()
+						.any(|(_, existing_trigger): &(String, Trigger)| {
+							existing_trigger.name == trigger.name
+						}) {
+						return Err(ConfigError::validation_error(
+							format!("Duplicate trigger name found: '{}'", trigger.name),
+							None,
+							Some(HashMap::from([
+								("path".to_string(), file_path.display().to_string()),
+								("trigger_name".to_string(), name.clone()),
+							])),
+						));
+					}
 					trigger_pairs.push((name, trigger));
 				}
 			}
@@ -1425,5 +1441,53 @@ mod tests {
 			},
 		};
 		assert!(max_body_length.validate().is_err());
+	}
+
+	#[tokio::test]
+	async fn test_load_all_duplicate_trigger_name() {
+		let temp_dir = TempDir::new().unwrap();
+		let file_path_1 = temp_dir.path().join("duplicate_trigger.json");
+		let file_path_2 = temp_dir.path().join("duplicate_trigger_2.json");
+
+		let trigger_config_1 = r#"{
+			"name": "TestTrigger",
+			"trigger_type": "Slack",
+			"config": {
+				"slack_url": {
+					"type": "plain",
+					"value": "https://hooks.slack.com/services/xxx"
+				}
+			}
+			"message": {
+				"title": "Test",
+				"body": "Test"
+			}
+		}"#;
+
+		let trigger_config_2 = r#"{
+			"name": "TestTrigger",
+			"trigger_type": "Discord",
+			"config": {
+				"discord_url": {
+					"type": "plain",
+					"value": "https://discord.com/api/webhooks/xxx"
+				}
+			}
+			"message": {
+				"title": "Test",
+				"body": "Test"
+			}
+		}"#;
+
+		fs::write(&file_path_1, trigger_config_1).unwrap();
+		fs::write(&file_path_2, trigger_config_2).unwrap();
+
+		let result: Result<HashMap<String, Trigger>, ConfigError> =
+			Trigger::load_all(Some(temp_dir.path())).await;
+
+		assert!(result.is_err());
+		if let Err(ConfigError::ValidationError(err)) = result {
+			assert!(err.message.contains("Duplicate trigger name found"));
+		}
 	}
 }

--- a/src/models/config/trigger_config.rs
+++ b/src/models/config/trigger_config.rs
@@ -1450,32 +1450,36 @@ mod tests {
 		let file_path_2 = temp_dir.path().join("duplicate_trigger_2.json");
 
 		let trigger_config_1 = r#"{
-			"name": "TestTrigger",
-			"trigger_type": "Slack",
-			"config": {
-				"slack_url": {
-					"type": "plain",
-					"value": "https://hooks.slack.com/services/xxx"
+			"test_trigger_1": {
+				"name": "TestTrigger",
+				"trigger_type": "slack",
+				"config": {
+					"slack_url": {
+						"type": "plain",
+						"value": "https://hooks.slack.com/services/xxx"
+					},
+					"message": {
+						"title": "Test",
+						"body": "Test"
+					}
 				}
-			}
-			"message": {
-				"title": "Test",
-				"body": "Test"
 			}
 		}"#;
 
 		let trigger_config_2 = r#"{
-			"name": "TestTrigger",
-			"trigger_type": "Discord",
-			"config": {
-				"discord_url": {
-					"type": "plain",
-					"value": "https://discord.com/api/webhooks/xxx"
+			"test_trigger_2": {
+				"name": "TestTrigger",
+				"trigger_type": "discord",
+				"config": {
+					"discord_url": {
+						"type": "plain",
+						"value": "https://discord.com/api/webhooks/xxx"
+					},
+					"message": {
+						"title": "Test",
+						"body": "Test"
+					}
 				}
-			}
-			"message": {
-				"title": "Test",
-				"body": "Test"
 			}
 		}"#;
 
@@ -1484,7 +1488,7 @@ mod tests {
 
 		let result: Result<HashMap<String, Trigger>, ConfigError> =
 			Trigger::load_all(Some(temp_dir.path())).await;
-
+		println!("RESULT: {:?}", result);
 		assert!(result.is_err());
 		if let Err(ConfigError::ValidationError(err)) = result {
 			assert!(err.message.contains("Duplicate trigger name found"));

--- a/src/models/config/trigger_config.rs
+++ b/src/models/config/trigger_config.rs
@@ -14,6 +14,7 @@ use crate::{
 		TriggerTypeConfig,
 	},
 	services::trigger::validate_script_config,
+	utils::normalize_string,
 };
 
 const TELEGRAM_MAX_BODY_LENGTH: usize = 4096;
@@ -203,7 +204,8 @@ impl ConfigLoader for Trigger {
 					if trigger_pairs
 						.iter()
 						.any(|(_, existing_trigger): &(String, Trigger)| {
-							existing_trigger.name.to_lowercase() == trigger.name.to_lowercase()
+							normalize_string(&existing_trigger.name)
+								== normalize_string(&trigger.name)
 						}) {
 						return Err(ConfigError::validation_error(
 							format!("Duplicate trigger name found: '{}'", trigger.name),

--- a/src/services/trigger/service.rs
+++ b/src/services/trigger/service.rs
@@ -12,6 +12,7 @@ use crate::{
 	models::{Monitor, MonitorMatch, ScriptLanguage, TriggerTypeConfig},
 	repositories::{TriggerRepositoryTrait, TriggerService},
 	services::{notification::NotificationService, trigger::error::TriggerError},
+	utils::normalize_string,
 };
 
 /// Trait for executing triggers
@@ -166,7 +167,11 @@ impl<T: TriggerRepositoryTrait + Send + Sync> TriggerExecutionServiceTrait
 					})?;
 				// Store the script content with its language
 				scripts.insert(
-					format!("{}|{}", monitor.name, condition.script_path),
+					format!(
+						"{}|{}",
+						normalize_string(&monitor.name),
+						condition.script_path
+					),
 					(condition.language.clone(), content),
 				);
 			}
@@ -206,7 +211,11 @@ impl<T: TriggerRepositoryTrait + Send + Sync> TriggerExecutionServiceTrait
 				})?;
 
 				scripts.insert(
-					format!("{}|{}", monitor.name, script_path.display()),
+					format!(
+						"{}|{}",
+						normalize_string(&monitor.name),
+						script_path.display()
+					),
 					(language.clone(), content),
 				);
 			}

--- a/src/utils/parsing.rs
+++ b/src/utils/parsing.rs
@@ -16,6 +16,19 @@ pub fn parse_string_to_bytes_size(s: &str) -> Result<u64, String> {
 	}
 }
 
+/// Normalizes a string by trimming whitespace and converting to lowercase.
+///
+/// This is useful for case-insensitive comparisons and removing leading/trailing whitespace.
+///
+/// # Arguments
+/// * `input` - The string to normalize
+///
+/// # Returns
+/// * `String` - The normalized string (trimmed and lowercase)
+pub fn normalize_string(input: &str) -> String {
+	input.trim().to_lowercase()
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;
@@ -58,6 +71,26 @@ mod tests {
 				"Expected error for invalid input: {}",
 				input
 			);
+		}
+	}
+
+	#[test]
+	fn test_normalize_string() {
+		let test_cases = vec![
+			("Hello World", "hello world"),
+			("  UPPERCASE  ", "uppercase"),
+			("MixedCase", "mixedcase"),
+			("  trim me  ", "trim me"),
+			("", ""),
+			("   ", ""),
+			("already lowercase", "already lowercase"),
+		];
+
+		for (input, expected) in test_cases {
+			let result = normalize_string(input);
+			println!("result: {}", result);
+			println!("expected: {}", expected);
+			assert_eq!(result, expected, "Failed to normalize: '{}'", input);
 		}
 	}
 }


### PR DESCRIPTION
# Summary

https://linear.app/openzeppelin-development/issue/PLAT-6648/risk-of-key-collision-and-script-data-overwrite-in

- Extending monitor, network and triggers validation to avoid having duplicate names.

Related issue:
https://github.com/OpenZeppelin/openzeppelin-monitor/issues/236

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
- [ ] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [x] Update documentation if applicable.
