### PR TITLE
chore: Add osv-scanner.toml file to ignore some false positives

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "RUSTSEC-2024-0436"
+reason = "The crate is unmaintained, but it works. If there is any new vulnerability, there will be another ID."


### PR DESCRIPTION
# Summary
This is part of the effort to improve the security scorecard ([PS-25](https://linear.app/openzeppelin-development/issue/PS-25/improve-security-scorecard))

The osv scanner used by GitHub code scanning includes also a check for deprecated / unmaintained crates. Sometimes, there is not an obvious alternative and as long as the crate still works fine, the "vulnerability" should be ignored (until there is an alternative to switch to or a real vulnerability is found)

The unmaintained `paste` crate ([RUSTSEC-2024-0436](https://rustsec.org/advisories/RUSTSEC-2024-0436.html)) is a transitive dependency and can only be fixed when the upstream packages are updated.

## Testing Process

## Checklist

- [x] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
- [ ] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [ ] Update documentation if applicable.
