### PR TITLE
feat: Rotate and track JSON-RPC error envelopes

### DIFF
--- a/src/services/blockchain/clients/mod.rs
+++ b/src/services/blockchain/clients/mod.rs
@@ -26,6 +26,6 @@ pub use midnight::client::{
 	MidnightClient, MidnightClientTrait, SubstrateClientTrait as MidnightSubstrateClientTrait,
 };
 pub use solana::client::{SignatureInfo, SolanaClient, SolanaClientTrait};
-pub use solana::error::SolanaClientError;
+pub use solana::error::{SolanaClientError, SLOT_UNAVAILABLE_ERROR_CODES};
 pub use stellar::client::{StellarClient, StellarClientTrait};
 pub use stellar::error::StellarClientError;

--- a/src/services/blockchain/clients/solana/error.rs
+++ b/src/services/blockchain/clients/solana/error.rs
@@ -226,14 +226,19 @@ pub mod error_codes {
 	pub const INTERNAL_ERROR: i64 = -32603;
 }
 
+/// JSON-RPC error codes that indicate the requested slot/block is unavailable rather
+/// than an endpoint being unhealthy. These represent legitimate Solana chain state and
+/// should be passed through to per-client handlers instead of triggering endpoint
+/// rotation.
+pub const SLOT_UNAVAILABLE_ERROR_CODES: &[i64] = &[
+	error_codes::BLOCK_NOT_AVAILABLE,
+	error_codes::SLOT_SKIPPED,
+	error_codes::LONG_TERM_STORAGE_SLOT_SKIPPED,
+];
+
 /// Checks if the given RPC error code indicates a skipped/unavailable slot
 pub fn is_slot_unavailable_error(code: i64) -> bool {
-	matches!(
-		code,
-		error_codes::BLOCK_NOT_AVAILABLE
-			| error_codes::SLOT_SKIPPED
-			| error_codes::LONG_TERM_STORAGE_SLOT_SKIPPED
-	)
+	SLOT_UNAVAILABLE_ERROR_CODES.contains(&code)
 }
 
 #[cfg(test)]

--- a/src/services/blockchain/transports/error.rs
+++ b/src/services/blockchain/transports/error.rs
@@ -32,6 +32,16 @@ pub enum TransportError {
 	/// URL rotation error
 	#[error("URL rotation failed: {0}")]
 	UrlRotation(ErrorContext),
+
+	/// JSON-RPC error envelope returned by upstream (HTTP 200 with `error` field, or
+	/// missing both `result` and `error`). Surfaced after rotation has been exhausted.
+	#[error("JSON-RPC error: code {code} for URL {url}: {message}")]
+	RpcError {
+		code: i64,
+		message: String,
+		url: String,
+		context: ErrorContext,
+	},
 }
 
 impl TransportError {
@@ -82,6 +92,25 @@ impl TransportError {
 	) -> Self {
 		Self::UrlRotation(ErrorContext::new_with_log(msg, source, metadata))
 	}
+
+	pub fn rpc_error(
+		code: i64,
+		message: impl Into<String>,
+		url: impl Into<String>,
+		source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+		metadata: Option<HashMap<String, String>>,
+	) -> Self {
+		let message = message.into();
+		let url = url.into();
+		let log_msg = format!("JSON-RPC error: code {} for URL {}: {}", code, url, message);
+
+		Self::RpcError {
+			code,
+			message,
+			url,
+			context: ErrorContext::new_with_log(log_msg, source, metadata),
+		}
+	}
 }
 
 impl TraceableError for TransportError {
@@ -92,6 +121,7 @@ impl TraceableError for TransportError {
 			Self::ResponseParse(ctx) => ctx.trace_id.clone(),
 			Self::RequestSerialization(ctx) => ctx.trace_id.clone(),
 			Self::UrlRotation(ctx) => ctx.trace_id.clone(),
+			Self::RpcError { context, .. } => context.trace_id.clone(),
 		}
 	}
 }
@@ -185,6 +215,32 @@ mod tests {
 			error.to_string(),
 			"URL rotation failed: test error [key1=value1]"
 		);
+	}
+
+	#[test]
+	fn test_rpc_error_formatting() {
+		let error = TransportError::rpc_error(
+			15,
+			"Too many request, try again later",
+			"http://example.com",
+			None,
+			None,
+		);
+		assert_eq!(
+			error.to_string(),
+			"JSON-RPC error: code 15 for URL http://example.com: Too many request, try again later"
+		);
+
+		let source_error = IoError::new(ErrorKind::NotFound, "test source");
+		let error = TransportError::rpc_error(
+			-32007,
+			"Slot was skipped",
+			"http://example.com",
+			Some(Box::new(source_error)),
+			Some(HashMap::from([("key1".to_string(), "value1".to_string())])),
+		);
+		// Trace ID is reachable via TraceableError impl
+		assert!(!error.trace_id().is_empty());
 	}
 
 	#[test]

--- a/src/services/blockchain/transports/error.rs
+++ b/src/services/blockchain/transports/error.rs
@@ -239,8 +239,10 @@ mod tests {
 			Some(Box::new(source_error)),
 			Some(HashMap::from([("key1".to_string(), "value1".to_string())])),
 		);
-		// Trace ID is reachable via TraceableError impl
-		assert!(!error.trace_id().is_empty());
+		assert_eq!(
+			error.to_string(),
+			"JSON-RPC error: code -32007 for URL http://example.com: Slot was skipped"
+		);
 	}
 
 	#[test]
@@ -303,6 +305,18 @@ mod tests {
 			status_code: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
 			url: "http://example.com".to_string(),
 			body: "Internal Server Error".to_string(),
+			context: error_context,
+		};
+		assert_eq!(transport_error.trace_id(), original_trace_id);
+
+		// RpcError must propagate its inner context's trace_id, not generate a fresh one.
+		let error_context = ErrorContext::new("Slot was skipped", None, None);
+		let original_trace_id = error_context.trace_id.clone();
+
+		let transport_error = TransportError::RpcError {
+			code: -32007,
+			message: "Slot was skipped".to_string(),
+			url: "http://example.com".to_string(),
 			context: error_context,
 		};
 		assert_eq!(transport_error.trace_id(), original_trace_id);

--- a/src/services/blockchain/transports/evm/http.rs
+++ b/src/services/blockchain/transports/evm/http.rs
@@ -38,7 +38,7 @@ impl EVMTransportClient {
 	pub async fn new(network: &Network) -> Result<Self, anyhow::Error> {
 		let test_connection_payload =
 			Some(r#"{"id":1,"jsonrpc":"2.0","method":"net_version","params":[]}"#.to_string());
-		let http_client = HttpTransportClient::new(network, test_connection_payload).await?;
+		let http_client = HttpTransportClient::new(network, test_connection_payload, &[]).await?;
 		Ok(Self { http_client })
 	}
 }

--- a/src/services/blockchain/transports/http/endpoint_manager.rs
+++ b/src/services/blockchain/transports/http/endpoint_manager.rs
@@ -25,6 +25,8 @@ use crate::services::blockchain::transports::{
 /// * `client` - The client to use for the endpoint manager
 /// * `rotation_lock` - A lock for managing the rotation process
 /// * `network_slug` - The network identifier for metrics labeling
+/// * `non_rotating_jsonrpc_codes` - JSON-RPC error codes that should not trigger endpoint
+///   rotation (e.g. Solana skipped-slot codes that represent legitimate chain state).
 #[derive(Clone, Debug)]
 pub struct EndpointManager {
 	pub active_url: Arc<RwLock<String>>,
@@ -32,6 +34,7 @@ pub struct EndpointManager {
 	client: ClientWithMiddleware,
 	rotation_lock: Arc<tokio::sync::Mutex<()>>,
 	network_slug: String,
+	non_rotating_jsonrpc_codes: &'static [i64],
 }
 
 /// Represents the outcome of a `EndpointManager::attempt_request_on_url` method call
@@ -55,6 +58,9 @@ impl EndpointManager {
 	/// * `active_url` - The initial active URL
 	/// * `fallback_urls` - A list of fallback URLs to rotate to
 	/// * `network_slug` - The network identifier for metrics labeling
+	/// * `non_rotating_jsonrpc_codes` - JSON-RPC error codes for which the manager should
+	///   pass the response through unchanged instead of rotating to a fallback. Use `&[]`
+	///   if every JSON-RPC error should rotate.
 	///
 	/// # Returns
 	pub fn new(
@@ -62,6 +68,7 @@ impl EndpointManager {
 		active_url: &str,
 		fallback_urls: Vec<String>,
 		network_slug: String,
+		non_rotating_jsonrpc_codes: &'static [i64],
 	) -> Self {
 		Self {
 			active_url: Arc::new(RwLock::new(active_url.to_string())),
@@ -69,6 +76,7 @@ impl EndpointManager {
 			rotation_lock: Arc::new(tokio::sync::Mutex::new(())),
 			client,
 			network_slug,
+			non_rotating_jsonrpc_codes,
 		}
 	}
 
@@ -290,14 +298,114 @@ impl EndpointManager {
 						let duration = attempt_start.elapsed().as_secs_f64();
 						crate::utils::metrics::observe_rpc_duration(&self.network_slug, duration);
 
-						// Successful response, parse JSON
-						return response.json().await.map_err(|e| {
-							TransportError::response_parse(
-								"Failed to parse JSON response".to_string(),
-								Some(Box::new(e)),
-								None,
-							)
-						});
+						// Parse JSON body
+						let value: Value = match response.json().await {
+							Ok(v) => v,
+							Err(e) => {
+								return Err(TransportError::response_parse(
+									"Failed to parse JSON response".to_string(),
+									Some(Box::new(e)),
+									None,
+								));
+							}
+						};
+
+						// Inspect the JSON-RPC envelope: a well-formed response has either a
+						// `result` field (success, possibly null) or an `error` field.
+						match (value.get("result"), value.get("error")) {
+							(Some(result), _) => {
+								if result.is_null() {
+									crate::utils::metrics::record_null_result(
+										&self.network_slug,
+										method,
+									);
+								}
+								return Ok(value);
+							}
+							(None, Some(error_obj)) => {
+								let code =
+									error_obj.get("code").and_then(|c| c.as_i64()).unwrap_or(0);
+								let message = error_obj
+									.get("message")
+									.and_then(|m| m.as_str())
+									.unwrap_or("")
+									.to_string();
+
+								if self.non_rotating_jsonrpc_codes.contains(&code) {
+									// Legitimate chain-state response — record for visibility
+									// but pass it through so the per-client error handler runs.
+									crate::utils::metrics::record_rpc_error(
+										&self.network_slug,
+										&code.to_string(),
+										"jsonrpc_passthrough",
+									);
+									return Ok(value);
+								}
+
+								crate::utils::metrics::record_rpc_error(
+									&self.network_slug,
+									&code.to_string(),
+									"jsonrpc",
+								);
+
+								tracing::warn!(
+									"JSON-RPC error from {}: code {} - {}",
+									current_url_snapshot,
+									code,
+									message,
+								);
+
+								crate::utils::metrics::record_endpoint_rotation(
+									&self.network_slug,
+									"jsonrpc_error",
+								);
+
+								match self.try_rotate_url(transport).await {
+									Ok(_new_url) => continue, // Retry on the new active URL
+									Err(rotation_error) => {
+										return Err(TransportError::rpc_error(
+											code,
+											message,
+											current_url_snapshot.clone(),
+											Some(Box::new(rotation_error)),
+											None,
+										));
+									}
+								}
+							}
+							(None, None) => {
+								// Malformed envelope — no `result` and no `error`. Treat as a
+								// rotatable failure, since the upstream is misbehaving.
+								crate::utils::metrics::record_rpc_error(
+									&self.network_slug,
+									"malformed",
+									"jsonrpc",
+								);
+
+								tracing::warn!(
+									"Malformed JSON-RPC envelope from {} (neither 'result' nor 'error' field)",
+									current_url_snapshot,
+								);
+
+								crate::utils::metrics::record_endpoint_rotation(
+									&self.network_slug,
+									"jsonrpc_error",
+								);
+
+								match self.try_rotate_url(transport).await {
+									Ok(_new_url) => continue,
+									Err(rotation_error) => {
+										return Err(TransportError::rpc_error(
+											0,
+											"Malformed JSON-RPC envelope",
+											current_url_snapshot.clone(),
+											Some(Box::new(rotation_error)),
+											None,
+										));
+									}
+								}
+							}
+						}
 					} else {
 						// HTTP error
 						let error_body = response.text().await.unwrap_or_default();

--- a/src/services/blockchain/transports/http/endpoint_manager.rs
+++ b/src/services/blockchain/transports/http/endpoint_manager.rs
@@ -5,6 +5,7 @@
 use reqwest_middleware::ClientWithMiddleware;
 use serde::Serialize;
 use serde_json::Value;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::RwLock;
@@ -271,6 +272,18 @@ impl EndpointManager {
 		method: &str,
 		params: Option<P>,
 	) -> Result<Value, TransportError> {
+		// Cap rotations per request: count distinct configured endpoints (active + unique
+		// fallbacks) so we can stop once each has been tried once.
+		let total_unique_endpoints = {
+			let mut endpoints: HashSet<String> = HashSet::new();
+			endpoints.insert(self.active_url.read().await.clone());
+			for url in self.fallback_urls.read().await.iter() {
+				endpoints.insert(url.clone());
+			}
+			endpoints.len()
+		};
+		let mut tried_urls: HashSet<String> = HashSet::new();
+
 		loop {
 			let attempt_start = Instant::now();
 
@@ -282,6 +295,7 @@ impl EndpointManager {
 				.ok()
 				.and_then(|u| u.host_str().map(|s| s.to_string()))
 				.unwrap_or_else(|| "unknown-host".into());
+			tried_urls.insert(current_url_snapshot.clone());
 
 			tracing::debug!(
 				"Attempting request on active URL: '{}'",
@@ -359,6 +373,18 @@ impl EndpointManager {
 									message,
 								);
 
+								// Stop once every distinct endpoint has been tried; otherwise
+								// healthy-but-erroring endpoints would cycle forever.
+								if tried_urls.len() >= total_unique_endpoints {
+									return Err(TransportError::rpc_error(
+										code,
+										message,
+										current_url_snapshot.clone(),
+										None,
+										None,
+									));
+								}
+
 								crate::utils::metrics::record_endpoint_rotation(
 									&self.network_slug,
 									"jsonrpc_error",
@@ -390,6 +416,16 @@ impl EndpointManager {
 									"Malformed JSON-RPC envelope from {} (neither 'result' nor 'error' field)",
 									current_host_snapshot,
 								);
+
+								if tried_urls.len() >= total_unique_endpoints {
+									return Err(TransportError::rpc_error(
+										0,
+										"Malformed JSON-RPC envelope",
+										current_url_snapshot.clone(),
+										None,
+										None,
+									));
+								}
 
 								crate::utils::metrics::record_endpoint_rotation(
 									&self.network_slug,

--- a/src/services/blockchain/transports/http/endpoint_manager.rs
+++ b/src/services/blockchain/transports/http/endpoint_manager.rs
@@ -352,10 +352,11 @@ impl EndpointManager {
 								if self.non_rotating_jsonrpc_codes.contains(&code) {
 									// Legitimate chain-state response — record for visibility
 									// but pass it through so the per-client error handler runs.
-									crate::utils::metrics::record_rpc_error(
+									// Tracked under a dedicated counter (not the errors counter)
+									// so it doesn't inflate error-rate alerts.
+									crate::utils::metrics::record_jsonrpc_passthrough(
 										&self.network_slug,
 										&code.to_string(),
-										"jsonrpc_passthrough",
 									);
 									return Ok(value);
 								}

--- a/src/services/blockchain/transports/http/endpoint_manager.rs
+++ b/src/services/blockchain/transports/http/endpoint_manager.rs
@@ -278,6 +278,10 @@ impl EndpointManager {
 			crate::utils::metrics::record_rpc_request(&self.network_slug, method);
 
 			let current_url_snapshot = self.active_url.read().await.clone();
+			let current_host_snapshot = Url::parse(&current_url_snapshot)
+				.ok()
+				.and_then(|u| u.host_str().map(|s| s.to_string()))
+				.unwrap_or_else(|| "unknown-host".into());
 
 			tracing::debug!(
 				"Attempting request on active URL: '{}'",
@@ -350,7 +354,7 @@ impl EndpointManager {
 
 								tracing::warn!(
 									"JSON-RPC error from {}: code {} - {}",
-									current_url_snapshot,
+									current_host_snapshot,
 									code,
 									message,
 								);
@@ -384,7 +388,7 @@ impl EndpointManager {
 
 								tracing::warn!(
 									"Malformed JSON-RPC envelope from {} (neither 'result' nor 'error' field)",
-									current_url_snapshot,
+									current_host_snapshot,
 								);
 
 								crate::utils::metrics::record_endpoint_rotation(
@@ -420,7 +424,7 @@ impl EndpointManager {
 
 						tracing::warn!(
 							"Request to {} failed with status {}: {}",
-							current_url_snapshot,
+							current_host_snapshot,
 							status,
 							error_body
 						);
@@ -477,7 +481,7 @@ impl EndpointManager {
 							tracing::warn!(
 								"HTTP error status {} on {} does not trigger rotation. Failing.",
 								status,
-								current_url_snapshot
+								current_host_snapshot
 							);
 							return Err(TransportError::http(
 								status,
@@ -496,7 +500,7 @@ impl EndpointManager {
 
 					tracing::warn!(
 						"Network error for {}: {}",
-						current_url_snapshot,
+						current_host_snapshot,
 						network_error,
 					);
 

--- a/src/services/blockchain/transports/http/endpoint_manager.rs
+++ b/src/services/blockchain/transports/http/endpoint_manager.rs
@@ -407,10 +407,13 @@ impl EndpointManager {
 							(None, None) => {
 								// Malformed envelope — no `result` and no `error`. Treat as a
 								// rotatable failure, since the upstream is misbehaving.
+								// `status_code="0"` keeps the slot numeric for PromQL filters
+								// (e.g. `status_code=~"5.."`); the malformed case is carried on
+								// `error_type` instead.
 								crate::utils::metrics::record_rpc_error(
 									&self.network_slug,
-									"malformed",
-									"jsonrpc",
+									"0",
+									"malformed_jsonrpc",
 								);
 
 								tracing::warn!(

--- a/src/services/blockchain/transports/http/transport.rs
+++ b/src/services/blockchain/transports/http/transport.rs
@@ -134,7 +134,10 @@ impl HttpTransportClient {
 					let network_slug = network.slug.clone();
 
 					// Initialize RPC metrics for this network so they appear in Prometheus
-					crate::utils::metrics::init_rpc_metrics_for_network(&network_slug);
+					crate::utils::metrics::init_rpc_metrics_for_network(
+						&network_slug,
+						non_rotating_jsonrpc_codes,
+					);
 
 					// Successfully connected - create and return the client
 					return Ok(Self {

--- a/src/services/blockchain/transports/http/transport.rs
+++ b/src/services/blockchain/transports/http/transport.rs
@@ -54,12 +54,16 @@ impl HttpTransportClient {
 	/// # Arguments
 	/// * `network` - Network configuration containing RPC URLs, weights, and other details
 	/// * `test_connection_payload` - Optional JSON RPC payload to test the connection (default is net_version)
+	/// * `non_rotating_jsonrpc_codes` - JSON-RPC error codes for which the endpoint manager
+	///   should pass responses through instead of rotating endpoints. See
+	///   [`EndpointManager::new`] for details.
 	///
 	/// # Returns
 	/// * `Result<Self, anyhow::Error>` - New client instance or connection error
 	pub async fn new(
 		network: &Network,
 		test_connection_payload: Option<String>,
+		non_rotating_jsonrpc_codes: &'static [i64],
 	) -> Result<Self, anyhow::Error> {
 		let mut rpc_urls: Vec<_> = network
 			.rpc_urls
@@ -140,6 +144,7 @@ impl HttpTransportClient {
 							rpc_url.url.as_ref(),
 							fallback_urls,
 							network_slug,
+							non_rotating_jsonrpc_codes,
 						),
 						test_connection_payload,
 					});

--- a/src/services/blockchain/transports/mod.rs
+++ b/src/services/blockchain/transports/mod.rs
@@ -56,6 +56,8 @@ use serde::Serialize;
 use serde_json::{json, Value};
 
 /// HTTP status codes that trigger RPC endpoint rotation
+/// - 400: Bad Request - some providers return 400 for transient/operational issues
+///   (e.g. malformed proxy responses) rather than 5xx, so rotation is worth attempting
 /// - 408: Request Timeout - the endpoint timed out processing the request
 /// - 410: Gone - the endpoint is no longer available
 /// - 429: Too Many Requests - indicates rate limiting from the current endpoint
@@ -63,7 +65,7 @@ use serde_json::{json, Value};
 /// - 502: Bad Gateway - the upstream RPC node behind a proxy is down
 /// - 503: Service Unavailable - the endpoint is overloaded or in maintenance
 /// - 504: Gateway Timeout - the upstream RPC node is unresponsive
-pub const ROTATE_ON_ERROR_CODES: [u16; 7] = [408, 410, 429, 500, 502, 503, 504];
+pub const ROTATE_ON_ERROR_CODES: [u16; 8] = [400, 408, 410, 429, 500, 502, 503, 504];
 
 /// Base trait for all blockchain transport clients
 #[async_trait::async_trait]

--- a/src/services/blockchain/transports/solana/http.rs
+++ b/src/services/blockchain/transports/solana/http.rs
@@ -164,6 +164,15 @@ impl Commitment {
 	}
 }
 
+/// JSON-RPC error codes that represent legitimate Solana chain state (not endpoint
+/// failure). The HTTP endpoint manager passes responses through instead of rotating.
+/// Mirrors `clients::solana::error::is_slot_unavailable_error`.
+const SOLANA_NON_ROTATING_JSONRPC_CODES: &[i64] = &[
+	-32004, // BLOCK_NOT_AVAILABLE
+	-32007, // SLOT_SKIPPED
+	-32009, // LONG_TERM_STORAGE_SLOT_SKIPPED
+];
+
 /// A client for interacting with Solana blockchain nodes
 ///
 /// This implementation wraps the HttpTransportClient to provide consistent
@@ -188,7 +197,12 @@ impl SolanaTransportClient {
 		// Use getHealth as the test connection method - it's lightweight and indicates node health
 		let test_connection_payload =
 			Some(r#"{"id":1,"jsonrpc":"2.0","method":"getHealth"}"#.to_string());
-		let http_client = HttpTransportClient::new(network, test_connection_payload).await?;
+		let http_client = HttpTransportClient::new(
+			network,
+			test_connection_payload,
+			SOLANA_NON_ROTATING_JSONRPC_CODES,
+		)
+		.await?;
 		Ok(Self { http_client })
 	}
 
@@ -204,7 +218,9 @@ impl SolanaTransportClient {
 		network: &Network,
 		test_payload: Option<String>,
 	) -> Result<Self, anyhow::Error> {
-		let http_client = HttpTransportClient::new(network, test_payload).await?;
+		let http_client =
+			HttpTransportClient::new(network, test_payload, SOLANA_NON_ROTATING_JSONRPC_CODES)
+				.await?;
 		Ok(Self { http_client })
 	}
 

--- a/src/services/blockchain/transports/solana/http.rs
+++ b/src/services/blockchain/transports/solana/http.rs
@@ -10,8 +10,9 @@ use serde_json::{json, Value};
 
 use crate::{
 	models::Network,
-	services::blockchain::transports::{
-		BlockchainTransport, HttpTransportClient, RotatingTransport, TransportError,
+	services::blockchain::{
+		clients::SLOT_UNAVAILABLE_ERROR_CODES,
+		transports::{BlockchainTransport, HttpTransportClient, RotatingTransport, TransportError},
 	},
 };
 
@@ -164,15 +165,6 @@ impl Commitment {
 	}
 }
 
-/// JSON-RPC error codes that represent legitimate Solana chain state (not endpoint
-/// failure). The HTTP endpoint manager passes responses through instead of rotating.
-/// Mirrors `clients::solana::error::is_slot_unavailable_error`.
-const SOLANA_NON_ROTATING_JSONRPC_CODES: &[i64] = &[
-	-32004, // BLOCK_NOT_AVAILABLE
-	-32007, // SLOT_SKIPPED
-	-32009, // LONG_TERM_STORAGE_SLOT_SKIPPED
-];
-
 /// A client for interacting with Solana blockchain nodes
 ///
 /// This implementation wraps the HttpTransportClient to provide consistent
@@ -200,7 +192,7 @@ impl SolanaTransportClient {
 		let http_client = HttpTransportClient::new(
 			network,
 			test_connection_payload,
-			SOLANA_NON_ROTATING_JSONRPC_CODES,
+			SLOT_UNAVAILABLE_ERROR_CODES,
 		)
 		.await?;
 		Ok(Self { http_client })
@@ -219,8 +211,7 @@ impl SolanaTransportClient {
 		test_payload: Option<String>,
 	) -> Result<Self, anyhow::Error> {
 		let http_client =
-			HttpTransportClient::new(network, test_payload, SOLANA_NON_ROTATING_JSONRPC_CODES)
-				.await?;
+			HttpTransportClient::new(network, test_payload, SLOT_UNAVAILABLE_ERROR_CODES).await?;
 		Ok(Self { http_client })
 	}
 

--- a/src/services/blockchain/transports/stellar/http.rs
+++ b/src/services/blockchain/transports/stellar/http.rs
@@ -38,7 +38,7 @@ impl StellarTransportClient {
 	pub async fn new(network: &Network) -> Result<Self, anyhow::Error> {
 		let test_connection_payload =
 			Some(r#"{"id":1,"jsonrpc":"2.0","method":"getNetwork","params":[]}"#.to_string());
-		let http_client = HttpTransportClient::new(network, test_connection_payload).await?;
+		let http_client = HttpTransportClient::new(network, test_connection_payload, &[]).await?;
 		Ok(Self { http_client })
 	}
 }

--- a/src/utils/metrics/README.md
+++ b/src/utils/metrics/README.md
@@ -52,6 +52,10 @@ The metrics system provides monitoring capabilities for the OpenZeppelin Monitor
 | `rpc_request_duration_seconds` | Histogram | network | Request latency distribution |
 | `rpc_endpoint_rotations_total` | Counter | network, reason | Endpoint rotations |
 | `rpc_rate_limits_total` | Counter | network, endpoint | HTTP 429 responses |
+| `rpc_null_results_total` | Counter | network, method | JSON-RPC responses where `result` was null (e.g. unknown block/tx) |
+| `rpc_jsonrpc_passthrough_total` | Counter | network, code | JSON-RPC error envelopes representing legitimate chain state (e.g. Solana skipped slots), passed through to the caller without rotating |
+
+> Note: `rpc_jsonrpc_passthrough_total` is intentionally separate from `rpc_request_errors_total`. Solana mainnet skips slots routinely, so counting those responses as errors would inflate any alert built on the error counter.
 
 ## Example Grafana Alerts
 

--- a/src/utils/metrics/mod.rs
+++ b/src/utils/metrics/mod.rs
@@ -215,6 +215,23 @@ lazy_static! {
 		REGISTRY.register(Box::new(counter.clone())).unwrap();
 		counter
 	};
+
+	/// Counter for JSON-RPC error envelopes that represent legitimate chain state
+	/// rather than endpoint failures (e.g. Solana skipped-slot codes).
+	///
+	/// Tracked separately from `rpc_request_errors_total` so that error-rate alerts
+	/// are not inflated by normal chain behaviour.
+	pub static ref RPC_JSONRPC_PASSTHROUGH_TOTAL: CounterVec = {
+		let counter = CounterVec::new(
+			Opts::new(
+				"rpc_jsonrpc_passthrough_total",
+				"Total number of JSON-RPC error envelopes passed through as legitimate chain state (not endpoint failures)",
+			),
+			&["network", "code"]
+		).unwrap();
+		REGISTRY.register(Box::new(counter.clone())).unwrap();
+		counter
+	};
 }
 
 /// Gather all metrics and encode into the provided format.
@@ -411,6 +428,21 @@ pub fn record_null_result(network: &str, method: &str) {
 		.inc();
 }
 
+/// Records a JSON-RPC error envelope that represents legitimate chain state and
+/// is passed through to the caller (e.g. a Solana skipped-slot response).
+///
+/// These responses are tracked separately from `rpc_request_errors_total` so
+/// that error-rate alerts are not inflated by normal chain behaviour.
+///
+/// # Arguments
+/// * `network` - The network slug
+/// * `code` - The JSON-RPC error code (as a string)
+pub fn record_jsonrpc_passthrough(network: &str, code: &str) {
+	RPC_JSONRPC_PASSTHROUGH_TOTAL
+		.with_label_values(&[network, code])
+		.inc();
+}
+
 /// Initializes RPC metrics for a network so they appear in Prometheus output with 0 values.
 ///
 /// This should be called when a transport client is created for a network.
@@ -418,7 +450,9 @@ pub fn record_null_result(network: &str, method: &str) {
 ///
 /// # Arguments
 /// * `network` - The network slug
-pub fn init_rpc_metrics_for_network(network: &str) {
+/// * `passthrough_codes` - JSON-RPC error codes that the transport treats as legitimate
+///   chain state. Each is seeded into `rpc_jsonrpc_passthrough_total`.
+pub fn init_rpc_metrics_for_network(network: &str, passthrough_codes: &[i64]) {
 	// Initialize error counters with common status codes
 	// These will show as 0 until actual errors occur
 	RPC_REQUEST_ERRORS_TOTAL
@@ -434,11 +468,15 @@ pub fn init_rpc_metrics_for_network(network: &str) {
 		.with_label_values(&[network, "0", "jsonrpc"])
 		.inc_by(0.0);
 	RPC_REQUEST_ERRORS_TOTAL
-		.with_label_values(&[network, "0", "jsonrpc_passthrough"])
-		.inc_by(0.0);
-	RPC_REQUEST_ERRORS_TOTAL
 		.with_label_values(&[network, "malformed", "jsonrpc"])
 		.inc_by(0.0);
+
+	// Initialize passthrough counters for the transport's skip-listed codes.
+	for code in passthrough_codes {
+		RPC_JSONRPC_PASSTHROUGH_TOTAL
+			.with_label_values(&[network, &code.to_string()])
+			.inc_by(0.0);
+	}
 
 	// Initialize rotation counters
 	RPC_ENDPOINT_ROTATIONS_TOTAL
@@ -495,6 +533,7 @@ mod tests {
 		RPC_ENDPOINT_ROTATIONS_TOTAL.reset();
 		RPC_RATE_LIMITS_TOTAL.reset();
 		RPC_NULL_RESULTS_TOTAL.reset();
+		RPC_JSONRPC_PASSTHROUGH_TOTAL.reset();
 	}
 
 	// Helper function to create a test network
@@ -580,6 +619,9 @@ mod tests {
 		RPC_RATE_LIMITS_TOTAL
 			.with_label_values(&["ethereum", "https://rpc.example.com"])
 			.inc();
+		RPC_JSONRPC_PASSTHROUGH_TOTAL
+			.with_label_values(&["solana", "-32007"])
+			.inc();
 
 		let metrics = gather_metrics().expect("failed to gather metrics");
 		let output = String::from_utf8(metrics).expect("metrics output is not valid UTF-8");
@@ -607,6 +649,7 @@ mod tests {
 		assert!(output.contains("rpc_request_duration_seconds"));
 		assert!(output.contains("rpc_endpoint_rotations_total"));
 		assert!(output.contains("rpc_rate_limits_total"));
+		assert!(output.contains("rpc_jsonrpc_passthrough_total"));
 	}
 
 	#[test]
@@ -966,6 +1009,20 @@ mod tests {
 		record_rpc_error("ethereum", "500", "http");
 		record_rpc_error("ethereum", "0", "network");
 
+		// Test record_jsonrpc_passthrough — must not affect rpc_request_errors_total.
+		record_jsonrpc_passthrough("solana", "-32007");
+		record_jsonrpc_passthrough("solana", "-32007");
+		record_jsonrpc_passthrough("solana", "-32004");
+
+		let passthrough_32007 = RPC_JSONRPC_PASSTHROUGH_TOTAL
+			.get_metric_with_label_values(&["solana", "-32007"])
+			.unwrap();
+		assert_eq!(passthrough_32007.get(), 2.0);
+		let passthrough_32004 = RPC_JSONRPC_PASSTHROUGH_TOTAL
+			.get_metric_with_label_values(&["solana", "-32004"])
+			.unwrap();
+		assert_eq!(passthrough_32004.get(), 1.0);
+
 		let rate_limit_errors = RPC_REQUEST_ERRORS_TOTAL
 			.get_metric_with_label_values(&["ethereum", "429", "http"])
 			.unwrap();
@@ -1026,8 +1083,8 @@ mod tests {
 		let _lock = TEST_MUTEX.lock().unwrap();
 		reset_all_metrics();
 
-		// Initialize metrics for a new network
-		init_rpc_metrics_for_network("arbitrum");
+		// Initialize metrics for a new network with a couple of passthrough codes
+		init_rpc_metrics_for_network("arbitrum", &[-32007, -32004]);
 
 		// Verify error counters are initialized with 0
 		let http_429 = RPC_REQUEST_ERRORS_TOTAL
@@ -1044,6 +1101,36 @@ mod tests {
 			.get_metric_with_label_values(&["arbitrum", "0", "network"])
 			.unwrap();
 		assert_eq!(network_error.get(), 0.0);
+
+		// Passthroughs must NOT be seeded under the errors counter — they belong on
+		// the dedicated passthrough counter so error-rate alerts stay clean.
+		let mut passthrough_label_present = false;
+		for family in REGISTRY.gather() {
+			if family.name() != "rpc_request_errors_total" {
+				continue;
+			}
+			for metric in family.get_metric() {
+				for label in metric.get_label() {
+					if label.name() == "error_type" && label.value() == "jsonrpc_passthrough" {
+						passthrough_label_present = true;
+					}
+				}
+			}
+		}
+		assert!(
+			!passthrough_label_present,
+			"passthroughs must not appear on rpc_request_errors_total"
+		);
+
+		// Passthrough counters are seeded for each provided code.
+		let passthrough_32007 = RPC_JSONRPC_PASSTHROUGH_TOTAL
+			.get_metric_with_label_values(&["arbitrum", "-32007"])
+			.unwrap();
+		assert_eq!(passthrough_32007.get(), 0.0);
+		let passthrough_32004 = RPC_JSONRPC_PASSTHROUGH_TOTAL
+			.get_metric_with_label_values(&["arbitrum", "-32004"])
+			.unwrap();
+		assert_eq!(passthrough_32004.get(), 0.0);
 
 		// Verify rotation counters are initialized with 0
 		let rate_limit_rotation = RPC_ENDPOINT_ROTATIONS_TOTAL

--- a/src/utils/metrics/mod.rs
+++ b/src/utils/metrics/mod.rs
@@ -201,6 +201,20 @@ lazy_static! {
 		REGISTRY.register(Box::new(counter.clone())).unwrap();
 		counter
 	};
+
+	/// Counter for RPC responses where the JSON-RPC `result` field is null.
+	///
+	/// `result: null` is a legitimate answer for some methods (e.g. `eth_getBlockByNumber`
+	/// for a future block, `eth_getTransactionReceipt` for an unknown hash). Tracking it
+	/// gives visibility on how often "not found" responses occur per network and method.
+	pub static ref RPC_NULL_RESULTS_TOTAL: CounterVec = {
+		let counter = CounterVec::new(
+			Opts::new("rpc_null_results_total", "Total number of JSON-RPC responses where result was null"),
+			&["network", "method"]
+		).unwrap();
+		REGISTRY.register(Box::new(counter.clone())).unwrap();
+		counter
+	};
 }
 
 /// Gather all metrics and encode into the provided format.
@@ -386,6 +400,17 @@ pub fn record_rate_limit(network: &str, endpoint: &str) {
 		.inc();
 }
 
+/// Records a JSON-RPC response where the `result` field was null.
+///
+/// # Arguments
+/// * `network` - The network slug
+/// * `method` - The JSON-RPC method that returned the null result
+pub fn record_null_result(network: &str, method: &str) {
+	RPC_NULL_RESULTS_TOTAL
+		.with_label_values(&[network, method])
+		.inc();
+}
+
 /// Initializes RPC metrics for a network so they appear in Prometheus output with 0 values.
 ///
 /// This should be called when a transport client is created for a network.
@@ -405,6 +430,15 @@ pub fn init_rpc_metrics_for_network(network: &str) {
 	RPC_REQUEST_ERRORS_TOTAL
 		.with_label_values(&[network, "0", "network"])
 		.inc_by(0.0);
+	RPC_REQUEST_ERRORS_TOTAL
+		.with_label_values(&[network, "0", "jsonrpc"])
+		.inc_by(0.0);
+	RPC_REQUEST_ERRORS_TOTAL
+		.with_label_values(&[network, "0", "jsonrpc_passthrough"])
+		.inc_by(0.0);
+	RPC_REQUEST_ERRORS_TOTAL
+		.with_label_values(&[network, "malformed", "jsonrpc"])
+		.inc_by(0.0);
 
 	// Initialize rotation counters
 	RPC_ENDPOINT_ROTATIONS_TOTAL
@@ -412,6 +446,9 @@ pub fn init_rpc_metrics_for_network(network: &str) {
 		.inc_by(0.0);
 	RPC_ENDPOINT_ROTATIONS_TOTAL
 		.with_label_values(&[network, "network_error"])
+		.inc_by(0.0);
+	RPC_ENDPOINT_ROTATIONS_TOTAL
+		.with_label_values(&[network, "jsonrpc_error"])
 		.inc_by(0.0);
 }
 
@@ -457,6 +494,7 @@ mod tests {
 		RPC_REQUEST_DURATION_SECONDS.reset();
 		RPC_ENDPOINT_ROTATIONS_TOTAL.reset();
 		RPC_RATE_LIMITS_TOTAL.reset();
+		RPC_NULL_RESULTS_TOTAL.reset();
 	}
 
 	// Helper function to create a test network

--- a/src/utils/metrics/mod.rs
+++ b/src/utils/metrics/mod.rs
@@ -468,7 +468,7 @@ pub fn init_rpc_metrics_for_network(network: &str, passthrough_codes: &[i64]) {
 		.with_label_values(&[network, "0", "jsonrpc"])
 		.inc_by(0.0);
 	RPC_REQUEST_ERRORS_TOTAL
-		.with_label_values(&[network, "malformed", "jsonrpc"])
+		.with_label_values(&[network, "0", "malformed_jsonrpc"])
 		.inc_by(0.0);
 
 	// Initialize passthrough counters for the transport's skip-listed codes.

--- a/src/utils/metrics/mod.rs
+++ b/src/utils/metrics/mod.rs
@@ -622,6 +622,9 @@ mod tests {
 		RPC_JSONRPC_PASSTHROUGH_TOTAL
 			.with_label_values(&["solana", "-32007"])
 			.inc();
+		RPC_NULL_RESULTS_TOTAL
+			.with_label_values(&["ethereum", "eth_getBlockByNumber"])
+			.inc();
 
 		let metrics = gather_metrics().expect("failed to gather metrics");
 		let output = String::from_utf8(metrics).expect("metrics output is not valid UTF-8");
@@ -650,6 +653,7 @@ mod tests {
 		assert!(output.contains("rpc_endpoint_rotations_total"));
 		assert!(output.contains("rpc_rate_limits_total"));
 		assert!(output.contains("rpc_jsonrpc_passthrough_total"));
+		assert!(output.contains("rpc_null_results_total"));
 	}
 
 	#[test]

--- a/tests/integration/blockchain/transports/http/endpoint_manager.rs
+++ b/tests/integration/blockchain/transports/http/endpoint_manager.rs
@@ -36,6 +36,7 @@ async fn test_endpoint_rotation() {
 		server1.url().as_ref(),
 		vec![server2.url(), server3.url()],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -72,6 +73,7 @@ async fn test_send_raw_request() {
 		server.url().as_ref(),
 		vec![],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -112,6 +114,7 @@ async fn test_rotation_on_error() {
 		primary_server.url().as_ref(),
 		vec![fallback_server.url()],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -145,6 +148,7 @@ async fn test_no_fallback_urls_available() {
 		server.url().as_ref(),
 		vec![],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -215,6 +219,7 @@ async fn test_rotate_url_no_fallbacks() {
 		server.url().as_ref(),
 		vec![],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -246,6 +251,7 @@ async fn test_rotate_url_all_urls_match_active() {
 		active_url.as_ref(),
 		vec![active_url.clone(), active_url.clone()],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -284,6 +290,7 @@ async fn test_rotate_url_connection_failure() {
 		server.url().as_ref(),
 		vec![invalid_url.to_string()],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -321,6 +328,7 @@ async fn test_rotate_url_update_client_failure() {
 		server1.url().as_ref(),
 		vec![server2.url()],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = AlwaysFailsToUpdateClientTransport {
 		current_url: Arc::new(RwLock::new(server1.url())),
@@ -351,6 +359,7 @@ async fn test_rotate_url_all_urls_fail_returns_url_rotation_error() {
 		invalid_url1,
 		vec![invalid_url2.to_string()],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -382,6 +391,7 @@ async fn test_update_client() {
 		server.url().as_ref(),
 		vec![],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 
 	// Test initial client
@@ -441,6 +451,7 @@ async fn test_send_raw_request_network_error() {
 		invalid_url,
 		vec![valid_server.url()], // Add valid fallback URL
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -468,6 +479,7 @@ async fn test_send_raw_request_network_error_no_fallback() {
 		invalid_url,
 		vec![], // No fallback URLs
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -502,6 +514,7 @@ async fn test_send_raw_request_response_parse_error() {
 		server.url().as_ref(),
 		vec![],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -530,6 +543,7 @@ async fn test_send_raw_request_all_urls_fail_returns_network_error() {
 		invalid_url1,
 		vec![invalid_url2.to_string(), invalid_url3.to_string()],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -545,11 +559,11 @@ async fn test_send_raw_request_all_urls_fail_returns_network_error() {
 async fn test_send_raw_request_returns_http_error_if_non_transient() {
 	let mut server = Server::new_async().await;
 
-	// Mock a non-transient HTTP error (e.g., 400 Bad Request)
+	// Mock a non-transient HTTP error (e.g., 404 Not Found)
 	let mock = server
 		.mock("POST", "/")
-		.with_status(400)
-		.with_body("Bad Request")
+		.with_status(404)
+		.with_body("Not Found")
 		.expect(1)
 		.create_async()
 		.await;
@@ -559,6 +573,7 @@ async fn test_send_raw_request_returns_http_error_if_non_transient() {
 		server.url().as_ref(),
 		vec![],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -574,11 +589,11 @@ async fn test_send_raw_request_returns_http_error_if_non_transient() {
 			body,
 			..
 		} => {
-			assert_eq!(status_code, 400);
+			assert_eq!(status_code, 404);
 			assert_eq!(url, server.url());
-			assert_eq!(body, "Bad Request");
+			assert_eq!(body, "Not Found");
 		}
-		_ => panic!("Expected Http error with status code 400"),
+		_ => panic!("Expected Http error with status code 404"),
 	}
 
 	mock.assert();
@@ -612,6 +627,7 @@ async fn test_rotation_on_5xx_error() {
 		primary_server.url().as_ref(),
 		vec![fallback_server.url()],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -656,6 +672,7 @@ async fn test_rotation_on_all_new_error_codes() {
 			primary_server.url().as_ref(),
 			vec![fallback_server.url()],
 			TEST_NETWORK_SLUG.to_string(),
+			&[],
 		);
 		let transport = MockTransport::new();
 
@@ -700,6 +717,7 @@ async fn test_no_fallback_urls_available_5xx() {
 		server.url().as_ref(),
 		vec![],
 		TEST_NETWORK_SLUG.to_string(),
+		&[],
 	);
 	let transport = MockTransport::new();
 
@@ -747,6 +765,7 @@ async fn test_non_rotation_error_codes_do_not_rotate() {
 			primary_server.url().as_ref(),
 			vec![fallback_server.url()],
 			TEST_NETWORK_SLUG.to_string(),
+			&[],
 		);
 		let transport = MockTransport::new();
 
@@ -777,4 +796,226 @@ async fn test_non_rotation_error_codes_do_not_rotate() {
 			status_code
 		);
 	}
+}
+
+// ============================================================
+// JSON-RPC envelope tests
+// ============================================================
+
+/// HTTP 200 with a JSON-RPC error envelope must trigger rotation to a fallback. Mirrors
+/// the upstream behavior where some providers (e.g. 1rpc.io) signal rate limiting via
+/// `{"error": {"code": 15, ...}}` instead of HTTP 429.
+#[tokio::test]
+async fn test_rotation_on_jsonrpc_error() {
+	let mut primary_server = Server::new_async().await;
+	let mut fallback_server = Server::new_async().await;
+
+	let primary_mock = primary_server
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(
+			r#"{"id":1,"jsonrpc":"2.0","error":{"message":"Too many request, try again later","code":15}}"#,
+		)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let fallback_mock = fallback_server
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(r#"{"jsonrpc":"2.0","result":"0x1","id":1}"#)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let manager = HttpEndpointManager::new(
+		get_mock_client_builder(),
+		primary_server.url().as_ref(),
+		vec![fallback_server.url()],
+		TEST_NETWORK_SLUG.to_string(),
+		&[],
+	);
+	let transport = MockTransport::new();
+
+	let result = manager
+		.send_raw_request(&transport, "eth_blockNumber", None::<Value>)
+		.await
+		.unwrap();
+
+	assert_eq!(result["result"], "0x1");
+	primary_mock.assert();
+	fallback_mock.assert();
+
+	// Active URL should now be the fallback
+	assert_eq!(&*manager.active_url.read().await, &fallback_server.url());
+}
+
+/// When no fallback is available and the primary returns a JSON-RPC error envelope, we
+/// surface a `TransportError::RpcError` carrying the upstream code and message.
+#[tokio::test]
+async fn test_jsonrpc_error_no_fallback() {
+	let mut server = Server::new_async().await;
+
+	let mock = server
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(
+			r#"{"id":1,"jsonrpc":"2.0","error":{"message":"Too many request, try again later","code":15}}"#,
+		)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let manager = HttpEndpointManager::new(
+		get_mock_client_builder(),
+		server.url().as_ref(),
+		vec![],
+		TEST_NETWORK_SLUG.to_string(),
+		&[],
+	);
+	let transport = MockTransport::new();
+
+	let err = manager
+		.send_raw_request(&transport, "eth_blockNumber", None::<Value>)
+		.await
+		.unwrap_err();
+
+	match err {
+		TransportError::RpcError {
+			code, message, url, ..
+		} => {
+			assert_eq!(code, 15);
+			assert_eq!(message, "Too many request, try again later");
+			assert_eq!(url, server.url());
+		}
+		other => panic!("Expected RpcError, got {:?}", other),
+	}
+	mock.assert();
+}
+
+/// JSON-RPC error codes in the per-transport skip-list (e.g. Solana's skipped-slot codes)
+/// must be passed through to the caller without rotating, so per-client handlers can
+/// distinguish "legitimate chain state" from "broken endpoint".
+#[tokio::test]
+async fn test_jsonrpc_passthrough_for_skip_listed_code() {
+	let mut server = Server::new_async().await;
+
+	let mock = server
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(
+			r#"{"id":1,"jsonrpc":"2.0","error":{"message":"Slot was skipped","code":-32007}}"#,
+		)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let manager = HttpEndpointManager::new(
+		get_mock_client_builder(),
+		server.url().as_ref(),
+		vec!["http://other-fallback.example.invalid".to_string()],
+		TEST_NETWORK_SLUG.to_string(),
+		&[-32004, -32007, -32009],
+	);
+	let transport = MockTransport::new();
+
+	let result = manager
+		.send_raw_request(&transport, "getBlock", Some(json!([12345])))
+		.await
+		.unwrap();
+
+	// Response is passed through unchanged so per-client error handlers can run.
+	assert_eq!(result["error"]["code"], -32007);
+	assert_eq!(result["error"]["message"], "Slot was skipped");
+	mock.assert();
+
+	// No rotation should have occurred.
+	assert_eq!(&*manager.active_url.read().await, &server.url());
+}
+
+/// `result: null` is a legitimate response for some methods (e.g. `eth_getBlockByNumber`
+/// for a future block). It must not trigger rotation and must be returned as-is.
+#[tokio::test]
+async fn test_null_result_passes_through() {
+	let mut server = Server::new_async().await;
+
+	let mock = server
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(r#"{"jsonrpc":"2.0","result":null,"id":1}"#)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let manager = HttpEndpointManager::new(
+		get_mock_client_builder(),
+		server.url().as_ref(),
+		vec!["http://other-fallback.example.invalid".to_string()],
+		TEST_NETWORK_SLUG.to_string(),
+		&[],
+	);
+	let transport = MockTransport::new();
+
+	let result = manager
+		.send_raw_request(
+			&transport,
+			"eth_getBlockByNumber",
+			Some(json!(["0xffffff", true])),
+		)
+		.await
+		.unwrap();
+
+	assert!(result["result"].is_null());
+	mock.assert();
+	assert_eq!(&*manager.active_url.read().await, &server.url());
+}
+
+/// A JSON body with neither `result` nor `error` is malformed and treated like a
+/// rotatable JSON-RPC failure.
+#[tokio::test]
+async fn test_malformed_envelope_rotates() {
+	let mut primary_server = Server::new_async().await;
+	let mut fallback_server = Server::new_async().await;
+
+	let primary_mock = primary_server
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(r#"{"id":1,"jsonrpc":"2.0"}"#)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let fallback_mock = fallback_server
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(r#"{"jsonrpc":"2.0","result":"0x1","id":1}"#)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let manager = HttpEndpointManager::new(
+		get_mock_client_builder(),
+		primary_server.url().as_ref(),
+		vec![fallback_server.url()],
+		TEST_NETWORK_SLUG.to_string(),
+		&[],
+	);
+	let transport = MockTransport::new();
+
+	let result = manager
+		.send_raw_request(&transport, "eth_blockNumber", None::<Value>)
+		.await
+		.unwrap();
+
+	assert_eq!(result["result"], "0x1");
+	primary_mock.assert();
+	fallback_mock.assert();
+	assert_eq!(&*manager.active_url.read().await, &fallback_server.url());
 }

--- a/tests/integration/blockchain/transports/http/endpoint_manager.rs
+++ b/tests/integration/blockchain/transports/http/endpoint_manager.rs
@@ -1019,3 +1019,115 @@ async fn test_malformed_envelope_rotates() {
 	fallback_mock.assert();
 	assert_eq!(&*manager.active_url.read().await, &fallback_server.url());
 }
+
+/// When every configured endpoint returns a JSON-RPC error envelope, the manager must try
+/// each endpoint once and then surface the last error rather than cycling indefinitely.
+#[tokio::test]
+async fn test_jsonrpc_error_all_endpoints_fail_does_not_loop() {
+	let mut server_a = Server::new_async().await;
+	let mut server_b = Server::new_async().await;
+
+	// `expect(1)` fails the test if either endpoint is hit more than once — which is what
+	// would happen under the prior infinite-rotation behavior.
+	let mock_a = server_a
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(r#"{"id":1,"jsonrpc":"2.0","error":{"message":"boom","code":15}}"#)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let mock_b = server_b
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(r#"{"id":1,"jsonrpc":"2.0","error":{"message":"boom","code":15}}"#)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let manager = HttpEndpointManager::new(
+		get_mock_client_builder(),
+		server_a.url().as_ref(),
+		vec![server_b.url()],
+		TEST_NETWORK_SLUG.to_string(),
+		&[],
+	);
+	let transport = MockTransport::new();
+
+	// Guard against regressions that reintroduce the infinite loop.
+	let result = tokio::time::timeout(
+		std::time::Duration::from_secs(5),
+		manager.send_raw_request(&transport, "eth_blockNumber", None::<Value>),
+	)
+	.await
+	.expect("send_raw_request must terminate when all endpoints fail")
+	.expect_err("expected an error after exhausting endpoints");
+
+	match result {
+		TransportError::RpcError { code, message, .. } => {
+			assert_eq!(code, 15);
+			assert_eq!(message, "boom");
+		}
+		other => panic!("Expected RpcError, got {:?}", other),
+	}
+
+	mock_a.assert();
+	mock_b.assert();
+}
+
+/// When every configured endpoint returns a malformed JSON-RPC envelope (neither `result`
+/// nor `error`), the manager must try each endpoint once and surface a malformed-envelope
+/// error rather than rotating forever.
+#[tokio::test]
+async fn test_malformed_envelope_all_endpoints_fail_does_not_loop() {
+	let mut server_a = Server::new_async().await;
+	let mut server_b = Server::new_async().await;
+
+	let mock_a = server_a
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(r#"{"id":1,"jsonrpc":"2.0"}"#)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let mock_b = server_b
+		.mock("POST", "/")
+		.with_status(200)
+		.with_header("content-type", "application/json")
+		.with_body(r#"{"id":1,"jsonrpc":"2.0"}"#)
+		.expect(1)
+		.create_async()
+		.await;
+
+	let manager = HttpEndpointManager::new(
+		get_mock_client_builder(),
+		server_a.url().as_ref(),
+		vec![server_b.url()],
+		TEST_NETWORK_SLUG.to_string(),
+		&[],
+	);
+	let transport = MockTransport::new();
+
+	let result = tokio::time::timeout(
+		std::time::Duration::from_secs(5),
+		manager.send_raw_request(&transport, "eth_blockNumber", None::<Value>),
+	)
+	.await
+	.expect("send_raw_request must terminate when all endpoints return malformed bodies")
+	.expect_err("expected an error after exhausting endpoints");
+
+	match result {
+		TransportError::RpcError { code, message, .. } => {
+			assert_eq!(code, 0);
+			assert_eq!(message, "Malformed JSON-RPC envelope");
+		}
+		other => panic!("Expected RpcError, got {:?}", other),
+	}
+
+	mock_a.assert();
+	mock_b.assert();
+}

--- a/tests/integration/blockchain/transports/http/transport.rs
+++ b/tests/integration/blockchain/transports/http/transport.rs
@@ -17,7 +17,7 @@ async fn test_client_creation() {
 	let mock = create_http_valid_server_mock_network_response(&mut server);
 	let network = create_evm_test_network_with_urls(vec![&server.url()]);
 
-	match HttpTransportClient::new(&network, None).await {
+	match HttpTransportClient::new(&network, None, &[]).await {
 		Ok(transport) => {
 			let active_url = transport.get_current_url().await;
 			assert_eq!(active_url, server.url());
@@ -28,7 +28,7 @@ async fn test_client_creation() {
 
 	let network = create_evm_test_network_with_urls(vec!["invalid-url"]);
 
-	match HttpTransportClient::new(&network, None).await {
+	match HttpTransportClient::new(&network, None, &[]).await {
 		Err(error) => {
 			assert!(error.to_string().contains("All RPC URLs failed to connect"))
 		}
@@ -53,7 +53,7 @@ async fn test_client_creation_with_test_connection_payload() {
 	const TEST_CONNECTION_PAYLOAD: &str =
 		r#"{"id":1,"jsonrpc":"2.0","method":"net_version","params":[]}"#;
 
-	match HttpTransportClient::new(&network, Some(TEST_CONNECTION_PAYLOAD.to_string())).await {
+	match HttpTransportClient::new(&network, Some(TEST_CONNECTION_PAYLOAD.to_string()), &[]).await {
 		Ok(transport) => {
 			let active_url = transport.get_current_url().await;
 			assert_eq!(active_url, server.url());
@@ -84,7 +84,7 @@ async fn test_client_creation_with_fallback() {
 
 	let network = create_evm_test_network_with_urls(vec![&server.url(), &server2.url()]);
 
-	match HttpTransportClient::new(&network, None).await {
+	match HttpTransportClient::new(&network, None, &[]).await {
 		Ok(transport) => {
 			let active_url = transport.get_current_url().await;
 			assert_eq!(active_url, server2.url());
@@ -103,7 +103,7 @@ async fn test_client_update_client() {
 	let mock1 = create_http_valid_server_mock_network_response(&mut server);
 
 	let network = create_evm_test_network_with_urls(vec![&server.url()]);
-	let client = HttpTransportClient::new(&network, None).await.unwrap();
+	let client = HttpTransportClient::new(&network, None, &[]).await.unwrap();
 
 	// Test successful update
 	let result = client.update_client(&server2.url()).await;
@@ -127,7 +127,7 @@ async fn test_client_try_connect() {
 	let mock2 = create_http_valid_server_mock_network_response(&mut server2);
 
 	let network = create_evm_test_network_with_urls(vec![&server.url()]);
-	let client = HttpTransportClient::new(&network, None).await.unwrap();
+	let client = HttpTransportClient::new(&network, None, &[]).await.unwrap();
 
 	let result = client.try_connect(&server2.url()).await;
 	assert!(result.is_ok(), "Try connect should succeed");
@@ -164,7 +164,7 @@ async fn test_client_try_connect_with_test_connection_payload() {
 	const TEST_CONNECTION_PAYLOAD: &str =
 		r#"{"id":1,"jsonrpc":"2.0","method":"net_version","params":[]}"#;
 
-	let client = HttpTransportClient::new(&network, Some(TEST_CONNECTION_PAYLOAD.to_string()))
+	let client = HttpTransportClient::new(&network, Some(TEST_CONNECTION_PAYLOAD.to_string()), &[])
 		.await
 		.unwrap();
 
@@ -191,7 +191,7 @@ async fn test_send_raw_request() {
 		.create();
 
 	let network = create_evm_test_network_with_urls(vec![&server.url()]);
-	let client = HttpTransportClient::new(&network, None).await.unwrap();
+	let client = HttpTransportClient::new(&network, None, &[]).await.unwrap();
 
 	// Test with params
 	let params = json!({"key": "value"});
@@ -238,7 +238,7 @@ async fn test_update_endpoint_manager_client() {
 		.await;
 
 	let network = create_evm_test_network_with_urls(vec![&server.url()]);
-	let mut client = HttpTransportClient::new(&network, None).await.unwrap();
+	let mut client = HttpTransportClient::new(&network, None, &[]).await.unwrap();
 
 	// Test initial client
 	let result = client


### PR DESCRIPTION
# Summary

  - Detect JSON-RPC error envelopes (HTTP 200 + `{"error":{...}}`) in the HTTP endpoint manager and rotate to a fallback instead of bubbling up `Missing 'result' field`. Fixes the silent failure observed on multiple RPCs in our production setup.                                                              
  - Track JSON-RPC failures in Prometheus: `rpc_request_errors_total{error_type="jsonrpc"}` + `rpc_endpoint_rotations_total{reason="jsonrpc_error"}`. New `rpc_null_results_total{network, method}` counter for legitimate `result: null` responses.                                                                                             
  - Per-transport skip-list so codes that represent legitimate chain state (Solana `-32004 / -32007 / -32009`) pass through to the per-client handler instead of burning through fallbacks.                                                                                                                                                                             
  - Add HTTP 400 to `ROTATE_ON_ERROR_CODES` — many providers use it wrongly for various issues, still it means we need to rotate.

## Testing Process

- **Start a fake RPC** that always 200s with a JSON-RPC error:
  ```bash
  python3 -c 'from http.server import *
  class H(BaseHTTPRequestHandler):
   def do_POST(s):
    s.rfile.read(int(s.headers.get("Content-Length",0)));b=b"{\"id\":1,\"jsonrpc\":\"2.0\",\"error\":{\"code\":15,\"message\":\"rate limited\"}}"
    s.send_response(200);s.send_header("Content-Length",str(len(b)));s.end_headers();s.wfile.write(b)
  HTTPServer(("127.0.0.1",9545),H).serve_forever()'
  ```
- **Add a test network** in `config/networks/`: primary `http://127.0.0.1:9545` (weight 100), fallback a real RPC like `https://base.drpc.org` (weight 99). Point an existing monitor at its slug.
- **Run with metrics**: `cargo run --release -- --metrics`
- **Verify** after ~30s:
  ```bash
  curl -s http://127.0.0.1:8081/metrics | grep test_jsonrpc_error
  ```
  Expect non-zero `rpc_request_errors_total{...,error_type="jsonrpc",status_code="15"}` and `rpc_endpoint_rotations_total{...,reason="jsonrpc_error"}`. Logs should show rotation warnings; blocks should keep being processed via the fallback (no `Failed to process blocks` errors).

## Checklist

- [X] Add a reference to related issues in the PR description.
- [X] Add unit tests if applicable.
- [X] Add integration tests if applicable.
- [X] Add property-based tests if applicable.
- [X] Update documentation if applicable.

> [!NOTE]
> If you are using Monitor in your stack, consider adding your team or organization to our list of [Monitor Users in the Wild](../INTHEWILD.md)!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added metrics to track JSON-RPC null results and error categorization for improved RPC health visibility.

* **Bug Fixes**
  * Improved JSON-RPC error handling in blockchain transport with better error classification and logging.
  * Enhanced endpoint rotation logic with support for additional HTTP error codes to increase reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->