### PR TITLE
fix(solana): Include CPI program IDs in matching

### DIFF
--- a/src/models/blockchain/solana/mod.rs
+++ b/src/models/blockchain/solana/mod.rs
@@ -44,7 +44,8 @@ pub use monitor::{
 	ParsedInstructionResult as SolanaParsedInstructionResult,
 };
 pub use transaction::{
-	Instruction as SolanaInstruction, ParsedInstruction as SolanaParsedInstruction,
-	Transaction as SolanaTransaction, TransactionInfo as SolanaTransactionInfo,
-	TransactionMessage as SolanaTransactionMessage, TransactionMeta as SolanaTransactionMeta,
+	InnerInstruction as SolanaInnerInstruction, Instruction as SolanaInstruction,
+	ParsedInstruction as SolanaParsedInstruction, Transaction as SolanaTransaction,
+	TransactionInfo as SolanaTransactionInfo, TransactionMessage as SolanaTransactionMessage,
+	TransactionMeta as SolanaTransactionMeta,
 };

--- a/src/models/blockchain/solana/transaction.rs
+++ b/src/models/blockchain/solana/transaction.rs
@@ -244,23 +244,34 @@ impl Transaction {
 		self.0.meta.as_ref().map(|m| m.fee).unwrap_or(0)
 	}
 
-	/// Get all program IDs invoked in this transaction
+	/// Get all program IDs invoked in this transaction, including inner instructions (CPIs)
 	pub fn program_ids(&self) -> Vec<String> {
 		let account_keys = &self.0.transaction.account_keys;
-		self.0
+
+		let resolve_program_id = |ix: &Instruction| -> Option<String> {
+			if let Some(program_id) = &ix.program_id {
+				return Some(program_id.clone());
+			}
+			let idx = ix.program_id_index as usize;
+			account_keys.get(idx).cloned()
+		};
+
+		let mut program_ids: Vec<String> = self
+			.0
 			.transaction
 			.instructions
 			.iter()
-			.filter_map(|ix| {
-				// First check if there's a parsed program_id
-				if let Some(program_id) = &ix.program_id {
-					return Some(program_id.clone());
-				}
-				// Otherwise, look up by index
-				let idx = ix.program_id_index as usize;
-				account_keys.get(idx).cloned()
-			})
-			.collect()
+			.filter_map(resolve_program_id)
+			.collect();
+
+		// Also include program IDs from inner instructions (CPI calls)
+		if let Some(meta) = &self.0.meta {
+			for inner in &meta.inner_instructions {
+				program_ids.extend(inner.instructions.iter().filter_map(resolve_program_id));
+			}
+		}
+
+		program_ids
 	}
 
 	/// Get the fee payer address (first account in account_keys by Solana convention)

--- a/src/models/blockchain/solana/transaction.rs
+++ b/src/models/blockchain/solana/transaction.rs
@@ -486,6 +486,62 @@ mod tests {
 	}
 
 	#[test]
+	fn test_program_ids_includes_inner_instructions() {
+		let mut tx_info = create_test_transaction(true);
+		// Add inner instructions with index-based program ID resolution
+		if let Some(ref mut meta) = tx_info.meta {
+			meta.inner_instructions = vec![InnerInstruction {
+				index: 0,
+				instructions: vec![Instruction {
+					program_id_index: 1, // "11111111111111111111111111111111" in account_keys
+					accounts: vec![0],
+					data: String::new(),
+					parsed: None,
+					program: None,
+					program_id: None, // Force index-based lookup
+				}],
+			}];
+		}
+
+		let transaction = Transaction(tx_info);
+		let program_ids = transaction.program_ids();
+
+		assert_eq!(program_ids.len(), 2);
+		assert_eq!(
+			program_ids[0],
+			"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
+		);
+		assert_eq!(program_ids[1], "11111111111111111111111111111111");
+	}
+
+	#[test]
+	fn test_program_ids_inner_instructions_with_program_id_field() {
+		let mut tx_info = create_test_transaction(true);
+		if let Some(ref mut meta) = tx_info.meta {
+			meta.inner_instructions = vec![InnerInstruction {
+				index: 0,
+				instructions: vec![Instruction {
+					program_id_index: 0,
+					accounts: vec![],
+					data: String::new(),
+					parsed: None,
+					program: None,
+					program_id: Some("BPFLoaderUpgradeab1e11111111111111111111111".to_string()),
+				}],
+			}];
+		}
+
+		let transaction = Transaction(tx_info);
+		let program_ids = transaction.program_ids();
+
+		assert_eq!(program_ids.len(), 2);
+		assert_eq!(
+			program_ids[1],
+			"BPFLoaderUpgradeab1e11111111111111111111111"
+		);
+	}
+
+	#[test]
 	fn test_serde_serialization() {
 		let tx_info = create_test_transaction(true);
 		let transaction = Transaction(tx_info);

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -70,6 +70,7 @@ pub use blockchain::solana::{
 	SolanaIdlTypeDef,
 	SolanaIdlTypeDefTy,
 	// Other Solana types
+	SolanaInnerInstruction,
 	SolanaInstruction,
 	SolanaMatchArguments,
 	SolanaMatchParamEntry,

--- a/src/services/blockchain/clients/solana/client.rs
+++ b/src/services/blockchain/clients/solana/client.rs
@@ -333,59 +333,7 @@ impl<T: Send + Sync + Clone> SolanaClient<T> {
 								.get("instructions")
 								.and_then(|instrs| instrs.as_array())
 								.map(|instrs| {
-									instrs
-										.iter()
-										.map(|ix| {
-											let program_id_index = ix
-												.get("programIdIndex")
-												.and_then(|idx| idx.as_u64())
-												.unwrap_or(0) as u8;
-											let accounts: Vec<u8> = ix
-												.get("accounts")
-												.and_then(|a| a.as_array())
-												.map(|a| {
-													a.iter()
-														.filter_map(|v| v.as_u64().map(|i| i as u8))
-														.collect()
-												})
-												.unwrap_or_default();
-											let data = ix
-												.get("data")
-												.and_then(|d| d.as_str())
-												.unwrap_or_default()
-												.to_string();
-											let parsed = ix.get("parsed").map(|p| {
-												let instruction_type = p
-													.get("type")
-													.and_then(|t| t.as_str())
-													.unwrap_or_default();
-												let info = p
-													.get("info")
-													.cloned()
-													.unwrap_or(serde_json::Value::Null);
-												crate::models::SolanaParsedInstruction {
-													instruction_type: instruction_type.to_string(),
-													info,
-												}
-											});
-											let program = ix
-												.get("program")
-												.and_then(|p| p.as_str())
-												.map(|s| s.to_string());
-											let program_id = ix
-												.get("programId")
-												.and_then(|p| p.as_str())
-												.map(|s| s.to_string());
-											SolanaInstruction {
-												program_id_index,
-												accounts,
-												data,
-												parsed,
-												program,
-												program_id,
-											}
-										})
-										.collect()
+									instrs.iter().map(Self::parse_single_instruction).collect()
 								})
 								.unwrap_or_default();
 							Some(crate::models::SolanaInnerInstruction {
@@ -433,64 +381,65 @@ impl<T: Send + Sync + Clone> SolanaClient<T> {
 			_ => return Ok(Vec::new()),
 		};
 
-		let mut instructions = Vec::with_capacity(raw_instructions.len());
+		Ok(raw_instructions
+			.iter()
+			.map(Self::parse_single_instruction)
+			.collect())
+	}
 
-		for raw_instr in raw_instructions {
-			// Get program ID index
-			let program_id_index = raw_instr
-				.get("programIdIndex")
-				.and_then(|idx| idx.as_u64())
-				.unwrap_or(0) as u8;
+	/// Parses a single instruction JSON value into a `SolanaInstruction`.
+	///
+	/// Shared by top-level and inner-instruction parsing so field extraction
+	/// stays consistent across both code paths.
+	fn parse_single_instruction(raw_instr: &serde_json::Value) -> SolanaInstruction {
+		let program_id_index = raw_instr
+			.get("programIdIndex")
+			.and_then(|idx| idx.as_u64())
+			.unwrap_or(0) as u8;
 
-			// Get account indices
-			let accounts: Vec<u8> = raw_instr
-				.get("accounts")
-				.and_then(|accs| accs.as_array())
-				.map(|accs| {
-					accs.iter()
-						.filter_map(|idx| idx.as_u64().map(|i| i as u8))
-						.collect()
-				})
-				.unwrap_or_default();
+		let accounts: Vec<u8> = raw_instr
+			.get("accounts")
+			.and_then(|accs| accs.as_array())
+			.map(|accs| {
+				accs.iter()
+					.filter_map(|idx| idx.as_u64().map(|i| i as u8))
+					.collect()
+			})
+			.unwrap_or_default();
 
-			// Get data (base58 encoded)
-			let data = raw_instr
-				.get("data")
-				.and_then(|d| d.as_str())
-				.unwrap_or_default()
-				.to_string();
+		let data = raw_instr
+			.get("data")
+			.and_then(|d| d.as_str())
+			.unwrap_or_default()
+			.to_string();
 
-			// Check for parsed instruction
-			let parsed = raw_instr.get("parsed").map(|p| {
-				let instruction_type = p.get("type").and_then(|t| t.as_str()).unwrap_or_default();
-				let info = p.get("info").cloned().unwrap_or(serde_json::Value::Null);
-				crate::models::SolanaParsedInstruction {
-					instruction_type: instruction_type.to_string(),
-					info,
-				}
-			});
+		let parsed = raw_instr.get("parsed").map(|p| {
+			let instruction_type = p.get("type").and_then(|t| t.as_str()).unwrap_or_default();
+			let info = p.get("info").cloned().unwrap_or(serde_json::Value::Null);
+			crate::models::SolanaParsedInstruction {
+				instruction_type: instruction_type.to_string(),
+				info,
+			}
+		});
 
-			let program = raw_instr
-				.get("program")
-				.and_then(|p| p.as_str())
-				.map(|s| s.to_string());
+		let program = raw_instr
+			.get("program")
+			.and_then(|p| p.as_str())
+			.map(|s| s.to_string());
 
-			let program_id = raw_instr
-				.get("programId")
-				.and_then(|p| p.as_str())
-				.map(|s| s.to_string());
+		let program_id = raw_instr
+			.get("programId")
+			.and_then(|p| p.as_str())
+			.map(|s| s.to_string());
 
-			instructions.push(SolanaInstruction {
-				program_id_index,
-				accounts,
-				data,
-				parsed,
-				program,
-				program_id,
-			});
+		SolanaInstruction {
+			program_id_index,
+			accounts,
+			data,
+			parsed,
+			program,
+			program_id,
 		}
-
-		Ok(instructions)
 	}
 }
 

--- a/src/services/blockchain/clients/solana/client.rs
+++ b/src/services/blockchain/clients/solana/client.rs
@@ -2088,6 +2088,188 @@ mod tests {
 		);
 	}
 
+	#[test]
+	fn test_parse_single_transaction_with_inner_instructions() {
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_with_inner"],
+				"message": {
+					"accountKeys": [
+						"FeePayer111111111111111111111111111111111111",
+						"SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf",
+						"BPFLoaderUpgradeab1e11111111111111111111111",
+						"KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
+					],
+					"instructions": [{
+						"programIdIndex": 1,
+						"accounts": [0, 2, 3],
+						"data": "3Bxs4h24hBtQy9rw"
+					}],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 5000,
+				"preBalances": [1000000, 500000],
+				"postBalances": [995000, 500000],
+				"logMessages": [
+					"Program SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf invoke [1]",
+					"Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [2]",
+					"Upgraded program KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD",
+					"Program BPFLoaderUpgradeab1e11111111111111111111111 success",
+					"Program SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf success"
+				],
+				"innerInstructions": [{
+					"index": 0,
+					"instructions": [{
+						"programIdIndex": 2,
+						"accounts": [3],
+						"data": ""
+					}]
+				}]
+			}
+		});
+
+		let result = client.parse_single_transaction(100, &raw_tx);
+		assert!(result.is_ok());
+		let tx = result.unwrap().expect("should parse transaction");
+
+		// Verify inner instructions were parsed
+		let meta = tx.meta.as_ref().unwrap();
+		assert_eq!(meta.inner_instructions.len(), 1);
+		assert_eq!(meta.inner_instructions[0].index, 0);
+		assert_eq!(meta.inner_instructions[0].instructions.len(), 1);
+		assert_eq!(
+			meta.inner_instructions[0].instructions[0].program_id_index,
+			2
+		);
+
+		// Verify program_ids() includes both top-level and inner instruction programs
+		let program_ids = tx.program_ids();
+		assert!(program_ids.contains(&"BPFLoaderUpgradeab1e11111111111111111111111".to_string()));
+	}
+
+	#[test]
+	fn test_parse_single_transaction_with_inner_instructions_parsed_format() {
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_parsed_inner"],
+				"message": {
+					"accountKeys": [
+						"FeePayer111111111111111111111111111111111111",
+						"SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf"
+					],
+					"instructions": [{
+						"programIdIndex": 1,
+						"accounts": [0],
+						"data": "abc"
+					}],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 5000,
+				"preBalances": [100],
+				"postBalances": [95],
+				"logMessages": [],
+				"innerInstructions": [{
+					"index": 0,
+					"instructions": [{
+						"programIdIndex": 0,
+						"accounts": [],
+						"data": "xyz",
+						"program": "bpf-upgradeable-loader",
+						"programId": "BPFLoaderUpgradeab1e11111111111111111111111",
+						"parsed": {
+							"type": "upgrade",
+							"info": {
+								"programId": "KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
+							}
+						}
+					}]
+				}]
+			}
+		});
+
+		let result = client.parse_single_transaction(100, &raw_tx);
+		assert!(result.is_ok());
+		let tx = result.unwrap().expect("should parse transaction");
+
+		let inner_ix = &tx.meta.as_ref().unwrap().inner_instructions[0].instructions[0];
+		assert_eq!(
+			inner_ix.program_id,
+			Some("BPFLoaderUpgradeab1e11111111111111111111111".to_string())
+		);
+		assert_eq!(inner_ix.program, Some("bpf-upgradeable-loader".to_string()));
+		assert!(inner_ix.parsed.is_some());
+		assert_eq!(
+			inner_ix.parsed.as_ref().unwrap().instruction_type,
+			"upgrade"
+		);
+	}
+
+	#[test]
+	fn test_parse_single_transaction_without_inner_instructions() {
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_no_inner"],
+				"message": {
+					"accountKeys": ["Account1"],
+					"instructions": [],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 5000,
+				"preBalances": [100],
+				"postBalances": [95],
+				"logMessages": []
+			}
+		});
+
+		let result = client.parse_single_transaction(100, &raw_tx);
+		assert!(result.is_ok());
+		let tx = result.unwrap().expect("should parse transaction");
+
+		// No innerInstructions field -> empty vec
+		assert!(tx.meta.as_ref().unwrap().inner_instructions.is_empty());
+	}
+
+	#[test]
+	fn test_parse_single_transaction_with_empty_inner_instructions() {
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_empty_inner"],
+				"message": {
+					"accountKeys": ["Account1"],
+					"instructions": [],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 5000,
+				"preBalances": [100],
+				"postBalances": [95],
+				"logMessages": [],
+				"innerInstructions": []
+			}
+		});
+
+		let result = client.parse_single_transaction(100, &raw_tx);
+		assert!(result.is_ok());
+		let tx = result.unwrap().expect("should parse transaction");
+
+		assert!(tx.meta.as_ref().unwrap().inner_instructions.is_empty());
+	}
+
 	#[tokio::test]
 	async fn test_fetch_stream_kind_derives() {
 		// Verify derived traits work correctly

--- a/src/services/blockchain/clients/solana/client.rs
+++ b/src/services/blockchain/clients/solana/client.rs
@@ -322,6 +322,81 @@ impl<T: Send + Sync + Clone> SolanaClient<T> {
 				})
 				.unwrap_or_default();
 
+			let inner_instructions: Vec<crate::models::SolanaInnerInstruction> = m
+				.get("innerInstructions")
+				.and_then(|ii| ii.as_array())
+				.map(|arr| {
+					arr.iter()
+						.filter_map(|inner| {
+							let index = inner.get("index")?.as_u64()? as u8;
+							let instructions: Vec<SolanaInstruction> = inner
+								.get("instructions")
+								.and_then(|instrs| instrs.as_array())
+								.map(|instrs| {
+									instrs
+										.iter()
+										.map(|ix| {
+											let program_id_index = ix
+												.get("programIdIndex")
+												.and_then(|idx| idx.as_u64())
+												.unwrap_or(0) as u8;
+											let accounts: Vec<u8> = ix
+												.get("accounts")
+												.and_then(|a| a.as_array())
+												.map(|a| {
+													a.iter()
+														.filter_map(|v| v.as_u64().map(|i| i as u8))
+														.collect()
+												})
+												.unwrap_or_default();
+											let data = ix
+												.get("data")
+												.and_then(|d| d.as_str())
+												.unwrap_or_default()
+												.to_string();
+											let parsed = ix.get("parsed").map(|p| {
+												let instruction_type = p
+													.get("type")
+													.and_then(|t| t.as_str())
+													.unwrap_or_default();
+												let info = p
+													.get("info")
+													.cloned()
+													.unwrap_or(serde_json::Value::Null);
+												crate::models::SolanaParsedInstruction {
+													instruction_type: instruction_type.to_string(),
+													info,
+												}
+											});
+											let program = ix
+												.get("program")
+												.and_then(|p| p.as_str())
+												.map(|s| s.to_string());
+											let program_id = ix
+												.get("programId")
+												.and_then(|p| p.as_str())
+												.map(|s| s.to_string());
+											SolanaInstruction {
+												program_id_index,
+												accounts,
+												data,
+												parsed,
+												program,
+												program_id,
+											}
+										})
+										.collect()
+								})
+								.unwrap_or_default();
+							Some(crate::models::SolanaInnerInstruction {
+								index,
+								instructions,
+							})
+						})
+						.collect()
+				})
+				.unwrap_or_default();
+
 			SolanaTransactionMeta {
 				err,
 				fee,
@@ -329,7 +404,7 @@ impl<T: Send + Sync + Clone> SolanaClient<T> {
 				post_balances,
 				pre_token_balances: Vec::new(),
 				post_token_balances: Vec::new(),
-				inner_instructions: Vec::new(),
+				inner_instructions,
 				log_messages,
 				compute_units_consumed: m.get("computeUnitsConsumed").and_then(|c| c.as_u64()),
 				loaded_addresses: None,

--- a/src/services/blockchain/clients/solana/client.rs
+++ b/src/services/blockchain/clients/solana/client.rs
@@ -328,12 +328,15 @@ impl<T: Send + Sync + Clone> SolanaClient<T> {
 				.map(|arr| {
 					arr.iter()
 						.filter_map(|inner| {
-							let index = inner.get("index")?.as_u64()? as u8;
+							let index = u8::try_from(inner.get("index")?.as_u64()?).ok()?;
 							let instructions: Vec<SolanaInstruction> = inner
 								.get("instructions")
 								.and_then(|instrs| instrs.as_array())
 								.map(|instrs| {
-									instrs.iter().map(Self::parse_single_instruction).collect()
+									instrs
+										.iter()
+										.filter_map(Self::parse_single_instruction)
+										.collect()
 								})
 								.unwrap_or_default();
 							Some(crate::models::SolanaInnerInstruction {
@@ -383,7 +386,7 @@ impl<T: Send + Sync + Clone> SolanaClient<T> {
 
 		Ok(raw_instructions
 			.iter()
-			.map(Self::parse_single_instruction)
+			.filter_map(Self::parse_single_instruction)
 			.collect())
 	}
 
@@ -391,18 +394,25 @@ impl<T: Send + Sync + Clone> SolanaClient<T> {
 	///
 	/// Shared by top-level and inner-instruction parsing so field extraction
 	/// stays consistent across both code paths.
-	fn parse_single_instruction(raw_instr: &serde_json::Value) -> SolanaInstruction {
-		let program_id_index = raw_instr
-			.get("programIdIndex")
-			.and_then(|idx| idx.as_u64())
-			.unwrap_or(0) as u8;
+	///
+	/// Returns `None` when `programIdIndex` is present but exceeds `u8::MAX`,
+	/// since silently truncating would redirect the instruction to a
+	/// different account. A missing `programIdIndex` (as in the `jsonParsed`
+	/// encoding, where `programId` is the real identifier) defaults to 0.
+	/// Individual out-of-range `accounts` entries are dropped, consistent
+	/// with the existing handling of non-numeric entries.
+	fn parse_single_instruction(raw_instr: &serde_json::Value) -> Option<SolanaInstruction> {
+		let program_id_index = match raw_instr.get("programIdIndex").and_then(|idx| idx.as_u64()) {
+			Some(n) => u8::try_from(n).ok()?,
+			None => 0,
+		};
 
 		let accounts: Vec<u8> = raw_instr
 			.get("accounts")
 			.and_then(|accs| accs.as_array())
 			.map(|accs| {
 				accs.iter()
-					.filter_map(|idx| idx.as_u64().map(|i| i as u8))
+					.filter_map(|idx| idx.as_u64().and_then(|i| u8::try_from(i).ok()))
 					.collect()
 			})
 			.unwrap_or_default();
@@ -432,14 +442,14 @@ impl<T: Send + Sync + Clone> SolanaClient<T> {
 			.and_then(|p| p.as_str())
 			.map(|s| s.to_string());
 
-		SolanaInstruction {
+		Some(SolanaInstruction {
 			program_id_index,
 			accounts,
 			data,
 			parsed,
 			program,
 			program_id,
-		}
+		})
 	}
 }
 
@@ -2217,6 +2227,220 @@ mod tests {
 		let tx = result.unwrap().expect("should parse transaction");
 
 		assert!(tx.meta.as_ref().unwrap().inner_instructions.is_empty());
+	}
+
+	#[test]
+	fn test_parse_single_transaction_drops_instruction_with_oob_program_id_index() {
+		// A conforming RPC cannot return programIdIndex > 255 (Solana's wire
+		// format packs it as u8), but if one does, silently truncating with
+		// `as u8` would redirect the instruction to account 0 and could
+		// produce false monitor matches. The parser must drop it instead.
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_oob_pid"],
+				"message": {
+					"accountKeys": ["Account1", "Account2"],
+					"instructions": [
+						{ "programIdIndex": 1, "accounts": [0], "data": "ok" },
+						{ "programIdIndex": 300, "accounts": [0], "data": "bad" },
+						{ "programIdIndex": 0, "accounts": [1], "data": "ok2" }
+					],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 0,
+				"preBalances": [0, 0],
+				"postBalances": [0, 0],
+				"logMessages": []
+			}
+		});
+
+		let tx = client
+			.parse_single_transaction(1, &raw_tx)
+			.unwrap()
+			.expect("should parse transaction");
+
+		// Out-of-range instruction dropped; the two valid ones remain in order.
+		assert_eq!(tx.transaction.instructions.len(), 2);
+		assert_eq!(tx.transaction.instructions[0].data, "ok");
+		assert_eq!(tx.transaction.instructions[1].data, "ok2");
+	}
+
+	#[test]
+	fn test_parse_single_transaction_drops_oob_account_indices() {
+		// Individual out-of-range account indices should be dropped, matching
+		// the existing filter_map behavior for non-numeric entries. Other
+		// valid indices in the same instruction are preserved.
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_oob_acct"],
+				"message": {
+					"accountKeys": ["Account1"],
+					"instructions": [{
+						"programIdIndex": 0,
+						"accounts": [1, 500, 2, 9999, 3],
+						"data": "d"
+					}],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 0,
+				"preBalances": [0],
+				"postBalances": [0],
+				"logMessages": []
+			}
+		});
+
+		let tx = client
+			.parse_single_transaction(1, &raw_tx)
+			.unwrap()
+			.expect("should parse transaction");
+
+		assert_eq!(tx.transaction.instructions.len(), 1);
+		assert_eq!(tx.transaction.instructions[0].accounts, vec![1u8, 2, 3]);
+	}
+
+	#[test]
+	fn test_parse_single_transaction_drops_inner_instruction_with_oob_program_id_index() {
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_inner_oob_pid"],
+				"message": {
+					"accountKeys": ["Account1", "Account2"],
+					"instructions": [{
+						"programIdIndex": 1, "accounts": [0], "data": "x"
+					}],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 0,
+				"preBalances": [0, 0],
+				"postBalances": [0, 0],
+				"logMessages": [],
+				"innerInstructions": [{
+					"index": 0,
+					"instructions": [
+						{ "programIdIndex": 1, "accounts": [], "data": "a" },
+						{ "programIdIndex": 999, "accounts": [], "data": "b" },
+						{ "programIdIndex": 0, "accounts": [], "data": "c" }
+					]
+				}]
+			}
+		});
+
+		let tx = client
+			.parse_single_transaction(1, &raw_tx)
+			.unwrap()
+			.expect("should parse transaction");
+
+		let inner = &tx.meta.as_ref().unwrap().inner_instructions;
+		assert_eq!(inner.len(), 1);
+		assert_eq!(inner[0].instructions.len(), 2);
+		assert_eq!(inner[0].instructions[0].data, "a");
+		assert_eq!(inner[0].instructions[1].data, "c");
+	}
+
+	#[test]
+	fn test_parse_single_transaction_drops_inner_group_with_oob_index() {
+		// The `index` on an innerInstructions group must fit in u8 (it
+		// references an outer instruction, which is u8-indexed on the wire).
+		// An out-of-range group index drops the whole group.
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_inner_oob_group"],
+				"message": {
+					"accountKeys": ["Account1"],
+					"instructions": [{
+						"programIdIndex": 0, "accounts": [], "data": "x"
+					}],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 0,
+				"preBalances": [0],
+				"postBalances": [0],
+				"logMessages": [],
+				"innerInstructions": [
+					{
+						"index": 0,
+						"instructions": [{
+							"programIdIndex": 0, "accounts": [], "data": "kept"
+						}]
+					},
+					{
+						"index": 300,
+						"instructions": [{
+							"programIdIndex": 0, "accounts": [], "data": "dropped"
+						}]
+					}
+				]
+			}
+		});
+
+		let tx = client
+			.parse_single_transaction(1, &raw_tx)
+			.unwrap()
+			.expect("should parse transaction");
+
+		let inner = &tx.meta.as_ref().unwrap().inner_instructions;
+		assert_eq!(inner.len(), 1);
+		assert_eq!(inner[0].index, 0);
+		assert_eq!(inner[0].instructions[0].data, "kept");
+	}
+
+	#[test]
+	fn test_parse_single_transaction_missing_program_id_index_defaults_to_zero() {
+		// The `jsonParsed` encoding omits `programIdIndex` — the real
+		// identifier lives in the `programId` string. Missing must still
+		// default to 0 (not be treated as an out-of-range drop).
+		let client = mock_client();
+		let raw_tx = json!({
+			"transaction": {
+				"signatures": ["sig_parsed_no_pid"],
+				"message": {
+					"accountKeys": ["Account1"],
+					"instructions": [{
+						"accounts": [0],
+						"data": "d",
+						"program": "system",
+						"programId": "11111111111111111111111111111111"
+					}],
+					"recentBlockhash": "hash1"
+				}
+			},
+			"meta": {
+				"err": null,
+				"fee": 0,
+				"preBalances": [0],
+				"postBalances": [0],
+				"logMessages": []
+			}
+		});
+
+		let tx = client
+			.parse_single_transaction(1, &raw_tx)
+			.unwrap()
+			.expect("should parse transaction");
+
+		assert_eq!(tx.transaction.instructions.len(), 1);
+		let ix = &tx.transaction.instructions[0];
+		assert_eq!(ix.program_id_index, 0);
+		assert_eq!(
+			ix.program_id,
+			Some("11111111111111111111111111111111".to_string())
+		);
 	}
 
 	#[tokio::test]

--- a/tests/integration/filters/solana/filter.rs
+++ b/tests/integration/filters/solana/filter.rs
@@ -8,9 +8,9 @@ use std::collections::HashMap;
 use openzeppelin_monitor::{
 	models::{
 		AddressWithSpec, BlockType, EventCondition, MatchConditions, Monitor, MonitorMatch,
-		SolanaBlock, SolanaConfirmedBlock, SolanaInstruction, SolanaMatchArguments,
-		SolanaMonitorMatch, SolanaTransaction, SolanaTransactionInfo, SolanaTransactionMessage,
-		SolanaTransactionMeta, TransactionCondition, TransactionStatus,
+		SolanaBlock, SolanaConfirmedBlock, SolanaInnerInstruction, SolanaInstruction,
+		SolanaMatchArguments, SolanaMonitorMatch, SolanaTransaction, SolanaTransactionInfo,
+		SolanaTransactionMessage, SolanaTransactionMeta, TransactionCondition, TransactionStatus,
 	},
 	services::filter::{handle_match, FilterError, FilterService},
 };
@@ -917,6 +917,133 @@ async fn test_filter_with_different_address() -> Result<(), Box<FilterError>> {
 		matches.is_empty(),
 		"Should not match with different address"
 	);
+
+	Ok(())
+}
+
+/// Tests that a monitor watching an address invoked via CPI (inner instruction)
+/// correctly matches the transaction. This simulates the scenario where a program
+/// upgrade is executed through a multisig (e.g., Squads V4), so BPFLoaderUpgradeab1e
+/// is called at depth [2] rather than directly at depth [1].
+#[tokio::test]
+async fn test_filter_matches_address_in_inner_instructions() -> Result<(), Box<FilterError>> {
+	let network = create_test_network();
+	let filter_service = FilterService::new();
+	let client = MockSolanaClientTrait::<MockSolanaTransportClient>::new();
+
+	// Monitor watches BPFLoaderUpgradeab1e with an event for the upgrade log
+	let monitor = Monitor {
+		name: "Upgrade Monitor".to_string(),
+		paused: false,
+		networks: vec!["solana_devnet".to_string()],
+		addresses: vec![AddressWithSpec {
+			address: "BPFLoaderUpgradeab1e11111111111111111111111".to_string(),
+			contract_spec: None,
+		}],
+		match_conditions: MatchConditions {
+			functions: vec![],
+			events: vec![EventCondition {
+				signature: "Upgraded program KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
+					.to_string(),
+				expression: None,
+			}],
+			transactions: vec![TransactionCondition {
+				status: TransactionStatus::Success,
+				expression: None,
+			}],
+		},
+		trigger_conditions: vec![],
+		triggers: vec![],
+		chain_configurations: vec![],
+	};
+
+	// Transaction where top-level instruction is Squads V4,
+	// and BPFLoaderUpgradeab1e is invoked via CPI (inner instruction)
+	let transaction = SolanaTransaction::from(SolanaTransactionInfo {
+		signature: "2BqY4vCoMGADSHdGxCEjFRMhMFHBCPhQvJq2t4pPgeMeZtE4AVsjguzCjCzPvqxJPDHtvmzzmxgXedWtGWA2XhUf"
+			.to_string(),
+		slot: 123456789,
+		block_time: Some(1234567890),
+		transaction: SolanaTransactionMessage {
+			account_keys: vec![
+				"FeePayer111111111111111111111111111111111111".to_string(),
+				"SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf".to_string(),
+				"BPFLoaderUpgradeab1e11111111111111111111111".to_string(),
+				"KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD".to_string(),
+			],
+			recent_blockhash: "ABC123".to_string(),
+			// Top-level instruction invokes Squads V4 (index 1 in account_keys)
+			instructions: vec![SolanaInstruction {
+				program_id_index: 1,
+				accounts: vec![0, 2, 3],
+				data: "3Bxs4h24hBtQy9rw".to_string(),
+				parsed: None,
+				program: None,
+				program_id: Some(
+					"SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf".to_string(),
+				),
+			}],
+			address_table_lookups: vec![],
+		},
+		meta: Some(SolanaTransactionMeta {
+			err: None,
+			fee: 5000,
+			pre_balances: vec![1000000000],
+			post_balances: vec![999000000],
+			// BPFLoaderUpgradeab1e is called via CPI from Squads
+			inner_instructions: vec![SolanaInnerInstruction {
+				index: 0,
+				instructions: vec![SolanaInstruction {
+					program_id_index: 2, // BPFLoaderUpgradeab1e in account_keys
+					accounts: vec![3],
+					data: String::new(),
+					parsed: None,
+					program: None,
+					program_id: Some(
+						"BPFLoaderUpgradeab1e11111111111111111111111".to_string(),
+					),
+				}],
+			}],
+			log_messages: vec![
+				"Program SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf invoke [1]".to_string(),
+				"Program log: Instruction: VaultTransactionExecute".to_string(),
+				"Program BPFLoaderUpgradeab1e11111111111111111111111 invoke [2]".to_string(),
+				"Upgraded program KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD".to_string(),
+				"Program BPFLoaderUpgradeab1e11111111111111111111111 success".to_string(),
+				"Program SQDS4ep65T869zMMBKyuUq6aD6EgTu8psMjkvj52pCf success".to_string(),
+			],
+			pre_token_balances: vec![],
+			post_token_balances: vec![],
+			compute_units_consumed: Some(83534),
+			loaded_addresses: None,
+		}),
+	});
+
+	let block = create_test_solana_block_with_transactions(vec![transaction]);
+
+	let matches = filter_service
+		.filter_block(&client, &network, &block, &[monitor], None)
+		.await?;
+
+	assert!(
+		!matches.is_empty(),
+		"Should match when monitored address is invoked via CPI (inner instruction)"
+	);
+
+	// Verify the match contains the expected event
+	let monitor_match = &matches[0];
+	if let MonitorMatch::Solana(solana_match) = monitor_match {
+		assert!(
+			!solana_match.matched_on.events.is_empty(),
+			"Should have matched the upgrade event"
+		);
+		assert_eq!(
+			solana_match.matched_on.events[0].signature,
+			"Upgraded program KLend2g3cP87fffoy8q1mQqGKjrxjC8boSyAYavgmjD"
+		);
+	} else {
+		panic!("Expected a Solana monitor match");
+	}
 
 	Ok(())
 }


### PR DESCRIPTION
# Summary

Solana monitors watching a program address only matched when that program was invoked as a top-level instruction. If the program was called via CPI (Cross-Program Invocation) — e.g., a program upgrade executed through a Squads V4 multisig — the monitor never triggered.    
                                                                                          
Root cause: program_ids() only extracted program IDs from top-level instructions, and the RPC client discarded innerInstructions from the response entirely.   

## Testing Process                                                                              
                                                                                             
  1. Run the new integration test that reproduces the exact scenario (Squads V4 → BPFLoaderUpgradeab1e CPI call):
cargo test test_filter_matches_address_in_inner_instructions -- --nocapture
  2. Verify no regression on existing Solana filter tests:
  cargo test integration::filters::solana -- --nocapture                                   
  3. To test end-to-end against a real transaction, configure a monitor for BPFLoaderUpgradeab1e11111111111111111111111 with event "Upgraded program <PROGRAM_ID>" and verify it triggers on upgrades executed through a multisig (e.g., tx 2BqY4vCoMGADSHdGxCEjFRMhMFHBCPhQvJq2t4pPgeMeZtE4AVsjguzCjCzPvqxJPDHtvmzzmxgXedWtGWA2XhUf on mainnet).

## Checklist

- [X] Add a reference to related issues in the PR description.
- [X] Add unit tests if applicable.
- [X] Add integration tests if applicable.
- [X] Add property-based tests if applicable.
- [X] Update documentation if applicable.

> [!NOTE]
> If you are using Monitor in your stack, consider adding your team or organization to our list of [Monitor Users in the Wild](../INTHEWILD.md)!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended Solana transaction tracking to include inner instructions (contract interactions within transactions), enabling comprehensive program ID detection and filtering across all instruction levels.

* **Tests**
  * Added integration test validating detection and filtering of program addresses within inner instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->