### PR TITLE
fix(examples): add recovery_config and max_past_blocks buffer to network examples

### DIFF
--- a/examples/config/networks/arbitrum_one.json
+++ b/examples/config/networks/arbitrum_one.json
@@ -16,5 +16,14 @@
   "block_time_ms": 250,
   "confirmation_blocks": 12,
   "cron_schedule": "0 */1 * * * *",
-  "store_blocks": false
+  "max_past_blocks": 750,
+  "store_blocks": false,
+  "recovery_config": {
+    "enabled": true,
+    "cron_schedule": "0 */5 * * * *",
+    "max_blocks_per_run": 100,
+    "max_block_age": 5000,
+    "max_retries": 3,
+    "retry_delay_ms": 1000
+  }
 }

--- a/examples/config/networks/arbitrum_one.json
+++ b/examples/config/networks/arbitrum_one.json
@@ -19,7 +19,7 @@
   "max_past_blocks": 750,
   "store_blocks": false,
   "recovery_config": {
-    "enabled": true,
+    "enabled": false,
     "cron_schedule": "0 */5 * * * *",
     "max_blocks_per_run": 100,
     "max_block_age": 5000,

--- a/examples/config/networks/base.json
+++ b/examples/config/networks/base.json
@@ -19,7 +19,7 @@
   "max_past_blocks": 100,
   "store_blocks": false,
   "recovery_config": {
-    "enabled": true,
+    "enabled": false,
     "cron_schedule": "0 */5 * * * *",
     "max_blocks_per_run": 50,
     "max_block_age": 2000,

--- a/examples/config/networks/base.json
+++ b/examples/config/networks/base.json
@@ -16,5 +16,14 @@
   "block_time_ms": 2000,
   "confirmation_blocks": 3,
   "cron_schedule": "0 */1 * * * *",
-  "store_blocks": false
+  "max_past_blocks": 100,
+  "store_blocks": false,
+  "recovery_config": {
+    "enabled": true,
+    "cron_schedule": "0 */5 * * * *",
+    "max_blocks_per_run": 50,
+    "max_block_age": 2000,
+    "max_retries": 3,
+    "retry_delay_ms": 1000
+  }
 }

--- a/examples/config/networks/ethereum_mainnet.json
+++ b/examples/config/networks/ethereum_mainnet.json
@@ -19,7 +19,7 @@
   "max_past_blocks": 54,
   "store_blocks": false,
   "recovery_config": {
-    "enabled": true,
+    "enabled": false,
     "cron_schedule": "0 */5 * * * *",
     "max_blocks_per_run": 10,
     "max_block_age": 1000,

--- a/examples/config/networks/ethereum_mainnet.json
+++ b/examples/config/networks/ethereum_mainnet.json
@@ -16,10 +16,10 @@
   "block_time_ms": 12000,
   "confirmation_blocks": 12,
   "cron_schedule": "0 */1 * * * *",
-  "max_past_blocks": 18,
+  "max_past_blocks": 54,
   "store_blocks": false,
   "recovery_config": {
-    "enabled": false,
+    "enabled": true,
     "cron_schedule": "0 */5 * * * *",
     "max_blocks_per_run": 10,
     "max_block_age": 1000,


### PR DESCRIPTION
## Summary

Without a `max_past_blocks` buffer larger than one cron interval, a monitor restart or scheduler delay causes `process_new_blocks` to skip unprocessed blocks — it falls back to `latest_confirmed - max_past_blocks` instead of `last_processed + 1`. The `recovery_config` only rescues gaps *within* the fetched range, so the window itself must be large enough to survive short downtime.

Changes:
- **ethereum_mainnet**: `max_past_blocks` 18 → 54 (3× formula), enable `recovery_config`
- **arbitrum_one**: add `max_past_blocks` 750 (3× formula), add `recovery_config`
- **base**: add `max_past_blocks` 100 (3× formula), add `recovery_config`

`max_past_blocks` is set to 3× the README formula value `(cron_interval_ms / block_time_ms) + confirmation_blocks + 1` to provide a buffer for restarts and scheduling delays without being excessively large.

`recovery_config` for Arbitrum uses higher `max_blocks_per_run` (100) and `max_block_age` (5000) to account for the higher block throughput at 250ms block time.

## Test plan

- [ ] Verify monitor starts cleanly against each network with updated config
- [ ] Restart the monitor mid-run and confirm no blocks are skipped in the logs
- [ ] Confirm `recovery_config` triggers after a simulated RPC failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network configurations for Arbitrum One, Base, and Ethereum Mainnet with new parameters for historical block retention and automated recovery handling. Added recovery scheduling options and retry mechanism configuration. Ethereum Mainnet's historical block support limit increased.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->