### PR TITLE
fix: Duplicate name in triggers config

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -12,24 +12,24 @@
       }
     },
     "node_modules/@frangio/servbot": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@frangio/servbot/-/servbot-0.2.5.tgz",
-      "integrity": "sha512-ogja4iAPZ1VwM5MU3C1ZhB88358F0PGbmSTGOkIZwOyLaDoMHIqOVCnavHjR7DV5h+oAI4Z4KDqlam3myQUrmg==",
+      "version": "0.3.0-1",
+      "resolved": "https://registry.npmjs.org/@frangio/servbot/-/servbot-0.3.0-1.tgz",
+      "integrity": "sha512-eKXRqt8Zh3aqtVYoyayuLiktcW6vnYCuwlcqg91cv3HSdM5foTmIECJEJiwI+GBmSLY37mzczpt/ZfvYqzrQWQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.x",
-        "pnpm": "7.5.1"
+        "pnpm": "10.x"
       }
     },
     "node_modules/@openzeppelin/docs-utils": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/docs-utils/-/docs-utils-0.1.5.tgz",
-      "integrity": "sha512-GfqXArKmdq8rv+hsP+g8uS1VEkvMIzWs31dCONffzmqFwJ+MOsaNQNZNXQnLRgUkzk8i5mTNDjJuxDy+aBZImQ==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/docs-utils/-/docs-utils-0.1.6.tgz",
+      "integrity": "sha512-cVLtDPrCdVgnLV9QRK9D1jrTB8ezQ8tCLTM4g6PHe9TIK3DbO6lSizLF98DhncK2bk6uodOLRT3LO1WtNzei1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@frangio/servbot": "^0.2.5",
+        "@frangio/servbot": "^0.3.0-1",
         "chalk": "^3.0.0",
         "chokidar": "^3.5.3",
         "env-paths": "^2.2.0",

--- a/examples/config/triggers/telegram_notifications.json
+++ b/examples/config/triggers/telegram_notifications.json
@@ -16,7 +16,7 @@
     }
   },
   "evm_large_transfer_usdc_telegram_markdown": {
-    "name": "Large Transfer Telegram Notification",
+    "name": "Large Transfer Telegram Notification (Markdown)",
     "trigger_type": "telegram",
     "config": {
       "token": {


### PR DESCRIPTION
# Summary

Since https://github.com/OpenZeppelin/openzeppelin-monitor/pull/258 we no longer allow trigger names to be identical.
The example configuration file still had trigger names that are the same. This PR renames one of the triggers to avoid errors on initial setup.

- Fixes a duplicate name in trigger example config.
- Upgrades docs NPM packages
  - Fixes docs 'invalid value for header' error when running `yarn docs:watch`

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
- [ ] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [ ] Update documentation if applicable.
