### PR TITLE
fix(examples): add recovery_config and max_past_blocks buffer to network examples

### DIFF
--- a/examples/config/networks/arbitrum_one.json
+++ b/examples/config/networks/arbitrum_one.json
@@ -16,5 +16,14 @@
   "block_time_ms": 250,
   "confirmation_blocks": 12,
   "cron_schedule": "0 */1 * * * *",
-  "store_blocks": false
+  "max_past_blocks": 750,
+  "store_blocks": false,
+  "recovery_config": {
+    "enabled": true,
+    "cron_schedule": "0 */5 * * * *",
+    "max_blocks_per_run": 100,
+    "max_block_age": 5000,
+    "max_retries": 3,
+    "retry_delay_ms": 1000
+  }
 }

--- a/examples/config/networks/arbitrum_one.json
+++ b/examples/config/networks/arbitrum_one.json
@@ -19,7 +19,7 @@
   "max_past_blocks": 750,
   "store_blocks": false,
   "recovery_config": {
-    "enabled": true,
+    "enabled": false,
     "cron_schedule": "0 */5 * * * *",
     "max_blocks_per_run": 100,
     "max_block_age": 5000,

--- a/examples/config/networks/base.json
+++ b/examples/config/networks/base.json
@@ -19,7 +19,7 @@
   "max_past_blocks": 100,
   "store_blocks": false,
   "recovery_config": {
-    "enabled": true,
+    "enabled": false,
     "cron_schedule": "0 */5 * * * *",
     "max_blocks_per_run": 50,
     "max_block_age": 2000,

--- a/examples/config/networks/base.json
+++ b/examples/config/networks/base.json
@@ -16,5 +16,14 @@
   "block_time_ms": 2000,
   "confirmation_blocks": 3,
   "cron_schedule": "0 */1 * * * *",
-  "store_blocks": false
+  "max_past_blocks": 100,
+  "store_blocks": false,
+  "recovery_config": {
+    "enabled": true,
+    "cron_schedule": "0 */5 * * * *",
+    "max_blocks_per_run": 50,
+    "max_block_age": 2000,
+    "max_retries": 3,
+    "retry_delay_ms": 1000
+  }
 }

--- a/examples/config/networks/ethereum_mainnet.json
+++ b/examples/config/networks/ethereum_mainnet.json
@@ -19,7 +19,7 @@
   "max_past_blocks": 54,
   "store_blocks": false,
   "recovery_config": {
-    "enabled": true,
+    "enabled": false,
     "cron_schedule": "0 */5 * * * *",
     "max_blocks_per_run": 10,
     "max_block_age": 1000,

--- a/examples/config/networks/ethereum_mainnet.json
+++ b/examples/config/networks/ethereum_mainnet.json
@@ -16,10 +16,10 @@
   "block_time_ms": 12000,
   "confirmation_blocks": 12,
   "cron_schedule": "0 */1 * * * *",
-  "max_past_blocks": 18,
+  "max_past_blocks": 54,
   "store_blocks": false,
   "recovery_config": {
-    "enabled": false,
+    "enabled": true,
     "cron_schedule": "0 */5 * * * *",
     "max_blocks_per_run": 10,
     "max_block_age": 1000,


### PR DESCRIPTION
Replaces closed PR #473.

## Summary

Without a `max_past_blocks` buffer larger than one cron interval, a monitor restart or scheduler delay can cause `process_new_blocks` to skip unprocessed blocks because it falls back to `latest_confirmed - max_past_blocks` instead of `last_processed + 1`. The recovery config only rescues gaps within the fetched range, so the window itself needs enough buffer for short downtime.

Changes:
- **ethereum_mainnet**: increase `max_past_blocks` from 18 to 54 and keep `recovery_config` disabled by default
- **arbitrum_one**: add `max_past_blocks` 750 and a disabled `recovery_config`
- **base**: add `max_past_blocks` 100 and a disabled `recovery_config`

The `recovery_config` examples are included but disabled by default so operators must explicitly opt in to the new recovery behavior.

## Test plan

- [ ] Verify monitor starts cleanly against each network with the updated config
- [ ] Restart the monitor mid-run and confirm no blocks are skipped in the logs
- [ ] Confirm `recovery_config` triggers after a simulated RPC failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable block history lookback limit to network configurations.
  * Introduced recovery configuration options including scheduling, retry policies, and block processing limits for improved resilience.

* **Updates**
  * Updated Ethereum Mainnet configuration block lookback parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->