### PR TITLE
fix: Remove deprecated reviewers field from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,28 +7,23 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     commit-message:
       # Prefix all commit messages with "chore(deps): "
       prefix: 'chore(deps): '
-    reviewers:
-      - OpenZeppelin/defender-sre
-      - OpenZeppelin/defender-dev
 
   # Maintain dependencies for cargo
   - package-ecosystem: cargo
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     ignore:
       - dependency-name: '*'
-        update-types: [version-update:semver-major]
+        update-types:
+        - version-update:semver-major
     commit-message:
       # Prefix all commit messages
       prefix: 'chore(deps): '
-    reviewers:
-      - OpenZeppelin/defender-dev
-      - OpenZeppelin/defender-sre
     labels:
       - dependabot
       - dependencies


### PR DESCRIPTION
# Summary
([PS-34](https://linear.app/openzeppelin-development/issue/PS-34/ensure-dependabot-config-is-consistent-across-all-repos)) For more info: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
- [ ] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [ ] Update documentation if applicable.
