### PR TITLE
docs: Add Ubuntu Setup Instructions (#309)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,9 +87,11 @@ Beginner focused information can be found below in [Open a Pull Request](#openin
      Or use the provided system package script (automatically ensures Python 3.9+ compatibility):
 
      ```sh
-     chmod +x ./scripts/linux/sys_pkgs.sh
+  chmod +x ./scripts/linux/sys_pkgs_core.sh
+  chmod +x ./scripts/linux/sys_pkgs_dev.sh
      # Installs required packages and ensures compatible Python version
-     ./scripts/linux/sys_pkgs.sh
+  ./scripts/linux/sys_pkgs_core.sh   # For runtime dependencies only
+  ./scripts/linux/sys_pkgs_dev.sh    # For Python/dev dependencies (calls core script)
      ```
 
    - Install dependencies:

--- a/README.md
+++ b/README.md
@@ -175,9 +175,11 @@ sudo apt install -y \
 or run the linux system package script (automatically ensures Python 3.9+ compatibility):
 
 ```bash
-chmod +x ./scripts/linux/sys_pkgs.sh
+chmod +x ./scripts/linux/sys_pkgs_core.sh
+chmod +x ./scripts/linux/sys_pkgs_dev.sh
 # Installs required packages and ensures compatible Python version
-./scripts/linux/sys_pkgs.sh
+./scripts/linux/sys_pkgs_core.sh   # For runtime dependencies only
+./scripts/linux/sys_pkgs_dev.sh    # For Python/dev dependencies (calls core script)
 ```
 
 #### Prerequisites

--- a/docs/modules/ROOT/pages/contribution.adoc
+++ b/docs/modules/ROOT/pages/contribution.adoc
@@ -67,9 +67,11 @@ Or use the provided system package script (automatically ensures Python 3.9+ com
 
 [source,bash]
 ----
-chmod +x ./scripts/linux/sys_pkgs.sh
+chmod +x ./scripts/linux/sys_pkgs_core.sh
+chmod +x ./scripts/linux/sys_pkgs_dev.sh
 # Installs required packages and ensures compatible Python version
-./scripts/linux/sys_pkgs.sh
+./scripts/linux/sys_pkgs_core.sh   // For runtime dependencies only
+./scripts/linux/sys_pkgs_dev.sh    // For Python/dev dependencies (calls core script)
 ----
 
 === Initial Setup

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -69,9 +69,11 @@ Or use the provided system package script (automatically ensures Python 3.9+ com
 
 [source,bash]
 ----
-chmod +x ./scripts/linux/sys_pkgs.sh
+chmod +x ./scripts/linux/sys_pkgs_core.sh
+chmod +x ./scripts/linux/sys_pkgs_dev.sh
 # Installs required packages and ensures compatible Python version
-./scripts/linux/sys_pkgs.sh
+./scripts/linux/sys_pkgs_core.sh   // For runtime dependencies only
+./scripts/linux/sys_pkgs_dev.sh    // For Python/dev dependencies (calls core script)
 ----
 
 === Local Installation

--- a/docs/modules/ROOT/pages/quickstart.adoc
+++ b/docs/modules/ROOT/pages/quickstart.adoc
@@ -42,18 +42,14 @@ sudo apt install -y \
     libssl-dev \
     libffi-dev \
     libyaml-dev \
-    python3 \
-    python3-venv \
-    python3-pip
 ----
 
-Or use the provided system package script (automatically ensures Python 3.9+ compatibility):
+Or use the provided system packages script:
 
 [source,bash]
 ----
-chmod +x ./scripts/linux/sys_pkgs.sh
-# Installs required packages and ensures compatible Python version
-./scripts/linux/sys_pkgs.sh
+chmod +x ./scripts/linux/sys_pkgs_core.sh
+./scripts/linux/sys_pkgs_core.sh   // For runtime dependencies only
 ----
 
 == Quick Setup Options

--- a/scripts/linux/sys_pkgs_core.sh
+++ b/scripts/linux/sys_pkgs_core.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Colors for pretty printing
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+info() { echo -e "${BLUE}ℹ${NC} $*"; }
+success() { echo -e "${GREEN}✅${NC} $*"; }
+warn() { echo -e "${YELLOW}⚠${NC} $*"; }
+error() { echo -e "${RED}❌${NC} $*"; }
+step() { echo -e "${CYAN}➤${NC} $*"; }
+
+# Don't run as root
+if [[ $EUID -eq 0 ]]; then
+    error "Don't run this as root - it will use sudo when needed"
+    exit 1
+fi
+
+# Check if we're on Ubuntu/Debian
+if ! command -v apt-get >/dev/null; then
+    error "This script requires apt-get (Ubuntu/Debian)"
+    exit 1
+fi
+
+step "Removing problematic cdrom sources..."
+sudo sed -i '/cdrom:/d' /etc/apt/sources.list /etc/apt/sources.list.d/*.list 2>/dev/null || true
+success "Cleaned up package sources"
+
+# Update with retry
+step "Updating package lists..."
+for i in {1..3}; do
+    if sudo apt-get update >/dev/null 2>&1; then
+        success "Package lists updated"
+        break
+    elif [[ $i -eq 3 ]]; then
+        error "Failed to update after 3 attempts"
+        exit 1
+    else
+        warn "Retry $i failed, trying again in 5 seconds..."
+        sleep 5
+    fi
+
+done
+
+# Install core packages
+step "Installing core packages..."
+sudo apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    pkg-config \
+    libssl-dev \
+    libffi-dev \
+    libyaml-dev \
+    software-properties-common \
+    ca-certificates >/dev/null 2>&1
+success "Core packages installed"
+
+echo -e "\n${GREEN}🎉 Core system setup complete!${NC}"


### PR DESCRIPTION
# Summary

This PR adds explicit Ubuntu setup instructions and a helper script to assist new contributors using Linux environments.

## Testing Process

-  Ubuntu 25.04 (arm64), 24.04.2 LTS (arm64), and 20.04.6 LTS (x86) (via UTM on Apple Silicon)
  - `cargo build` successful
  - `pre-commit` installs and runs as expected
  - `setup_and_run.sh` works the same as on my mac
  
## Checklist

- [ ] Add a reference to related issues in the PR description. N/A
- [ ] Add unit tests if applicable. N/A
- [ ] Add integration tests if applicable. N/A
- [ ] Add property-based tests if applicable. N/A
- [x] Update documentation if applicable.

## Changes

- Added `scripts/linux/sys_pkgs.sh` to automate system-level setup (linux)
- Updated documentaton across the board for consistency with the new branching option