### PR TITLE
feat: Update payload builder to support formatted titles

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -618,7 +618,7 @@ A Trigger defines actions to take when monitored conditions are met. Triggers ca
         "value": "https://hooks.slack.com/services/A/B/C"
       },
       "message": {
-        "title": "large_transfer_slack triggered",
+        "title": "${monitor.name} triggered",
         "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }

--- a/examples/config/triggers/discord_notifications.json
+++ b/examples/config/triggers/discord_notifications.json
@@ -8,7 +8,7 @@
         "value": "https://discord.com/api/webhooks/123-456-789"
       },
       "message": {
-        "title": "large_transfer_discord triggered",
+        "title": "${monitor.name} triggered",
         "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
@@ -22,7 +22,7 @@
         "value": "https://discord.com/api/webhooks/123-456-789"
       },
       "message": {
-        "title": "large_transfer_discord triggered",
+        "title": "${monitor.name} triggered",
         "body": "**Large transfer** of **${events.0.args.value} USDC** from `${events.0.args.from}` to `${events.0.args.to}`\n[View on Etherscan](https://etherscan.io/tx/${transaction.hash}#eventlog)"
       }
     }

--- a/examples/config/triggers/slack_notifications.json
+++ b/examples/config/triggers/slack_notifications.json
@@ -8,7 +8,7 @@
         "value": "https://hooks.slack.com/services/A/B/C"
       },
       "message": {
-        "title": "large_transfer_slack triggered",
+        "title": "${monitor.name} triggered",
         "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
@@ -22,7 +22,7 @@
         "value": "https://hooks.slack.com/services/A/B/C"
       },
       "message": {
-        "title": "large_transfer_slack triggered",
+        "title": "${monitor.name} triggered",
         "body": "*USDC Transfer Details*\n*Amount:* ${events.0.args.value} USDC\n*From:* ${events.0.args.from}\n*To:* ${events.0.args.to}\n*Transaction:* <https://etherscan.io/tx/${transaction.hash}#eventlog|View on Etherscan>"
       }
     }

--- a/examples/config/triggers/telegram_notifications.json
+++ b/examples/config/triggers/telegram_notifications.json
@@ -10,7 +10,7 @@
       "chat_id": "9876543210",
       "disable_web_preview": true,
       "message": {
-        "title": "large_transfer_telegram triggered",
+        "title": "${monitor.name} triggered",
         "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
@@ -26,7 +26,7 @@
       "chat_id": "9876543210",
       "disable_web_preview": true,
       "message": {
-        "title": "large_transfer_telegram triggered",
+        "title": "${monitor.name} triggered",
         "body": "*USDC Transfer Details*\n*Amount:* ${events.0.args.value} USDC\n*From:* ${events.0.args.from}\n*To:* ${events.0.args.to}\n*Transaction:* [View on Etherscan](https://etherscan.io/tx/${transaction.hash}#eventlog)"
       }
     }

--- a/examples/config/triggers/webhook_notifications.json
+++ b/examples/config/triggers/webhook_notifications.json
@@ -16,7 +16,7 @@
         "Content-Type": "application/json"
       },
       "message": {
-        "title": "large_transfer_webhook triggered",
+        "title": "${monitor.name} triggered",
         "body": "Large transfer of ${events.0.args.value} USDC from ${events.0.args.from} to ${events.0.args.to} | https://etherscan.io/tx/${transaction.hash}#eventlog"
       }
     }
@@ -38,7 +38,7 @@
         "Content-Type": "application/json"
       },
       "message": {
-        "title": "large_transfer_webhook triggered",
+        "title": "${monitor.name} triggered",
         "body": "# USDC Transfer Alert\n\n**Large transfer detected**\n\n- **Amount:** ${events.0.args.value} USDC\n- **From:** `${events.0.args.from}`\n- **To:** `${events.0.args.to}`\n\n[View on Etherscan](https://etherscan.io/tx/${transaction.hash}#eventlog)"
       }
     }
@@ -60,7 +60,7 @@
         "Content-Type": "application/json"
       },
       "message": {
-        "title": "large_swap_by_dex_webhook triggered",
+        "title": "${monitor.name} triggered",
         "body": "${monitor.name} triggered because of a large swap of ${functions.0.args.out_min} tokens | https://stellar.expert/explorer/public/tx/${transaction.hash}"
       }
     }

--- a/src/services/notification/payload_builder.rs
+++ b/src/services/notification/payload_builder.rs
@@ -46,8 +46,9 @@ impl WebhookPayloadBuilder for SlackPayloadBuilder {
 		body_template: &str,
 		variables: &HashMap<String, String>,
 	) -> serde_json::Value {
-		let message = format_template(body_template, variables);
-		let full_message = format!("*{}*\n\n{}", title, message);
+		let formatted_title = format_template(title, variables);
+		let formatted_message = format_template(body_template, variables);
+		let full_message = format!("*{}*\n\n{}", formatted_title, formatted_message);
 		json!({
 			"blocks": [
 				{
@@ -72,8 +73,9 @@ impl WebhookPayloadBuilder for DiscordPayloadBuilder {
 		body_template: &str,
 		variables: &HashMap<String, String>,
 	) -> serde_json::Value {
-		let message = format_template(body_template, variables);
-		let full_message = format!("*{}*\n\n{}", title, message);
+		let formatted_title = format_template(title, variables);
+		let formatted_message = format_template(body_template, variables);
+		let full_message = format!("*{}*\n\n{}", formatted_title, formatted_message);
 		json!({
 			"content": full_message
 		})
@@ -159,11 +161,12 @@ impl WebhookPayloadBuilder for TelegramPayloadBuilder {
 		variables: &HashMap<String, String>,
 	) -> serde_json::Value {
 		// First, substitute variables.
-		let message = format_template(body_template, variables);
+		let formatted_title = format_template(title, variables);
+		let formatted_message = format_template(body_template, variables);
 
 		// Then, escape both the title and the formatted message for Telegram MarkdownV2.
-		let escaped_title = Self::escape_markdown_v2(title);
-		let escaped_message = Self::escape_markdown_v2(&message);
+		let escaped_title = Self::escape_markdown_v2(&formatted_title);
+		let escaped_message = Self::escape_markdown_v2(&formatted_message);
 
 		let full_message = format!("*{}* \n\n{}", escaped_title, escaped_message);
 		json!({
@@ -185,10 +188,11 @@ impl WebhookPayloadBuilder for GenericWebhookPayloadBuilder {
 		body_template: &str,
 		variables: &HashMap<String, String>,
 	) -> serde_json::Value {
-		let message = format_template(body_template, variables);
+		let formatted_title = format_template(title, variables);
+		let formatted_message = format_template(body_template, variables);
 		json!({
-			"title": title,
-			"body": message
+			"title": formatted_title,
+			"body": formatted_message
 		})
 	}
 }
@@ -200,9 +204,12 @@ mod tests {
 
 	#[test]
 	fn test_slack_payload_builder() {
-		let title = "Test Title";
-		let message = "Test Message";
-		let variables = HashMap::from([("value".to_string(), "42".to_string())]);
+		let title = "Test ${title_value}";
+		let message = "Test ${message_value}";
+		let variables = HashMap::from([
+			("title_value".to_string(), "Title".to_string()),
+			("message_value".to_string(), "Message".to_string()),
+		]);
 		let payload = SlackPayloadBuilder.build_payload(title, message, &variables);
 		assert_eq!(
 			payload,
@@ -222,9 +229,12 @@ mod tests {
 
 	#[test]
 	fn test_discord_payload_builder() {
-		let title = "Test Title";
-		let message = "Test Message";
-		let variables = HashMap::from([("value".to_string(), "42".to_string())]);
+		let title = "Test ${title_value}";
+		let message = "Test ${message_value}";
+		let variables = HashMap::from([
+			("title_value".to_string(), "Title".to_string()),
+			("message_value".to_string(), "Message".to_string()),
+		]);
 		let payload = DiscordPayloadBuilder.build_payload(title, message, &variables);
 		assert_eq!(
 			payload,
@@ -240,9 +250,12 @@ mod tests {
 			chat_id: "12345".to_string(),
 			disable_web_preview: true,
 		};
-		let title = "Test Title";
-		let message = "Test Message";
-		let variables = HashMap::from([("value".to_string(), "42".to_string())]);
+		let title = "Test ${title_value}";
+		let message = "Test ${message_value}";
+		let variables = HashMap::from([
+			("title_value".to_string(), "Title".to_string()),
+			("message_value".to_string(), "Message".to_string()),
+		]);
 		let payload = builder.build_payload(title, message, &variables);
 		assert_eq!(
 			payload,
@@ -257,9 +270,12 @@ mod tests {
 
 	#[test]
 	fn test_generic_webhook_payload_builder() {
-		let title = "Test Title";
-		let message = "Test Message";
-		let variables = HashMap::from([("value".to_string(), "42".to_string())]);
+		let title = "Test ${title_value}";
+		let message = "Test ${message_value}";
+		let variables = HashMap::from([
+			("title_value".to_string(), "Title".to_string()),
+			("message_value".to_string(), "Message".to_string()),
+		]);
 		let payload = GenericWebhookPayloadBuilder.build_payload(title, message, &variables);
 		assert_eq!(
 			payload,


### PR DESCRIPTION
# Summary

Closes #335 

This PR simply uses the existing `format_template` method also for the title of webhook notifications.

## Testing Process

- Add Network configuration
- Add Trigger configuration with Telegram, Discord, Slack or generic Webhook, in the trigger add a variable inside the message title
- Add Monitor configuration (can be the USDC example) and include above triggers
- Run monitor

## Checklist

- [X] Add a reference to related issues in the PR description.
- [X] Add unit tests if applicable.
- [X] Add integration tests if applicable.
- [X] Add property-based tests if applicable.
- [X] Update documentation if applicable.
