### PR TITLE
chore(deps): Bump openssl in workspace Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6097,15 +6097,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -6135,9 +6134,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary

- Updates the **root** `Cargo.lock` so `openssl` resolves to **0.10.80** and `openssl-sys` to **0.9.116** (via `native-tls` / `lettre`).
- Brings the workspace lockfile in line with the versions already used in `fuzz/Cargo.lock`, so Dependabot/security views are not split across two different `openssl` pins.

## Test plan

- [x] `pre-commit` / `clippy` (ran as part of `git commit`)
- [ ] CI green on this PR