### PR TITLE
refactor: Enhance notification errors

### DIFF
--- a/src/services/notification/discord.rs
+++ b/src/services/notification/discord.rs
@@ -80,7 +80,7 @@ impl DiscordNotifier {
 		url: String,
 		title: String,
 		body_template: String,
-	) -> Result<Self, Box<NotificationError>> {
+	) -> Result<Self, NotificationError> {
 		Ok(Self {
 			inner: WebhookNotifier::new(WebhookConfig {
 				url,

--- a/src/services/notification/discord.rs
+++ b/src/services/notification/discord.rs
@@ -149,8 +149,8 @@ impl Notifier for DiscordNotifier {
 	/// * `message` - The formatted message to send
 	///
 	/// # Returns
-	/// * `Result<(), anyhow::Error>` - Success or error
-	async fn notify(&self, message: &str) -> Result<(), anyhow::Error> {
+	/// * `Result<(), NotificationError>` - Success or error
+	async fn notify(&self, message: &str) -> Result<(), NotificationError> {
 		let mut payload_fields = HashMap::new();
 		let discord_message = DiscordMessage {
 			content: message.to_string(),

--- a/src/services/notification/email.rs
+++ b/src/services/notification/email.rs
@@ -144,35 +144,39 @@ impl EmailNotifier<SmtpTransport> {
 	/// * `config` - Trigger configuration containing email parameters
 	///
 	/// # Returns
-	/// * `Option<Self>` - Notifier instance if config is email type
-	pub fn from_config(config: &TriggerTypeConfig) -> Option<Self> {
-		match config {
-			TriggerTypeConfig::Email {
-				host,
-				port,
-				username,
-				password,
-				message,
-				sender,
-				recipients,
-			} => {
-				let smtp_config = SmtpConfig {
-					host: host.clone(),
-					port: port.unwrap_or(465),
-					username: username.as_ref().to_string(),
-					password: password.as_ref().to_string(),
-				};
+	/// * `Result<Self, NotificationError>` - Notifier instance if config is email type
+	pub fn from_config(config: &TriggerTypeConfig) -> Result<Self, NotificationError> {
+		if let TriggerTypeConfig::Email {
+			host,
+			port,
+			username,
+			password,
+			message,
+			sender,
+			recipients,
+		} = config
+		{
+			let smtp_config = SmtpConfig {
+				host: host.clone(),
+				port: port.unwrap_or(465),
+				username: username.as_ref().to_string(),
+				password: password.as_ref().to_string(),
+			};
 
-				let email_content = EmailContent {
-					subject: message.title.clone(),
-					body_template: message.body.clone(),
-					sender: sender.clone(),
-					recipients: recipients.clone(),
-				};
+			let email_content = EmailContent {
+				subject: message.title.clone(),
+				body_template: message.body.clone(),
+				sender: sender.clone(),
+				recipients: recipients.clone(),
+			};
 
-				Self::new(smtp_config, email_content).ok()
-			}
-			_ => None,
+			Self::new(smtp_config, email_content)
+		} else {
+			Err(NotificationError::config_error(
+				format!("Invalid email configuration: {:?}", config),
+				None,
+				None,
+			))
 		}
 	}
 }
@@ -326,7 +330,7 @@ mod tests {
 		let config = create_test_email_config(Some(587));
 
 		let notifier = EmailNotifier::from_config(&config);
-		assert!(notifier.is_some());
+		assert!(notifier.is_ok());
 
 		let notifier = notifier.unwrap();
 		assert_eq!(notifier.subject, "Test Subject");
@@ -341,7 +345,7 @@ mod tests {
 		let config = create_test_email_config(None);
 
 		let notifier = EmailNotifier::from_config(&config);
-		assert!(notifier.is_some());
+		assert!(notifier.is_ok());
 	}
 
 	////////////////////////////////////////////////////////////

--- a/src/services/notification/email.rs
+++ b/src/services/notification/email.rs
@@ -88,7 +88,7 @@ impl EmailNotifier<SmtpTransport> {
 	pub fn new(
 		smtp_config: SmtpConfig,
 		email_content: EmailContent,
-	) -> Result<Self, Box<NotificationError>> {
+	) -> Result<Self, NotificationError> {
 		let client = SmtpTransport::relay(&smtp_config.host)
 			.map_err(|e| {
 				NotificationError::internal_error(

--- a/src/services/notification/error.rs
+++ b/src/services/notification/error.rs
@@ -13,19 +13,19 @@ use uuid::Uuid;
 pub enum NotificationError {
 	/// Errors related to network connectivity issues
 	#[error("Network error: {0}")]
-	NetworkError(ErrorContext),
+	NetworkError(Box<ErrorContext>),
 
 	/// Errors related to malformed requests or invalid responses
 	#[error("Config error: {0}")]
-	ConfigError(ErrorContext),
+	ConfigError(Box<ErrorContext>),
 
 	/// Errors related to internal processing errors
 	#[error("Internal error: {0}")]
-	InternalError(ErrorContext),
+	InternalError(Box<ErrorContext>),
 
 	/// Errors related to script execution
 	#[error("Script execution error: {0}")]
-	ExecutionError(ErrorContext),
+	ExecutionError(Box<ErrorContext>),
 
 	/// Other errors that don't fit into the categories above
 	#[error(transparent)]
@@ -39,7 +39,7 @@ impl NotificationError {
 		source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 		metadata: Option<HashMap<String, String>>,
 	) -> Self {
-		Self::NetworkError(ErrorContext::new_with_log(msg, source, metadata))
+		Self::NetworkError(Box::new(ErrorContext::new_with_log(msg, source, metadata)))
 	}
 
 	// Config error
@@ -48,7 +48,7 @@ impl NotificationError {
 		source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 		metadata: Option<HashMap<String, String>>,
 	) -> Self {
-		Self::ConfigError(ErrorContext::new_with_log(msg, source, metadata))
+		Self::ConfigError(Box::new(ErrorContext::new_with_log(msg, source, metadata)))
 	}
 
 	// Internal error
@@ -57,7 +57,7 @@ impl NotificationError {
 		source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 		metadata: Option<HashMap<String, String>>,
 	) -> Self {
-		Self::InternalError(ErrorContext::new_with_log(msg, source, metadata))
+		Self::InternalError(Box::new(ErrorContext::new_with_log(msg, source, metadata)))
 	}
 
 	// Execution error
@@ -66,7 +66,7 @@ impl NotificationError {
 		source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
 		metadata: Option<HashMap<String, String>>,
 	) -> Self {
-		Self::ExecutionError(ErrorContext::new_with_log(msg, source, metadata))
+		Self::ExecutionError(Box::new(ErrorContext::new_with_log(msg, source, metadata)))
 	}
 }
 
@@ -193,7 +193,7 @@ mod tests {
 		let original_trace_id = error_context.trace_id.clone();
 
 		// Wrap it in a NotificationError
-		let notification_error = NotificationError::NetworkError(error_context);
+		let notification_error = NotificationError::NetworkError(Box::new(error_context));
 
 		// Verify the trace ID is preserved
 		assert_eq!(notification_error.trace_id(), original_trace_id);
@@ -203,7 +203,7 @@ mod tests {
 		let error_context = ErrorContext::new("Middle error", Some(Box::new(source_error)), None);
 		let original_trace_id = error_context.trace_id.clone();
 
-		let notification_error = NotificationError::NetworkError(error_context);
+		let notification_error = NotificationError::NetworkError(Box::new(error_context));
 		assert_eq!(notification_error.trace_id(), original_trace_id);
 
 		// Test Other variant

--- a/src/services/notification/mod.rs
+++ b/src/services/notification/mod.rs
@@ -122,18 +122,11 @@ impl NotificationService {
 					.await?;
 			}
 			TriggerType::Webhook => {
-				let notifier = WebhookNotifier::from_config(&trigger.config);
-				if let Some(notifier) = notifier {
-					notifier
-						.notify(&notifier.format_message(&variables))
-						.await?;
-				} else {
-					return Err(NotificationError::config_error(
-						"Invalid webhook configuration",
-						None,
-						None,
-					));
-				}
+				let notifier = WebhookNotifier::from_config(&trigger.config)?;
+
+				notifier
+					.notify(&notifier.format_message(&variables))
+					.await?;
 			}
 			TriggerType::Discord => {
 				let notifier = DiscordNotifier::from_config(&trigger.config)?;

--- a/src/services/notification/script.rs
+++ b/src/services/notification/script.rs
@@ -38,7 +38,7 @@ impl ScriptExecutor for ScriptNotifier {
 		&self,
 		monitor_match: &MonitorMatch,
 		script_content: &(ScriptLanguage, String),
-	) -> Result<(), anyhow::Error> {
+	) -> Result<(), NotificationError> {
 		match &self.config {
 			TriggerTypeConfig::Script {
 				script_path: _,
@@ -59,14 +59,24 @@ impl ScriptExecutor for ScriptNotifier {
 
 				match result {
 					Ok(true) => Ok(()),
-					Ok(false) => Err(anyhow::anyhow!("Trigger script execution failed")),
+					Ok(false) => Err(NotificationError::execution_error(
+						"Trigger script execution failed",
+						None,
+						None,
+					)),
 					Err(e) => {
-						return Err(anyhow::anyhow!("Trigger script execution error: {}", e));
+						return Err(NotificationError::execution_error(
+							format!("Trigger script execution error: {}", e),
+							None,
+							None,
+						));
 					}
 				}
 			}
-			_ => Err(anyhow::anyhow!(
-				"Invalid configuration type for ScriptNotifier"
+			_ => Err(NotificationError::config_error(
+				"Invalid configuration type for ScriptNotifier",
+				None,
+				None,
 			)),
 		}
 	}

--- a/src/services/notification/script.rs
+++ b/src/services/notification/script.rs
@@ -6,6 +6,8 @@ use crate::{
 	services::trigger::ScriptExecutorFactory,
 };
 
+use super::NotificationError;
+
 /// A notification handler that executes scripts when triggered
 ///
 /// This notifier takes a script configuration and executes the specified script
@@ -17,12 +19,14 @@ pub struct ScriptNotifier {
 
 impl ScriptNotifier {
 	/// Creates a Script notifier from a trigger configuration
-	pub fn from_config(config: &TriggerTypeConfig) -> Option<Self> {
-		match config {
-			TriggerTypeConfig::Script { .. } => Some(Self {
+	pub fn from_config(config: &TriggerTypeConfig) -> Result<Self, NotificationError> {
+		if let TriggerTypeConfig::Script { .. } = config {
+			Ok(Self {
 				config: config.clone(),
-			}),
-			_ => None,
+			})
+		} else {
+			let msg = format!("Invalid script configuration: {:?}", config);
+			Err(NotificationError::config_error(msg, None, None))
 		}
 	}
 }
@@ -118,7 +122,7 @@ mod tests {
 	fn test_from_config_with_script_config() {
 		let config = create_test_script_config();
 		let notifier = ScriptNotifier::from_config(&config);
-		assert!(notifier.is_some());
+		assert!(notifier.is_ok());
 	}
 
 	#[tokio::test]

--- a/src/services/notification/slack.rs
+++ b/src/services/notification/slack.rs
@@ -27,7 +27,7 @@ impl SlackNotifier {
 		url: String,
 		title: String,
 		body_template: String,
-	) -> Result<Self, Box<NotificationError>> {
+	) -> Result<Self, NotificationError> {
 		Ok(Self {
 			inner: WebhookNotifier::new(WebhookConfig {
 				url,

--- a/src/services/notification/slack.rs
+++ b/src/services/notification/slack.rs
@@ -95,8 +95,8 @@ impl Notifier for SlackNotifier {
 	/// * `message` - The formatted message to send
 	///
 	/// # Returns
-	/// * `Result<(), anyhow::Error>` - Success or error
-	async fn notify(&self, message: &str) -> Result<(), anyhow::Error> {
+	/// * `Result<(), NotificationError>` - Success or error
+	async fn notify(&self, message: &str) -> Result<(), NotificationError> {
 		let mut payload_fields = HashMap::new();
 		let blocks = serde_json::json!([
 			{

--- a/src/services/notification/telegram.rs
+++ b/src/services/notification/telegram.rs
@@ -35,7 +35,7 @@ impl TelegramNotifier {
 		disable_web_preview: Option<bool>,
 		title: String,
 		body_template: String,
-	) -> Result<Self, Box<NotificationError>> {
+	) -> Result<Self, NotificationError> {
 		let url = format!(
 			"{}/bot{}/sendMessage",
 			base_url.unwrap_or("https://api.telegram.org".to_string()),

--- a/src/services/notification/telegram.rs
+++ b/src/services/notification/telegram.rs
@@ -208,8 +208,8 @@ impl Notifier for TelegramNotifier {
 	/// * `message` - The formatted message to send
 	///
 	/// # Returns
-	/// * `Result<(), anyhow::Error>` - Success or error
-	async fn notify(&self, message: &str) -> Result<(), anyhow::Error> {
+	/// * `Result<(), NotificationError>` - Success or error
+	async fn notify(&self, message: &str) -> Result<(), NotificationError> {
 		// Add message and disable_web_preview to URL parameters
 		let mut url_params = self.inner.url_params.clone().unwrap_or_default();
 		url_params.insert("text".to_string(), message.to_string());

--- a/src/services/notification/webhook.rs
+++ b/src/services/notification/webhook.rs
@@ -79,8 +79,8 @@ impl WebhookNotifier {
 	/// * `config` - Webhook configuration
 	///
 	/// # Returns
-	/// * `Result<Self, Box<NotificationError>>` - Notifier instance if config is valid
-	pub fn new(config: WebhookConfig) -> Result<Self, Box<NotificationError>> {
+	/// * `Result<Self, NotificationError>` - Notifier instance if config is valid
+	pub fn new(config: WebhookConfig) -> Result<Self, NotificationError> {
 		let mut headers = config.headers.unwrap_or_default();
 		if !headers.contains_key("Content-Type") {
 			headers.insert("Content-Type".to_string(), "application/json".to_string());
@@ -147,7 +147,7 @@ impl WebhookNotifier {
 		&self,
 		secret: &str,
 		payload: &WebhookMessage,
-	) -> Result<(String, String), Box<NotificationError>> {
+	) -> Result<(String, String), NotificationError> {
 		let timestamp = Utc::now().timestamp_millis();
 
 		// Create HMAC instance

--- a/tests/integration/notifications/email.rs
+++ b/tests/integration/notifications/email.rs
@@ -18,7 +18,7 @@ mock! {
 
 	#[async_trait]
 	impl Notifier for EmailNotifier {
-		async fn notify(&self, message: &str) -> Result<(), anyhow::Error>;
+		async fn notify(&self, message: &str) -> Result<(), NotificationError>;
 	}
 }
 


### PR DESCRIPTION
# Summary

Some preparation for #243 to make notification error handling stricter.

- Update `from_config` methods to return `Result<Self, NotificationError>` instead of `Option`
- Remove `NotificationError` boxing, wrap `ErrorContext` instead
- Replace `Other` and anyhow with specific `NotifyFailed` variant for `notify` methods

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
- [ ] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [ ] Update documentation if applicable.
