### PR TITLE
feat: support unlimited max_past_blocks with batched catch-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ RUST_TEST_THREADS=1 cargo +stable llvm-cov
 - The `max_past_blocks` configuration is critical:
   - Calculate as: `(cron_interval_ms/block_time_ms) + confirmation_blocks + 1` (defaults to this calculation if not specified).
   - Example for 1-minute Ethereum cron: `(60000/12000) + 12 + 1 = 18 blocks`.
-  - Too low settings may result in missed blocks.
+  - Too low numeric settings may skip older unprocessed blocks after downtime. Use `"unlimited"` to avoid this clamp; catch-up still runs in bounded batches.
 - Trigger conditions are executed sequentially based on their position in the trigger conditions array. Proper execution also depends on the number of available file descriptors on your system. Ideally, you should increase the open file descriptor limit to at least 2,048 or higher for optimal performance.
   - Security Risk: Only run scripts that you trust and fully understand. Malicious scripts can harm your system or expose sensitive data. Always review script contents and verify their source before execution.
   - HTTP requests to RPC endpoints may consume file descriptors for each connection. The number of concurrent connections can increase significantly when processing blocks with many transactions, as each transaction may require multiple RPC calls.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -488,7 +488,7 @@ A Network configuration defines connection details and operational parameters fo
 | `**block_time_ms**` | `Number` | Average block time in milliseconds |
 | `**confirmation_blocks**` | `Number` | Number of blocks to wait for confirmation |
 | `**cron_schedule**` | `String` | Monitor scheduling in cron format |
-| `**max_past_blocks**` | `Number` | Maximum number of past blocks to process |
+| `**max_past_blocks**` | `Number` or `"unlimited"` | Maximum number of past blocks to process, or `"unlimited"` to resume from the last processed block without clamping |
 | `**store_blocks**` | `Boolean` | Whether to store processed blocks (defaults output to `./data/` directory) |
 | `**recovery_config**` | `Object` | Optional configuration for missed block recovery (see below) |
 
@@ -1752,7 +1752,7 @@ The monitor implements a comprehensive error handling system with rich context a
 * The `max_past_blocks` configuration is critical:
   * Calculate as: `(cron_interval_ms/block_time_ms) + confirmation_blocks + 1` (defaults to this calculation if not specified).
   * Example for 1-minute Ethereum cron: `(60000/12000) + 12 + 1 = 18 blocks`.
-  * Too low settings may result in missed blocks.
+  * Too low numeric settings may skip older unprocessed blocks after downtime. Use `"unlimited"` to avoid this clamp; catch-up still runs in bounded batches.
 * Trigger conditions are executed sequentially based on their position in the trigger conditions array. Proper execution also depends on the number of available file descriptors on your system. To ensure optimal performance, it is recommended to increase the limit for open file descriptors to at least 2048 or higher. On Unix-based systems you can check the current limit by running `ulimit -n` and _***temporarily***_ increase it with `ulimit -n 2048`.
 * Since scripts are loaded at startup, any modifications to script files require restarting the monitor to take effect.
 * See performance considerations about custom scripts [here](/monitor/scripts#performance-considerations).

--- a/src/models/config/network_config.rs
+++ b/src/models/config/network_config.rs
@@ -269,26 +269,37 @@ impl ConfigLoader for Network {
 		}
 
 		// Validate max_past_blocks ("unlimited" is always valid)
-		if let Some(MaxPastBlocks::Limited(max_blocks)) = self.max_past_blocks {
-			if max_blocks == 0 {
-				return Err(ConfigError::validation_error(
-					"max_past_blocks must be greater than 0",
-					None,
-					None,
-				));
+		match self.max_past_blocks {
+			Some(MaxPastBlocks::Limited(max_blocks)) => {
+				if max_blocks == 0 {
+					return Err(ConfigError::validation_error(
+						"max_past_blocks must be greater than 0",
+						None,
+						None,
+					));
+				}
+
+				let recommended_blocks = self.get_recommended_past_blocks();
+
+				if max_blocks < recommended_blocks {
+					tracing::warn!(
+						"Network '{}' max_past_blocks ({}) is below the recommended minimum ({}); \
+						 blocks will be skipped on every tick, not just after downtime. Use \
+						 \"unlimited\" to never skip.",
+						self.slug,
+						max_blocks,
+						recommended_blocks
+					);
+				}
 			}
-
-			let recommended_blocks = self.get_recommended_past_blocks();
-
-			if max_blocks < recommended_blocks {
+			Some(MaxPastBlocks::Unlimited) if self.store_blocks == Some(true) => {
 				tracing::warn!(
-					"Network '{}' max_past_blocks ({}) below recommended {} \
-					 (cron_interval/block_time + confirmations + 1)",
-					self.slug,
-					max_blocks,
-					recommended_blocks
+					"Network '{}' unlimited catch-up with store_blocks enabled can write the \
+					 entire backlog to disk during catch-up (one file per batch)",
+					self.slug
 				);
 			}
+			_ => {}
 		}
 
 		// Log a warning if the network uses an insecure protocol
@@ -503,6 +514,35 @@ mod tests {
 	fn test_validate_unlimited_max_past_blocks() {
 		let network = NetworkBuilder::new().unlimited_past_blocks().build();
 		assert!(network.validate().is_ok());
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_validate_unlimited_max_past_blocks_with_store_blocks_warns() {
+		let network = NetworkBuilder::new()
+			.unlimited_past_blocks()
+			.store_blocks(true)
+			.build();
+
+		assert!(network.validate().is_ok());
+		assert!(logs_contain(
+			"unlimited catch-up with store_blocks enabled can write the entire backlog to disk \
+			 during catch-up (one file per batch)"
+		));
+	}
+
+	#[test]
+	#[traced_test]
+	fn test_validate_unlimited_max_past_blocks_without_store_blocks_does_not_warn() {
+		let network = NetworkBuilder::new()
+			.unlimited_past_blocks()
+			.store_blocks(false)
+			.build();
+
+		assert!(network.validate().is_ok());
+		assert!(!logs_contain(
+			"unlimited catch-up with store_blocks enabled"
+		));
 	}
 
 	fn network_json_with_max_past_blocks(value: &str) -> String {

--- a/src/models/config/network_config.rs
+++ b/src/models/config/network_config.rs
@@ -7,7 +7,10 @@ use async_trait::async_trait;
 use std::{collections::HashMap, path::Path, str::FromStr};
 
 use crate::{
-	models::{config::error::ConfigError, BlockChainType, ConfigLoader, Network, SecretValue},
+	models::{
+		config::error::ConfigError, BlockChainType, ConfigLoader, MaxPastBlocks, Network,
+		SecretValue,
+	},
 	utils::{get_cron_interval_ms, normalize_string},
 };
 
@@ -265,8 +268,8 @@ impl ConfigLoader for Network {
 			return Err(ConfigError::validation_error(e.to_string(), None, None));
 		}
 
-		// Validate max_past_blocks
-		if let Some(max_blocks) = self.max_past_blocks {
+		// Validate max_past_blocks ("unlimited" is always valid)
+		if let Some(MaxPastBlocks::Limited(max_blocks)) = self.max_past_blocks {
 			if max_blocks == 0 {
 				return Err(ConfigError::validation_error(
 					"max_past_blocks must be greater than 0",
@@ -494,6 +497,103 @@ mod tests {
 			network.validate(),
 			Err(ConfigError::ValidationError(_))
 		));
+	}
+
+	#[test]
+	fn test_validate_unlimited_max_past_blocks() {
+		let network = NetworkBuilder::new().unlimited_past_blocks().build();
+		assert!(network.validate().is_ok());
+	}
+
+	fn network_json_with_max_past_blocks(value: &str) -> String {
+		format!(
+			r#"{{
+			"name": "Test Network",
+			"slug": "test_network",
+			"network_type": "EVM",
+			"rpc_urls": [
+				{{
+					"type_": "rpc",
+					"url": {{
+						"type": "plain",
+						"value": "https://eth.drpc.org"
+					}},
+					"weight": 100
+				}}
+			],
+			"chain_id": 1,
+			"block_time_ms": 1000,
+			"confirmation_blocks": 1,
+			"cron_schedule": "0 */5 * * * *",
+			{}
+			"store_blocks": true
+		}}"#,
+			value
+		)
+	}
+
+	#[test]
+	fn test_max_past_blocks_deserialize_number() {
+		let network: Network = serde_json::from_str(&network_json_with_max_past_blocks(
+			"\"max_past_blocks\": 10,",
+		))
+		.unwrap();
+		assert_eq!(network.max_past_blocks, Some(MaxPastBlocks::Limited(10)));
+	}
+
+	#[test]
+	fn test_max_past_blocks_deserialize_unlimited() {
+		let network: Network = serde_json::from_str(&network_json_with_max_past_blocks(
+			"\"max_past_blocks\": \"unlimited\",",
+		))
+		.unwrap();
+		assert_eq!(network.max_past_blocks, Some(MaxPastBlocks::Unlimited));
+	}
+
+	#[test]
+	fn test_max_past_blocks_deserialize_absent() {
+		let network: Network =
+			serde_json::from_str(&network_json_with_max_past_blocks("")).unwrap();
+		assert_eq!(network.max_past_blocks, None);
+	}
+
+	#[test]
+	fn test_max_past_blocks_deserialize_invalid_string() {
+		let result: Result<Network, _> = serde_json::from_str(&network_json_with_max_past_blocks(
+			"\"max_past_blocks\": \"infinite\",",
+		));
+		let error = result.unwrap_err().to_string();
+		assert!(error.contains("a non-negative integer or the string \"unlimited\""));
+	}
+
+	#[test]
+	fn test_max_past_blocks_deserialize_bool() {
+		let result: Result<Network, _> = serde_json::from_str(&network_json_with_max_past_blocks(
+			"\"max_past_blocks\": true,",
+		));
+		let error = result.unwrap_err().to_string();
+		assert!(error.contains("a non-negative integer or the string \"unlimited\""));
+	}
+
+	#[test]
+	fn test_max_past_blocks_deserialize_negative() {
+		let result: Result<Network, _> = serde_json::from_str(&network_json_with_max_past_blocks(
+			"\"max_past_blocks\": -5,",
+		));
+		let error = result.unwrap_err().to_string();
+		assert!(error.contains("a non-negative integer or the string \"unlimited\""));
+	}
+
+	#[test]
+	fn test_max_past_blocks_serialize() {
+		assert_eq!(
+			serde_json::to_string(&MaxPastBlocks::Limited(10)).unwrap(),
+			"10"
+		);
+		assert_eq!(
+			serde_json::to_string(&MaxPastBlocks::Unlimited).unwrap(),
+			"\"unlimited\""
+		);
 	}
 
 	#[test]

--- a/src/models/core/mod.rs
+++ b/src/models/core/mod.rs
@@ -13,7 +13,7 @@ pub use monitor::{
 	AddressWithSpec, EventCondition, FunctionCondition, MatchConditions, Monitor, ScriptLanguage,
 	TransactionCondition, TransactionStatus, TriggerConditions, SCRIPT_LANGUAGE_EXTENSIONS,
 };
-pub use network::{BlockRecoveryConfig, Network, RpcUrl};
+pub use network::{BlockRecoveryConfig, MaxPastBlocks, Network, RpcUrl};
 pub use trigger::{
 	NotificationMessage, Trigger, TriggerType, TriggerTypeConfig, WebhookPayloadMode,
 };

--- a/src/models/core/network.rs
+++ b/src/models/core/network.rs
@@ -1,6 +1,88 @@
-use serde::{Deserialize, Serialize};
+use serde::{
+	de::{self, Visitor},
+	Deserialize, Deserializer, Serialize, Serializer,
+};
 
 use crate::models::{BlockChainType, SecretValue};
+
+/// Maximum number of past blocks to process for a network.
+///
+/// Serialized as a JSON number for `Limited(n)` or the string `"unlimited"`
+/// for `Unlimited`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaxPastBlocks {
+	/// Process at most this many past blocks behind the latest confirmed block
+	Limited(u64),
+	/// No limit: never skip blocks, always resume from the last processed block
+	Unlimited,
+}
+
+impl std::fmt::Display for MaxPastBlocks {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		match self {
+			MaxPastBlocks::Limited(blocks) => write!(f, "{}", blocks),
+			MaxPastBlocks::Unlimited => write!(f, "unlimited"),
+		}
+	}
+}
+
+impl Serialize for MaxPastBlocks {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: Serializer,
+	{
+		match self {
+			MaxPastBlocks::Limited(blocks) => serializer.serialize_u64(*blocks),
+			MaxPastBlocks::Unlimited => serializer.serialize_str("unlimited"),
+		}
+	}
+}
+
+impl<'de> Deserialize<'de> for MaxPastBlocks {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: Deserializer<'de>,
+	{
+		struct MaxPastBlocksVisitor;
+
+		impl Visitor<'_> for MaxPastBlocksVisitor {
+			type Value = MaxPastBlocks;
+
+			fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+				formatter.write_str("a non-negative integer or the string \"unlimited\"")
+			}
+
+			fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+			where
+				E: de::Error,
+			{
+				Ok(MaxPastBlocks::Limited(value))
+			}
+
+			fn visit_i64<E>(self, value: i64) -> Result<Self::Value, E>
+			where
+				E: de::Error,
+			{
+				u64::try_from(value)
+					.map(MaxPastBlocks::Limited)
+					.map_err(|_| E::invalid_value(de::Unexpected::Signed(value), &self))
+			}
+
+			fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+			where
+				E: de::Error,
+			{
+				if value == "unlimited" {
+					Ok(MaxPastBlocks::Unlimited)
+				} else {
+					Err(E::invalid_value(de::Unexpected::Str(value), &self))
+				}
+			}
+		}
+
+		deserializer.deserialize_any(MaxPastBlocksVisitor)
+	}
+}
 
 /// Configuration for missed block recovery job.
 ///
@@ -62,8 +144,8 @@ pub struct Network {
 	/// Cron expression for how often to check for new blocks
 	pub cron_schedule: String,
 
-	/// Maximum number of past blocks to process
-	pub max_past_blocks: Option<u64>,
+	/// Maximum number of past blocks to process (a number or "unlimited")
+	pub max_past_blocks: Option<MaxPastBlocks>,
 
 	/// Whether to store processed blocks
 	pub store_blocks: Option<bool>,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -88,9 +88,9 @@ pub use blockchain::solana::{
 // Re-export core types
 pub use core::{
 	AddressWithSpec, BlockRecoveryConfig, EventCondition, FunctionCondition, MatchConditions,
-	Monitor, Network, NotificationMessage, RpcUrl, ScriptLanguage, TransactionCondition,
-	TransactionStatus, Trigger, TriggerConditions, TriggerType, TriggerTypeConfig,
-	WebhookPayloadMode, SCRIPT_LANGUAGE_EXTENSIONS,
+	MaxPastBlocks, Monitor, Network, NotificationMessage, RpcUrl, ScriptLanguage,
+	TransactionCondition, TransactionStatus, Trigger, TriggerConditions, TriggerType,
+	TriggerTypeConfig, WebhookPayloadMode, SCRIPT_LANGUAGE_EXTENSIONS,
 };
 
 // Re-export config types

--- a/src/services/blockchain/clients/evm/client.rs
+++ b/src/services/blockchain/clients/evm/client.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 
 use anyhow::Context;
 use async_trait::async_trait;
-use futures;
+use futures::{stream, StreamExt, TryStreamExt};
 use serde_json::json;
 use tracing::instrument;
 
@@ -211,7 +211,7 @@ impl<T: Send + Sync + Clone + BlockchainTransport> BlockChainClient for EvmClien
 		start_block: u64,
 		end_block: Option<u64>,
 	) -> Result<Vec<BlockType>, anyhow::Error> {
-		let block_futures: Vec<_> = (start_block..=end_block.unwrap_or(start_block))
+		stream::iter(start_block..=end_block.unwrap_or(start_block))
 			.map(|block_number| {
 				let params = json!([
 					format!("0x{:x}", block_number),
@@ -239,11 +239,8 @@ impl<T: Send + Sync + Clone + BlockchainTransport> BlockChainClient for EvmClien
 					Ok(BlockType::EVM(Box::new(block)))
 				}
 			})
-			.collect();
-
-		futures::future::join_all(block_futures)
+			.buffered(32)
+			.try_collect()
 			.await
-			.into_iter()
-			.collect::<Result<Vec<_>, _>>()
 	}
 }

--- a/src/services/blockwatcher/recovery.rs
+++ b/src/services/blockwatcher/recovery.rs
@@ -332,7 +332,7 @@ where
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::models::{BlockChainType, RpcUrl, SecretString, SecretValue};
+	use crate::models::{BlockChainType, MaxPastBlocks, RpcUrl, SecretString, SecretValue};
 	use crate::services::blockwatcher::storage::{
 		BlockStorage, FileBlockStorage, MissedBlockEntry,
 	};
@@ -355,7 +355,7 @@ mod tests {
 			block_time_ms: 12000,
 			confirmation_blocks: 12,
 			cron_schedule: "*/10 * * * * *".to_string(),
-			max_past_blocks: Some(100),
+			max_past_blocks: Some(MaxPastBlocks::Limited(100)),
 			store_blocks: Some(true),
 			recovery_config: Some(BlockRecoveryConfig {
 				enabled: true,

--- a/src/services/blockwatcher/service.rs
+++ b/src/services/blockwatcher/service.rs
@@ -14,7 +14,7 @@ use tokio_cron_scheduler::{Job, JobScheduler};
 use tracing::instrument;
 
 use crate::{
-	models::{BlockType, Network, ProcessedBlock},
+	models::{BlockType, MaxPastBlocks, Network, ProcessedBlock},
 	services::{
 		blockchain::{BlockChainClient, BlockFetchResult, FetchStreamKind},
 		blockwatcher::{
@@ -24,7 +24,314 @@ use crate::{
 			tracker::{BlockCheckResult, BlockTracker, BlockTrackerTrait},
 		},
 	},
+	utils::metrics::BLOCK_CHECKPOINT_LAG,
 };
+
+/// Number of blocks fetched and processed per batch while catching up.
+///
+/// The checkpoint is saved after each batch, so a failure mid catch-up only
+/// retries a single batch on the next tick instead of the whole backlog.
+const CATCHUP_BATCH_SIZE: u64 = 30;
+
+struct BatchProcessSummary {
+	block_count: usize,
+	stream_kind: FetchStreamKind,
+}
+
+struct BatchProcessingContext<'a, S, H, T, TR> {
+	network: &'a Network,
+	block_storage: &'a Arc<S>,
+	block_handler: &'a Arc<H>,
+	trigger_handler: &'a Arc<T>,
+	block_tracker: &'a Arc<TR>,
+	latest_confirmed_block: u64,
+}
+
+struct BatchProcessingOptions {
+	batch_start: u64,
+	checkpoint_block: u64,
+	delete_blocks_before_save: bool,
+}
+
+async fn save_checkpoint<S: BlockStorage>(
+	block_storage: &Arc<S>,
+	network: &Network,
+	checkpoint_block: u64,
+	latest_confirmed_block: u64,
+) -> Result<(), BlockWatcherError> {
+	block_storage
+		.save_last_processed_block(&network.slug, checkpoint_block)
+		.await
+		.with_context(|| "Failed to save last processed block")?;
+
+	BLOCK_CHECKPOINT_LAG
+		.with_label_values(&[network.slug.as_str()])
+		.set(latest_confirmed_block.saturating_sub(checkpoint_block) as f64);
+
+	Ok(())
+}
+
+fn log_checkpoint_lag(network: &Network, checkpoint_block: u64, latest_confirmed_block: u64) {
+	let lag = latest_confirmed_block.saturating_sub(checkpoint_block);
+	tracing::info!(
+		network = %network.slug,
+		checkpoint_block,
+		latest_confirmed_block,
+		lag,
+		"Block checkpoint lag is {} blocks",
+		lag
+	);
+}
+
+async fn process_block_batch<
+	S: BlockStorage,
+	H: Fn(BlockType, Network) -> BoxFuture<'static, ProcessedBlock> + Send + Sync + 'static,
+	T: Fn(&ProcessedBlock) -> tokio::task::JoinHandle<()> + Send + Sync + 'static,
+	TR: BlockTrackerTrait + Send + Sync + 'static,
+>(
+	context: &BatchProcessingContext<'_, S, H, T, TR>,
+	fetch_result: BlockFetchResult,
+	options: BatchProcessingOptions,
+) -> Result<BatchProcessSummary, BlockWatcherError> {
+	let network = context.network;
+	let block_storage = context.block_storage;
+	let block_tracker = context.block_tracker;
+	let batch_start = options.batch_start;
+	let checkpoint_block = options.checkpoint_block;
+	let delete_blocks_before_save = options.delete_blocks_before_save;
+	let stream_kind = fetch_result.stream_kind;
+	let blocks = fetch_result.blocks;
+
+	// Reset expected_next to the batch start so long catch-ups can checkpoint
+	// independently without false out-of-order warnings between batches.
+	block_tracker
+		.reset_expected_next(network, batch_start)
+		.await;
+
+	// Detect missing blocks based on the fetch stream kind.
+	// Dense streams (sequential block retrieval) use gap detection.
+	// Sparse streams (address-filtered) rely on explicitly reported failed blocks.
+	let missed_blocks = match &stream_kind {
+		FetchStreamKind::Dense => block_tracker.detect_missing_blocks(network, &blocks).await,
+		FetchStreamKind::Sparse => fetch_result.failed_blocks,
+	};
+
+	// Log and save missed blocks if any
+	if !missed_blocks.is_empty() {
+		tracing::error!(
+			network = %network.slug,
+			count = missed_blocks.len(),
+			"Missed {} blocks: {:?}",
+			missed_blocks.len(),
+			missed_blocks
+		);
+
+		// Save missed blocks in batch (enabled if store_blocks OR recovery is enabled)
+		let recovery_enabled = network.recovery_config.as_ref().is_some_and(|c| c.enabled);
+		if network.store_blocks.unwrap_or(false) || recovery_enabled {
+			block_storage
+				.save_missed_blocks(&network.slug, &missed_blocks)
+				.await
+				.with_context(|| format!("Failed to save {} missed blocks", missed_blocks.len()))?;
+		}
+	}
+
+	// Create channels for our pipeline
+	let channel_size = (blocks.len() * 2).max(1);
+	let (process_tx, process_rx) = mpsc::channel::<(BlockType, u64)>(channel_size);
+	let (trigger_tx, trigger_rx) = mpsc::channel::<ProcessedBlock>(channel_size);
+
+	// Stage 1: Block Processing Pipeline
+	let process_handle = tokio::spawn({
+		let network = network.clone();
+		let block_handler = Arc::clone(context.block_handler);
+		let mut trigger_tx = trigger_tx.clone();
+
+		async move {
+			// Process blocks concurrently, up to 32 at a time
+			let mut results = process_rx
+				.map(|(block, _)| {
+					let network = network.clone();
+					let block_handler = block_handler.clone();
+					async move { (block_handler)(block, network).await }
+				})
+				.buffer_unordered(32);
+
+			// Process all results and send them to trigger channel
+			while let Some(result) = results.next().await {
+				trigger_tx
+					.send(result)
+					.await
+					.with_context(|| "Failed to send processed block")?;
+			}
+
+			Ok::<(), BlockWatcherError>(())
+		}
+	});
+
+	// Stage 2: Trigger Pipeline
+	let trigger_handle = tokio::spawn({
+		let network = network.clone();
+		let trigger_handler = Arc::clone(context.trigger_handler);
+		let block_tracker = Arc::clone(context.block_tracker);
+
+		async move {
+			let mut trigger_rx = trigger_rx;
+			let mut pending_blocks = BTreeMap::new();
+			let mut next_block_number = Some(batch_start);
+			let block_tracker = block_tracker.clone();
+
+			// Process all incoming blocks
+			while let Some(processed_block) = trigger_rx.next().await {
+				let block_number = processed_block.block_number;
+
+				// Buffer the block - we'll check and execute in order
+				pending_blocks.insert(block_number, processed_block);
+
+				// Process blocks in order as long as we have the next expected block
+				while let Some(expected) = next_block_number {
+					if let Some(block) = pending_blocks.remove(&expected) {
+						// Check for duplicate or out-of-order blocks when actually executing
+						// This ensures we're checking the execution order, not arrival order
+						match block_tracker
+							.check_processed_block(&network, expected)
+							.await
+						{
+							BlockCheckResult::Ok => {
+								// Block is valid, execute it
+							}
+							BlockCheckResult::Duplicate { last_seen } => {
+								tracing::error!(
+									network = %network.slug,
+									block_number = expected,
+									last_seen = last_seen,
+									"Duplicate block detected: received block {} again (last seen: {})",
+									expected,
+									last_seen
+								);
+							}
+							BlockCheckResult::OutOfOrder {
+								expected: exp,
+								received,
+							} => {
+								tracing::warn!(
+									network = %network.slug,
+									block_number = received,
+									expected = exp,
+									"Out of order block detected: received {} but expected {}",
+									received,
+									exp
+								);
+							}
+						}
+
+						(trigger_handler)(&block);
+						next_block_number = Some(expected + 1);
+					} else {
+						break;
+					}
+				}
+			}
+
+			// Process any remaining blocks in order after the channel is closed
+			while let Some(min_block) = pending_blocks.keys().next().copied() {
+				if let Some(block) = pending_blocks.remove(&min_block) {
+					// Check for duplicate or out-of-order blocks when executing
+					match block_tracker
+						.check_processed_block(&network, min_block)
+						.await
+					{
+						BlockCheckResult::Ok => {
+							// Block is valid, execute it
+						}
+						BlockCheckResult::Duplicate { last_seen } => {
+							tracing::error!(
+								network = %network.slug,
+								block_number = min_block,
+								last_seen = last_seen,
+								"Duplicate block detected: received block {} again (last seen: {})",
+								min_block,
+								last_seen
+							);
+						}
+						BlockCheckResult::OutOfOrder {
+							expected: exp,
+							received,
+						} => {
+							tracing::warn!(
+								network = %network.slug,
+								block_number = received,
+								expected = exp,
+								"Out of order block detected: received {} but expected {}",
+								received,
+								exp
+							);
+						}
+					}
+
+					(trigger_handler)(&block);
+				}
+			}
+			Ok::<(), BlockWatcherError>(())
+		}
+	});
+
+	// Feed blocks into the pipeline
+	futures::future::join_all(blocks.iter().map(|block| {
+		let mut process_tx = process_tx.clone();
+		async move {
+			let block_number = block.number().unwrap_or(0);
+
+			// Send block to processing pipeline
+			process_tx
+				.send((block.clone(), block_number))
+				.await
+				.with_context(|| "Failed to send block to pipeline")?;
+
+			Ok::<(), BlockWatcherError>(())
+		}
+	}))
+	.await
+	.into_iter()
+	.collect::<Result<Vec<_>, _>>()
+	.with_context(|| format!("Failed to process blocks for network {}", network.slug))?;
+
+	// Drop the sender after all blocks are sent
+	drop(process_tx);
+	drop(trigger_tx);
+
+	// Wait for both pipeline stages to complete
+	let (process_result, trigger_result) = tokio::join!(process_handle, trigger_handle);
+	process_result.map_err(|e| anyhow::anyhow!("Block processing task failed: {}", e))??;
+	trigger_result.map_err(|e| anyhow::anyhow!("Trigger processing task failed: {}", e))??;
+
+	if network.store_blocks.unwrap_or(false) {
+		if delete_blocks_before_save {
+			block_storage
+				.delete_blocks(&network.slug)
+				.await
+				.with_context(|| "Failed to delete old blocks")?;
+		}
+
+		block_storage
+			.save_blocks(&network.slug, &blocks)
+			.await
+			.with_context(|| "Failed to save blocks")?;
+	}
+
+	save_checkpoint(
+		block_storage,
+		network,
+		checkpoint_block,
+		context.latest_confirmed_block,
+	)
+	.await?;
+
+	Ok(BatchProcessSummary {
+		block_count: blocks.len(),
+		stream_kind,
+	})
+}
 
 /// Trait for job scheduler
 ///
@@ -480,13 +787,30 @@ pub async fn process_new_blocks<
 
 	let recommended_past_blocks = network.get_recommended_past_blocks();
 
-	let max_past_blocks = network.max_past_blocks.unwrap_or(recommended_past_blocks);
+	let max_past_blocks = network
+		.max_past_blocks
+		.unwrap_or(MaxPastBlocks::Limited(recommended_past_blocks));
 
-	// Calculate the start block number, using the default if max_past_blocks is not set
-	let start_block = std::cmp::max(
-		last_processed_block + 1,
-		latest_confirmed_block.saturating_sub(max_past_blocks),
-	);
+	// Calculate the start block number, using the default if max_past_blocks is not set.
+	// Unlimited networks never clamp: they always resume from the last processed block.
+	let start_block = if last_processed_block == 0 {
+		latest_confirmed_block
+	} else {
+		match max_past_blocks {
+			MaxPastBlocks::Limited(max) => std::cmp::max(
+				last_processed_block.saturating_add(1),
+				latest_confirmed_block.saturating_sub(max),
+			),
+			MaxPastBlocks::Unlimited => last_processed_block.saturating_add(1),
+		}
+	};
+	let skipped_blocks = match max_past_blocks {
+		MaxPastBlocks::Limited(_) if last_processed_block != 0 => {
+			let next_block = last_processed_block.saturating_add(1);
+			(start_block > next_block).then_some(start_block - next_block)
+		}
+		_ => None,
+	};
 
 	tracing::info!(
 		"Processing blocks:\n\tLast processed block: {}\n\tLatest confirmed block: {}\n\tStart \
@@ -494,267 +818,124 @@ pub async fn process_new_blocks<
 		last_processed_block,
 		latest_confirmed_block,
 		start_block,
-		if start_block > last_processed_block + 1 {
-			format!(
-				" (skipped {} blocks)",
-				start_block - (last_processed_block + 1)
-			)
-		} else {
-			String::new()
-		},
+		skipped_blocks
+			.map(|blocks| format!(" (skipped {} blocks)", blocks))
+			.unwrap_or_default(),
 		network.confirmation_blocks,
 		max_past_blocks
 	);
 
-	let fetch_result = if last_processed_block == 0 {
-		rpc_client
+	let mut total_blocks_processed = 0;
+	let mut stream_kind = FetchStreamKind::Dense;
+	let mut checkpoint_block = last_processed_block;
+	let mut blocks_deleted = false;
+	let batch_context = BatchProcessingContext {
+		network,
+		block_storage: &block_storage,
+		block_handler: &block_handler,
+		trigger_handler: &trigger_handler,
+		block_tracker: &block_tracker,
+		latest_confirmed_block,
+	};
+
+	if last_processed_block == 0 {
+		let fetch_result = rpc_client
 			.get_blocks_with_meta(latest_confirmed_block, None)
 			.await
-			.with_context(|| format!("Failed to get block {}", latest_confirmed_block))?
+			.with_context(|| format!("Failed to get block {}", latest_confirmed_block))?;
+		let summary = process_block_batch(
+			&batch_context,
+			fetch_result,
+			BatchProcessingOptions {
+				batch_start: latest_confirmed_block,
+				checkpoint_block: latest_confirmed_block,
+				delete_blocks_before_save: true,
+			},
+		)
+		.await?;
+		total_blocks_processed += summary.block_count;
+		stream_kind = summary.stream_kind;
+		checkpoint_block = latest_confirmed_block;
 	} else if last_processed_block < latest_confirmed_block {
-		rpc_client
-			.get_blocks_with_meta(start_block, Some(latest_confirmed_block))
-			.await
-			.with_context(|| {
-				format!(
-					"Failed to get blocks from {} to {}",
-					start_block, latest_confirmed_block
+		// The per-network run_lock serializes cron ticks while long catch-ups are still running.
+		let mut batch_start = start_block;
+		while batch_start <= latest_confirmed_block {
+			let batch_end = std::cmp::min(
+				batch_start.saturating_add(CATCHUP_BATCH_SIZE - 1),
+				latest_confirmed_block,
+			);
+			let batch_result = async {
+				let fetch_result = rpc_client
+					.get_blocks_with_meta(batch_start, Some(batch_end))
+					.await
+					.with_context(|| {
+						format!("Failed to get blocks from {} to {}", batch_start, batch_end)
+					})?;
+
+				process_block_batch(
+					&batch_context,
+					fetch_result,
+					BatchProcessingOptions {
+						batch_start,
+						checkpoint_block: batch_end,
+						delete_blocks_before_save: network.store_blocks.unwrap_or(false)
+							&& !blocks_deleted,
+					},
 				)
-			})?
+				.await
+			}
+			.await;
+
+			match batch_result {
+				Ok(summary) => {
+					total_blocks_processed += summary.block_count;
+					stream_kind = summary.stream_kind;
+					checkpoint_block = batch_end;
+					blocks_deleted = blocks_deleted || network.store_blocks.unwrap_or(false);
+				}
+				Err(error) => {
+					tracing::error!(
+						network = %network.slug,
+						batch_start,
+						batch_end,
+						error = %error,
+						"Failed to process block batch"
+					);
+					log_checkpoint_lag(network, checkpoint_block, latest_confirmed_block);
+					return Err(error);
+				}
+			}
+
+			batch_start = batch_end + 1;
+		}
 	} else {
-		BlockFetchResult {
+		let fetch_result = BlockFetchResult {
 			blocks: Vec::new(),
 			failed_blocks: Vec::new(),
 			stream_kind: FetchStreamKind::Dense,
-		}
-	};
-
-	let stream_kind = fetch_result.stream_kind;
-	let blocks = fetch_result.blocks;
-
-	// Reset expected_next to start_block to ensure synchronization with this execution
-	// This prevents false out-of-order warnings when reprocessing blocks or restarting
-	block_tracker
-		.reset_expected_next(network, start_block)
-		.await;
-
-	// Detect missing blocks based on the fetch stream kind.
-	// Dense streams (sequential block retrieval) use gap detection.
-	// Sparse streams (address-filtered) rely on explicitly reported failed blocks.
-	let missed_blocks = match stream_kind {
-		FetchStreamKind::Dense => block_tracker.detect_missing_blocks(network, &blocks).await,
-		FetchStreamKind::Sparse => fetch_result.failed_blocks,
-	};
-
-	// Log and save missed blocks if any
-	if !missed_blocks.is_empty() {
-		tracing::error!(
-			network = %network.slug,
-			count = missed_blocks.len(),
-			"Missed {} blocks: {:?}",
-			missed_blocks.len(),
-			missed_blocks
-		);
-
-		// Save missed blocks in batch (enabled if store_blocks OR recovery is enabled)
-		let recovery_enabled = network.recovery_config.as_ref().is_some_and(|c| c.enabled);
-		if network.store_blocks.unwrap_or(false) || recovery_enabled {
-			block_storage
-				.save_missed_blocks(&network.slug, &missed_blocks)
-				.await
-				.with_context(|| format!("Failed to save {} missed blocks", missed_blocks.len()))?;
-		}
+		};
+		let summary = process_block_batch(
+			&batch_context,
+			fetch_result,
+			BatchProcessingOptions {
+				batch_start: start_block,
+				checkpoint_block: latest_confirmed_block,
+				delete_blocks_before_save: true,
+			},
+		)
+		.await?;
+		total_blocks_processed += summary.block_count;
+		stream_kind = summary.stream_kind;
+		checkpoint_block = latest_confirmed_block;
 	}
 
-	// Create channels for our pipeline
-	let (process_tx, process_rx) = mpsc::channel::<(BlockType, u64)>(blocks.len() * 2);
-	let (trigger_tx, trigger_rx) = mpsc::channel::<ProcessedBlock>(blocks.len() * 2);
-
-	// Stage 1: Block Processing Pipeline
-	let process_handle = tokio::spawn({
-		let network = network.clone();
-		let block_handler = block_handler.clone();
-		let mut trigger_tx = trigger_tx.clone();
-
-		async move {
-			// Process blocks concurrently, up to 32 at a time
-			let mut results = process_rx
-				.map(|(block, _)| {
-					let network = network.clone();
-					let block_handler = block_handler.clone();
-					async move { (block_handler)(block, network).await }
-				})
-				.buffer_unordered(32);
-
-			// Process all results and send them to trigger channel
-			while let Some(result) = results.next().await {
-				trigger_tx
-					.send(result)
-					.await
-					.with_context(|| "Failed to send processed block")?;
-			}
-
-			Ok::<(), BlockWatcherError>(())
-		}
-	});
-
-	// Stage 2: Trigger Pipeline
-	let trigger_handle = tokio::spawn({
-		let network = network.clone();
-		let trigger_handler = trigger_handler.clone();
-		let block_tracker = block_tracker.clone();
-
-		async move {
-			let mut trigger_rx = trigger_rx;
-			let mut pending_blocks = BTreeMap::new();
-			let mut next_block_number = Some(start_block);
-			let block_tracker = block_tracker.clone();
-
-			// Process all incoming blocks
-			while let Some(processed_block) = trigger_rx.next().await {
-				let block_number = processed_block.block_number;
-
-				// Buffer the block - we'll check and execute in order
-				pending_blocks.insert(block_number, processed_block);
-
-				// Process blocks in order as long as we have the next expected block
-				while let Some(expected) = next_block_number {
-					if let Some(block) = pending_blocks.remove(&expected) {
-						// Check for duplicate or out-of-order blocks when actually executing
-						// This ensures we're checking the execution order, not arrival order
-						match block_tracker
-							.check_processed_block(&network, expected)
-							.await
-						{
-							BlockCheckResult::Ok => {
-								// Block is valid, execute it
-							}
-							BlockCheckResult::Duplicate { last_seen } => {
-								tracing::error!(
-									network = %network.slug,
-									block_number = expected,
-									last_seen = last_seen,
-									"Duplicate block detected: received block {} again (last seen: {})",
-									expected,
-									last_seen
-								);
-							}
-							BlockCheckResult::OutOfOrder {
-								expected: exp,
-								received,
-							} => {
-								tracing::warn!(
-									network = %network.slug,
-									block_number = received,
-									expected = exp,
-									"Out of order block detected: received {} but expected {}",
-									received,
-									exp
-								);
-							}
-						}
-
-						(trigger_handler)(&block);
-						next_block_number = Some(expected + 1);
-					} else {
-						break;
-					}
-				}
-			}
-
-			// Process any remaining blocks in order after the channel is closed
-			while let Some(min_block) = pending_blocks.keys().next().copied() {
-				if let Some(block) = pending_blocks.remove(&min_block) {
-					// Check for duplicate or out-of-order blocks when executing
-					match block_tracker
-						.check_processed_block(&network, min_block)
-						.await
-					{
-						BlockCheckResult::Ok => {
-							// Block is valid, execute it
-						}
-						BlockCheckResult::Duplicate { last_seen } => {
-							tracing::error!(
-								network = %network.slug,
-								block_number = min_block,
-								last_seen = last_seen,
-								"Duplicate block detected: received block {} again (last seen: {})",
-								min_block,
-								last_seen
-							);
-						}
-						BlockCheckResult::OutOfOrder {
-							expected: exp,
-							received,
-						} => {
-							tracing::warn!(
-								network = %network.slug,
-								block_number = received,
-								expected = exp,
-								"Out of order block detected: received {} but expected {}",
-								received,
-								exp
-							);
-						}
-					}
-
-					(trigger_handler)(&block);
-				}
-			}
-			Ok::<(), BlockWatcherError>(())
-		}
-	});
-
-	// Feed blocks into the pipeline
-	futures::future::join_all(blocks.iter().map(|block| {
-		let mut process_tx = process_tx.clone();
-		async move {
-			let block_number = block.number().unwrap_or(0);
-
-			// Send block to processing pipeline
-			process_tx
-				.send((block.clone(), block_number))
-				.await
-				.with_context(|| "Failed to send block to pipeline")?;
-
-			Ok::<(), BlockWatcherError>(())
-		}
-	}))
-	.await
-	.into_iter()
-	.collect::<Result<Vec<_>, _>>()
-	.with_context(|| format!("Failed to process blocks for network {}", network.slug))?;
-
-	// Drop the sender after all blocks are sent
-	drop(process_tx);
-	drop(trigger_tx);
-
-	// Wait for both pipeline stages to complete
-	let (_process_result, _trigger_result) = tokio::join!(process_handle, trigger_handle);
-
-	if network.store_blocks.unwrap_or(false) {
-		// Delete old blocks before saving new ones
-		block_storage
-			.delete_blocks(&network.slug)
-			.await
-			.with_context(|| "Failed to delete old blocks")?;
-
-		block_storage
-			.save_blocks(&network.slug, &blocks)
-			.await
-			.with_context(|| "Failed to save blocks")?;
-	}
-	// Update the last processed block
-	block_storage
-		.save_last_processed_block(&network.slug, latest_confirmed_block)
-		.await
-		.with_context(|| "Failed to save last processed block")?;
+	log_checkpoint_lag(network, checkpoint_block, latest_confirmed_block);
 
 	match stream_kind {
 		FetchStreamKind::Sparse => {
 			tracing::info!(
 				"Processed {} slots with matching transactions (scanned slot range {}-{}) in {}ms for network {:?}",
-				blocks.len(),
+				total_blocks_processed,
 				start_block,
 				latest_confirmed_block,
 				start_time.elapsed().as_millis(),
@@ -764,7 +945,7 @@ pub async fn process_new_blocks<
 		FetchStreamKind::Dense => {
 			tracing::info!(
 				"Processed {} blocks (range {}-{}) in {}ms for network {:?}",
-				blocks.len(),
+				total_blocks_processed,
 				start_block,
 				latest_confirmed_block,
 				start_time.elapsed().as_millis(),
@@ -838,6 +1019,7 @@ mod tests {
 		latest_block: Arc<AtomicU64>,
 		blocks_to_return: Arc<std::sync::Mutex<Vec<BlockType>>>,
 		fail_get_blocks: Arc<AtomicBool>,
+		fail_on_call: Arc<AtomicUsize>,
 		call_count: Arc<AtomicUsize>,
 	}
 
@@ -847,6 +1029,7 @@ mod tests {
 				latest_block: Arc::new(AtomicU64::new(latest_block)),
 				blocks_to_return: Arc::new(std::sync::Mutex::new(Vec::new())),
 				fail_get_blocks: Arc::new(AtomicBool::new(false)),
+				fail_on_call: Arc::new(AtomicUsize::new(0)),
 				call_count: Arc::new(AtomicUsize::new(0)),
 			}
 		}
@@ -859,6 +1042,12 @@ mod tests {
 		#[allow(dead_code)]
 		fn with_failing_get_blocks(self) -> Self {
 			self.fail_get_blocks.store(true, Ordering::SeqCst);
+			self
+		}
+
+		fn with_failing_get_blocks_after(self, successful_calls: usize) -> Self {
+			self.fail_on_call
+				.store(successful_calls + 1, Ordering::SeqCst);
 			self
 		}
 	}
@@ -874,9 +1063,14 @@ mod tests {
 			start: u64,
 			end: Option<u64>,
 		) -> Result<Vec<BlockType>, anyhow::Error> {
-			self.call_count.fetch_add(1, Ordering::SeqCst);
+			let call_number = self.call_count.fetch_add(1, Ordering::SeqCst) + 1;
 
 			if self.fail_get_blocks.load(Ordering::SeqCst) {
+				return Err(anyhow::anyhow!("Simulated RPC failure"));
+			}
+
+			let fail_on_call = self.fail_on_call.load(Ordering::SeqCst);
+			if fail_on_call != 0 && call_number >= fail_on_call {
 				return Err(anyhow::anyhow!("Simulated RPC failure"));
 			}
 
@@ -1074,7 +1268,7 @@ mod tests {
 			.unwrap();
 
 		let mut network = create_test_network();
-		network.max_past_blocks = Some(50); // Only process last 50 blocks
+		network.max_past_blocks = Some(MaxPastBlocks::Limited(50)); // Only process last 50 blocks
 
 		let rpc_client = MockRpcClient::new(1000);
 		let block_tracker = Arc::new(BlockTracker::new(100));
@@ -1099,6 +1293,100 @@ mod tests {
 			.await
 			.unwrap();
 		assert_eq!(last_processed, Some(988)); // 1000 - 12 confirmations
+	}
+
+	#[tokio::test]
+	async fn test_process_new_blocks_unlimited_processes_full_gap() {
+		let temp_dir = tempdir().unwrap();
+		let storage = Arc::new(FileBlockStorage::new(temp_dir.path().to_path_buf()));
+
+		storage
+			.save_last_processed_block("test_network", 10)
+			.await
+			.unwrap();
+
+		let mut network = create_test_network();
+		network.max_past_blocks = Some(MaxPastBlocks::Unlimited);
+		network.store_blocks = Some(false);
+
+		let rpc_client = MockRpcClient::new(1000);
+		let block_tracker = Arc::new(BlockTracker::new(2000));
+		let block_handler = create_block_handler();
+		let trigger_count = Arc::new(AtomicUsize::new(0));
+		let trigger_handler = {
+			let trigger_count = trigger_count.clone();
+			Arc::new(move |_block: &ProcessedBlock| {
+				trigger_count.fetch_add(1, Ordering::SeqCst);
+				tokio::spawn(async move {})
+			})
+		};
+
+		let result = process_new_blocks(
+			&network,
+			&rpc_client,
+			storage.clone(),
+			block_handler,
+			trigger_handler,
+			block_tracker,
+		)
+		.await;
+
+		assert!(result.is_ok());
+
+		let last_processed = storage
+			.get_last_processed_block("test_network")
+			.await
+			.unwrap();
+		assert_eq!(last_processed, Some(988));
+		assert_eq!(trigger_count.load(Ordering::SeqCst), 978);
+		assert_eq!(rpc_client.call_count.load(Ordering::SeqCst), 33);
+	}
+
+	#[tokio::test]
+	async fn test_process_new_blocks_unlimited_failure_keeps_last_successful_batch_checkpoint() {
+		let temp_dir = tempdir().unwrap();
+		let storage = Arc::new(FileBlockStorage::new(temp_dir.path().to_path_buf()));
+
+		storage
+			.save_last_processed_block("test_network", 10)
+			.await
+			.unwrap();
+
+		let mut network = create_test_network();
+		network.max_past_blocks = Some(MaxPastBlocks::Unlimited);
+		network.store_blocks = Some(false);
+
+		let rpc_client = MockRpcClient::new(200).with_failing_get_blocks_after(2);
+		let block_tracker = Arc::new(BlockTracker::new(2000));
+		let block_handler = create_block_handler();
+		let trigger_count = Arc::new(AtomicUsize::new(0));
+		let trigger_handler = {
+			let trigger_count = trigger_count.clone();
+			Arc::new(move |_block: &ProcessedBlock| {
+				trigger_count.fetch_add(1, Ordering::SeqCst);
+				tokio::spawn(async move {})
+			})
+		};
+
+		let result = process_new_blocks(
+			&network,
+			&rpc_client,
+			storage.clone(),
+			block_handler,
+			trigger_handler,
+			block_tracker,
+		)
+		.await;
+
+		assert!(result.is_err());
+
+		let last_processed = storage
+			.get_last_processed_block("test_network")
+			.await
+			.unwrap();
+		assert_eq!(last_processed, Some(70));
+		assert_eq!(trigger_count.load(Ordering::SeqCst), 60);
+		assert_eq!(rpc_client.call_count.load(Ordering::SeqCst), 3);
 	}
 
 	#[tokio::test]

--- a/src/services/blockwatcher/service.rs
+++ b/src/services/blockwatcher/service.rs
@@ -33,6 +33,12 @@ use crate::{
 /// retries a single batch on the next tick instead of the whole backlog.
 const CATCHUP_BATCH_SIZE: u64 = 30;
 
+/// Maximum number of unlimited catch-up batches processed by a single tick.
+///
+/// This bounds tick duration so the per-network run_lock is released and
+/// recovery can interleave. The next tick resumes from the per-batch checkpoint.
+const MAX_BATCHES_PER_TICK: u64 = 100;
+
 struct BatchProcessSummary {
 	block_count: usize,
 	stream_kind: FetchStreamKind,
@@ -859,7 +865,23 @@ pub async fn process_new_blocks<
 	} else if last_processed_block < latest_confirmed_block {
 		// The per-network run_lock serializes cron ticks while long catch-ups are still running.
 		let mut batch_start = start_block;
+		let mut batches_processed_this_tick = 0;
 		while batch_start <= latest_confirmed_block {
+			if matches!(max_past_blocks, MaxPastBlocks::Unlimited)
+				&& batches_processed_this_tick >= MAX_BATCHES_PER_TICK
+			{
+				let remaining_lag = latest_confirmed_block.saturating_sub(checkpoint_block);
+				tracing::info!(
+					network = %network.slug,
+					checkpoint = checkpoint_block,
+					latest_confirmed = latest_confirmed_block,
+					remaining_lag,
+					batches_processed = batches_processed_this_tick,
+					"Reached unlimited catch-up batch cap; continuing next tick"
+				);
+				break;
+			}
+
 			let batch_end = std::cmp::min(
 				batch_start.saturating_add(CATCHUP_BATCH_SIZE - 1),
 				latest_confirmed_block,
@@ -892,6 +914,7 @@ pub async fn process_new_blocks<
 					stream_kind = summary.stream_kind;
 					checkpoint_block = batch_end;
 					blocks_deleted = blocks_deleted || network.store_blocks.unwrap_or(false);
+					batches_processed_this_tick += 1;
 				}
 				Err(error) => {
 					tracing::error!(
@@ -906,7 +929,10 @@ pub async fn process_new_blocks<
 				}
 			}
 
-			batch_start = batch_end + 1;
+			if batch_end == latest_confirmed_block {
+				break;
+			}
+			batch_start = batch_end.saturating_add(1);
 		}
 	} else {
 		let fetch_result = BlockFetchResult {
@@ -1340,6 +1366,80 @@ mod tests {
 		assert_eq!(last_processed, Some(988));
 		assert_eq!(trigger_count.load(Ordering::SeqCst), 978);
 		assert_eq!(rpc_client.call_count.load(Ordering::SeqCst), 33);
+	}
+
+	#[tokio::test]
+	async fn test_process_new_blocks_unlimited_caps_batches_per_tick_and_resumes() {
+		let temp_dir = tempdir().unwrap();
+		let storage = Arc::new(FileBlockStorage::new(temp_dir.path().to_path_buf()));
+		let last_processed = 10;
+
+		storage
+			.save_last_processed_block("test_network", last_processed)
+			.await
+			.unwrap();
+
+		let mut network = create_test_network();
+		network.max_past_blocks = Some(MaxPastBlocks::Unlimited);
+		network.store_blocks = Some(false);
+
+		let first_tick_blocks = MAX_BATCHES_PER_TICK * CATCHUP_BATCH_SIZE;
+		let remaining_blocks = CATCHUP_BATCH_SIZE + 20;
+		let first_tick_checkpoint = last_processed + first_tick_blocks;
+		let latest_confirmed_block = first_tick_checkpoint + remaining_blocks;
+		let latest_block = latest_confirmed_block + network.confirmation_blocks;
+
+		let rpc_client = MockRpcClient::new(latest_block);
+		let block_tracker = Arc::new(BlockTracker::new(4000));
+		let block_handler = create_block_handler();
+		let trigger_handler = create_trigger_handler();
+
+		let result = process_new_blocks(
+			&network,
+			&rpc_client,
+			storage.clone(),
+			block_handler.clone(),
+			trigger_handler.clone(),
+			block_tracker.clone(),
+		)
+		.await;
+
+		assert!(result.is_ok());
+		assert_eq!(
+			storage
+				.get_last_processed_block("test_network")
+				.await
+				.unwrap(),
+			Some(first_tick_checkpoint)
+		);
+		assert_eq!(
+			rpc_client.call_count.load(Ordering::SeqCst),
+			usize::try_from(MAX_BATCHES_PER_TICK).unwrap()
+		);
+
+		let result = process_new_blocks(
+			&network,
+			&rpc_client,
+			storage.clone(),
+			block_handler,
+			trigger_handler,
+			block_tracker,
+		)
+		.await;
+
+		assert!(result.is_ok());
+		assert_eq!(
+			storage
+				.get_last_processed_block("test_network")
+				.await
+				.unwrap(),
+			Some(latest_confirmed_block)
+		);
+		assert_eq!(
+			rpc_client.call_count.load(Ordering::SeqCst),
+			usize::try_from(MAX_BATCHES_PER_TICK + remaining_blocks.div_ceil(CATCHUP_BATCH_SIZE))
+				.unwrap()
+		);
 	}
 
 	#[tokio::test]

--- a/src/utils/metrics/mod.rs
+++ b/src/utils/metrics/mod.rs
@@ -137,6 +137,20 @@ lazy_static! {
 		gauge
 	};
 
+	/// Gauge Vector for block checkpoint lag per network.
+	///
+	/// Tracks the number of blocks the saved checkpoint lags behind the latest
+	/// confirmed block, labeled by network slug. Updated whenever the checkpoint
+	/// is saved, so a mid catch-up failure leaves an accurate value.
+	pub static ref BLOCK_CHECKPOINT_LAG: GaugeVec = {
+		let gauge = GaugeVec::new(
+			Opts::new("block_checkpoint_lag", "Number of blocks the checkpoint lags behind the latest confirmed block"),
+			&["network"]
+		).unwrap();
+		REGISTRY.register(Box::new(gauge.clone())).unwrap();
+		gauge
+	};
+
 	// ============================================================
 	// RPC Operational Metrics
 	// ============================================================

--- a/src/utils/tests/builders/network.rs
+++ b/src/utils/tests/builders/network.rs
@@ -3,7 +3,7 @@
 //! - `NetworkBuilder`: Builder for creating test Network instances
 
 use crate::models::{
-	BlockChainType, BlockRecoveryConfig, Network, RpcUrl, SecretString, SecretValue,
+	BlockChainType, BlockRecoveryConfig, MaxPastBlocks, Network, RpcUrl, SecretString, SecretValue,
 };
 
 /// Builder for creating test Network instances
@@ -18,7 +18,7 @@ pub struct NetworkBuilder {
 	block_time_ms: u64,
 	confirmation_blocks: u64,
 	cron_schedule: String,
-	max_past_blocks: Option<u64>,
+	max_past_blocks: Option<MaxPastBlocks>,
 	recovery_config: Option<BlockRecoveryConfig>,
 }
 
@@ -35,7 +35,7 @@ impl Default for NetworkBuilder {
 			block_time_ms: 1000,
 			confirmation_blocks: 1,
 			cron_schedule: "0 */5 * * * *".to_string(),
-			max_past_blocks: Some(10),
+			max_past_blocks: Some(MaxPastBlocks::Limited(10)),
 			recovery_config: None,
 		}
 	}
@@ -148,7 +148,12 @@ impl NetworkBuilder {
 	}
 
 	pub fn max_past_blocks(mut self, blocks: u64) -> Self {
-		self.max_past_blocks = Some(blocks);
+		self.max_past_blocks = Some(MaxPastBlocks::Limited(blocks));
+		self
+	}
+
+	pub fn unlimited_past_blocks(mut self) -> Self {
+		self.max_past_blocks = Some(MaxPastBlocks::Unlimited);
 		self
 	}
 
@@ -192,7 +197,7 @@ mod tests {
 		assert_eq!(network.block_time_ms, 1000);
 		assert_eq!(network.confirmation_blocks, 1);
 		assert_eq!(network.cron_schedule, "0 */5 * * * *");
-		assert_eq!(network.max_past_blocks, Some(10));
+		assert_eq!(network.max_past_blocks, Some(MaxPastBlocks::Limited(10)));
 		assert_eq!(network.rpc_urls.len(), 0);
 	}
 

--- a/tests/integration/blockwatcher/service.rs
+++ b/tests/integration/blockwatcher/service.rs
@@ -1,6 +1,6 @@
 use futures::future::BoxFuture;
 use mockall::predicate;
-use std::sync::Arc;
+use std::{collections::VecDeque, sync::Arc};
 use tokio_cron_scheduler::JobScheduler;
 
 use crate::integration::mocks::{
@@ -8,7 +8,7 @@ use crate::integration::mocks::{
 	MockEVMTransportClient, MockEvmClientTrait, MockJobScheduler,
 };
 use openzeppelin_monitor::{
-	models::{BlockChainType, BlockType, Network, ProcessedBlock},
+	models::{BlockChainType, BlockType, MaxPastBlocks, Network, ProcessedBlock},
 	services::blockwatcher::{
 		process_new_blocks, BlockCheckResult, BlockTracker, BlockTrackerTrait, BlockWatcherError,
 		BlockWatcherService, NetworkBlockWatcher,
@@ -21,8 +21,8 @@ struct MockConfig {
 	last_processed_block: Option<u64>,
 	latest_block: u64,
 	blocks_to_return: Vec<BlockType>,
-	expected_save_block: Option<u64>,
-	expected_block_range: Option<(u64, Option<u64>)>,
+	expected_save_blocks: Vec<u64>,
+	expected_block_ranges: Vec<(u64, Option<u64>)>,
 	expected_tracked_blocks: Vec<u64>,
 	store_blocks: bool,
 }
@@ -38,25 +38,44 @@ fn setup_mocks_with_network(
 ) {
 	// Setup mock block storage
 	let mut block_storage = MockBlockStorage::new();
+	let expected_save_blocks = config.expected_save_blocks.clone();
+	let expected_block_ranges = config.expected_block_ranges.clone();
 
 	// Configure get_last_processed_block
+	let last_processed_block = config.last_processed_block;
 	block_storage
 		.expect_get_last_processed_block()
 		.with(predicate::always())
-		.returning(move |_| Ok(config.last_processed_block))
+		.returning(move |_| Ok(last_processed_block))
 		.times(1);
 
 	// Configure save_last_processed_block if expected
-	if let Some(expected_block) = config.expected_save_block {
+	if !expected_save_blocks.is_empty() {
+		let expected_blocks = Arc::new(std::sync::Mutex::new(VecDeque::from(
+			expected_save_blocks.clone(),
+		)));
 		block_storage
 			.expect_save_last_processed_block()
-			.with(predicate::always(), predicate::eq(expected_block))
-			.returning(|_, _| Ok(()))
-			.times(1);
+			.with(predicate::always(), predicate::always())
+			.returning(move |_, block| {
+				let expected_block = expected_blocks
+					.lock()
+					.unwrap()
+					.pop_front()
+					.expect("unexpected save_last_processed_block call");
+				assert_eq!(block, expected_block);
+				Ok(())
+			})
+			.times(expected_save_blocks.len());
 	}
 
 	// Configure block storage expectations based on store_blocks flag
 	if config.store_blocks {
+		let expected_save_count = if expected_block_ranges.is_empty() {
+			1
+		} else {
+			expected_block_ranges.len()
+		};
 		block_storage
 			.expect_delete_blocks()
 			.with(predicate::always())
@@ -67,7 +86,7 @@ fn setup_mocks_with_network(
 			.expect_save_blocks()
 			.with(predicate::always(), predicate::always())
 			.returning(|_, _| Ok(()))
-			.times(1);
+			.times(expected_save_count);
 	} else {
 		block_storage.expect_delete_blocks().times(0);
 		block_storage.expect_save_blocks().times(0);
@@ -85,13 +104,35 @@ fn setup_mocks_with_network(
 		.returning(move || Ok(config.latest_block))
 		.times(1);
 
-	// Configure get_blocks if range is specified
-	if let Some((from, to)) = config.expected_block_range {
+	// Configure get_blocks if ranges are specified
+	if !expected_block_ranges.is_empty() {
+		let expected_ranges = Arc::new(std::sync::Mutex::new(VecDeque::from(
+			expected_block_ranges.clone(),
+		)));
+		let blocks_to_return = config.blocks_to_return.clone();
 		rpc_client
 			.expect_get_blocks()
-			.with(predicate::eq(from), predicate::eq(to))
-			.returning(move |_, _| Ok(config.blocks_to_return.clone()))
-			.times(1);
+			.with(predicate::always(), predicate::always())
+			.returning(move |from, to| {
+				let expected_range = expected_ranges
+					.lock()
+					.unwrap()
+					.pop_front()
+					.expect("unexpected get_blocks call");
+				assert_eq!((from, to), expected_range);
+
+				let end = to.unwrap_or(from);
+				Ok(blocks_to_return
+					.iter()
+					.filter(|block| {
+						block
+							.number()
+							.is_some_and(|number| number >= from && number <= end)
+					})
+					.cloned()
+					.collect())
+			})
+			.times(expected_block_ranges.len());
 	}
 
 	// Setup mock block tracker with the same Arc<MockBlockStorage>
@@ -104,34 +145,76 @@ fn setup_mocks_with_network(
 	let confirmation_blocks = network.map(|n| n.confirmation_blocks).unwrap_or(1); // default confirmation_blocks = 1
 	let latest_confirmed = config.latest_block.saturating_sub(confirmation_blocks);
 	let max_past_blocks = network
-		.and_then(|n| n.max_past_blocks)
-		.or_else(|| network.map(|n| n.get_recommended_past_blocks()))
-		.unwrap_or(50); // default max_past_blocks = 50
-	let start_block = std::cmp::max(
-		last_processed + 1,
-		latest_confirmed.saturating_sub(max_past_blocks),
-	);
+		.map(|n| {
+			n.max_past_blocks
+				.unwrap_or(MaxPastBlocks::Limited(n.get_recommended_past_blocks()))
+		})
+		.unwrap_or(MaxPastBlocks::Limited(50)); // default max_past_blocks = 50
+	let start_block = if last_processed == 0 {
+		latest_confirmed
+	} else {
+		match max_past_blocks {
+			MaxPastBlocks::Limited(max) => std::cmp::max(
+				last_processed.saturating_add(1),
+				latest_confirmed.saturating_sub(max),
+			),
+			MaxPastBlocks::Unlimited => last_processed.saturating_add(1),
+		}
+	};
 
-	// Configure reset_expected_next to be called at the start of each execution
+	let expected_batches = if expected_block_ranges.is_empty() {
+		vec![(start_block, Vec::new())]
+	} else {
+		expected_block_ranges
+			.iter()
+			.map(|(from, to)| {
+				let end = to.unwrap_or(*from);
+				let expected_blocks = config
+					.expected_tracked_blocks
+					.iter()
+					.copied()
+					.filter(|block| *block >= *from && *block <= end)
+					.collect();
+				(*from, expected_blocks)
+			})
+			.collect()
+	};
+
+	let expected_reset_batches = expected_batches.clone();
+	let expected_resets = Arc::new(std::sync::Mutex::new(VecDeque::from(
+		expected_reset_batches,
+	)));
 	block_tracker
 		.expect_reset_expected_next()
 		.withf(move |network: &Network, block: &u64| {
-			network.network_type == BlockChainType::EVM && *block == start_block
+			if network.network_type != BlockChainType::EVM {
+				return false;
+			}
+			let mut expected_resets = expected_resets.lock().unwrap();
+			let Some((expected_start, _)) = expected_resets.pop_front() else {
+				return false;
+			};
+			*block == expected_start
 		})
 		.returning(|_, _| ())
-		.times(1);
+		.times(expected_batches.len());
 
-	// Configure detect_missing_blocks to return empty vec (no gaps expected in most tests)
-	let expected_blocks = config.expected_tracked_blocks.clone();
+	let expected_detect_batches = expected_batches.clone();
+	let expected_detects = Arc::new(std::sync::Mutex::new(VecDeque::from(
+		expected_detect_batches,
+	)));
 	block_tracker
 		.expect_detect_missing_blocks()
 		.withf(move |_, blocks: &[BlockType]| {
-			// Verify blocks match expected
+			let mut expected_detects = expected_detects.lock().unwrap();
+			let Some((_, expected_blocks)) = expected_detects.pop_front() else {
+				return false;
+			};
 			let block_numbers: Vec<u64> = blocks.iter().filter_map(|b| b.number()).collect();
 			block_numbers == expected_blocks
 		})
 		.returning(|_, _| Vec::new())
-		.times(1);
+		.times(expected_batches.len());
 
 	// Configure check_processed_block to return Ok for all expected blocks
 	for &block_number in &config.expected_tracked_blocks {
@@ -161,8 +244,8 @@ async fn test_normal_block_range() {
 			create_test_block(BlockChainType::EVM, 103),
 			create_test_block(BlockChainType::EVM, 104),
 		],
-		expected_save_block: Some(104),
-		expected_block_range: Some((101, Some(104))),
+		expected_save_blocks: vec![104],
+		expected_block_ranges: vec![(101, Some(104))],
 		expected_tracked_blocks: vec![101, 102, 103, 104],
 		store_blocks: false,
 	};
@@ -209,8 +292,8 @@ async fn test_fresh_start_processing() {
 		last_processed_block: Some(0),
 		latest_block: 100,
 		blocks_to_return: vec![create_test_block(BlockChainType::EVM, 99)],
-		expected_save_block: Some(99),
-		expected_block_range: Some((99, None)),
+		expected_save_blocks: vec![99],
+		expected_block_ranges: vec![(99, None)],
 		expected_tracked_blocks: vec![99],
 		store_blocks: false,
 	};
@@ -257,9 +340,9 @@ async fn test_no_new_blocks() {
 		last_processed_block: Some(100),
 		latest_block: 100,        // Same as last_processed_block
 		blocks_to_return: vec![], // No blocks should be returned
-		expected_save_block: Some(99), /* We still store the last confirmed (latest_block - 1
+		expected_save_blocks: vec![99], /* We still store the last confirmed (latest_block - 1
 		                           * confirmations) block */
-		expected_block_range: None,      // No block range should be requested
+		expected_block_ranges: vec![],   // No block range should be requested
 		expected_tracked_blocks: vec![], // No blocks should be tracked
 		store_blocks: true,
 	};
@@ -300,7 +383,7 @@ async fn test_no_new_blocks() {
 #[tokio::test]
 async fn test_concurrent_processing() {
 	let mut network = create_test_network("Test Network", "test-network", BlockChainType::EVM);
-	network.max_past_blocks = Some(51); // match processing limit
+	network.max_past_blocks = Some(MaxPastBlocks::Limited(51)); // match processing limit
 
 	// Create 50 blocks to test the pipeline
 	let blocks_to_process: Vec<u64> = (101..151).collect();
@@ -312,8 +395,8 @@ async fn test_concurrent_processing() {
 			.iter()
 			.map(|&num| create_test_block(BlockChainType::EVM, num))
 			.collect(),
-		expected_save_block: Some(150),
-		expected_block_range: Some((101, Some(150))),
+		expected_save_blocks: vec![130, 150],
+		expected_block_ranges: vec![(101, Some(130)), (131, Some(150))],
 		expected_tracked_blocks: blocks_to_process.clone(),
 		store_blocks: false,
 	};
@@ -413,8 +496,8 @@ async fn test_ordered_trigger_handling() {
 			.iter()
 			.map(|&num| create_test_block(BlockChainType::EVM, num))
 			.collect(),
-		expected_save_block: Some(105),
-		expected_block_range: Some((101, Some(105))),
+		expected_save_blocks: vec![105],
+		expected_block_ranges: vec![(101, Some(105))],
 		expected_tracked_blocks: blocks_to_process.clone(),
 		store_blocks: false,
 	};
@@ -506,8 +589,8 @@ async fn test_block_storage_enabled() {
 		last_processed_block: Some(100),
 		latest_block: 103,
 		blocks_to_return: blocks_to_process.clone(),
-		expected_save_block: Some(102),
-		expected_block_range: Some((101, Some(102))),
+		expected_save_blocks: vec![102],
+		expected_block_ranges: vec![(101, Some(102))],
 		expected_tracked_blocks: vec![101, 102],
 		store_blocks: true,
 	};
@@ -547,7 +630,7 @@ async fn test_block_storage_enabled() {
 #[tokio::test]
 async fn test_max_past_blocks_limit() {
 	let mut network = create_test_network("Test Network", "test-network", BlockChainType::EVM);
-	network.max_past_blocks = Some(3); // Only process last 3 blocks max
+	network.max_past_blocks = Some(MaxPastBlocks::Limited(3)); // Only process last 3 blocks max
 
 	let config = MockConfig {
 		last_processed_block: Some(100),
@@ -558,9 +641,9 @@ async fn test_max_past_blocks_limit() {
 			create_test_block(BlockChainType::EVM, 108),
 			create_test_block(BlockChainType::EVM, 109),
 		],
-		expected_save_block: Some(109),
+		expected_save_blocks: vec![109],
 		// Should start at 106 (110 - 1 confirmation - 3 past blocks) instead of 101
-		expected_block_range: Some((106, Some(109))),
+		expected_block_ranges: vec![(106, Some(109))],
 		expected_tracked_blocks: vec![106, 107, 108, 109],
 		store_blocks: false,
 	};
@@ -633,9 +716,9 @@ async fn test_max_past_blocks_limit_recommended() {
 			create_test_block(BlockChainType::EVM, 137),
 			create_test_block(BlockChainType::EVM, 138),
 		],
-		expected_save_block: Some(138),
-		expected_block_range: Some((125, Some(138))), /* start at 125 (150 - 12 (confirmations) - 13 (max_past_blocks)
-													  stop at 138 (150 - 12 (confirmations) */
+		expected_save_blocks: vec![138],
+		expected_block_ranges: vec![(125, Some(138))], /* start at 125 (150 - 12 (confirmations) - 13 (max_past_blocks)
+													   stop at 138 (150 - 12 (confirmations) */
 		expected_tracked_blocks: vec![
 			125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138,
 		],
@@ -688,9 +771,9 @@ async fn test_confirmation_blocks() {
 			create_test_block(BlockChainType::EVM, 102),
 			create_test_block(BlockChainType::EVM, 103),
 		],
-		expected_save_block: Some(103), /* We expect this to be saved as the last processed block
-		                                 * with 2 confirmations */
-		expected_block_range: Some((101, Some(103))),
+		expected_save_blocks: vec![103], /* We expect this to be saved as the last processed block
+		                                  * with 2 confirmations */
+		expected_block_ranges: vec![(101, Some(103))],
 		expected_tracked_blocks: vec![101, 102, 103],
 		store_blocks: false,
 	};

--- a/tests/integration/filters/solana/filter.rs
+++ b/tests/integration/filters/solana/filter.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 
 use openzeppelin_monitor::{
 	models::{
-		AddressWithSpec, BlockType, EventCondition, MatchConditions, Monitor, MonitorMatch,
-		SolanaBlock, SolanaConfirmedBlock, SolanaInnerInstruction, SolanaInstruction,
+		AddressWithSpec, BlockType, EventCondition, MatchConditions, MaxPastBlocks, Monitor,
+		MonitorMatch, SolanaBlock, SolanaConfirmedBlock, SolanaInnerInstruction, SolanaInstruction,
 		SolanaMatchArguments, SolanaMonitorMatch, SolanaTransaction, SolanaTransactionInfo,
 		SolanaTransactionMessage, SolanaTransactionMeta, TransactionCondition, TransactionStatus,
 	},
@@ -34,7 +34,7 @@ fn create_test_network() -> Network {
 		block_time_ms: 400,
 		confirmation_blocks: 1,
 		cron_schedule: "*/10 * * * * *".to_string(),
-		max_past_blocks: Some(50),
+		max_past_blocks: Some(MaxPastBlocks::Limited(50)),
 		store_blocks: Some(true),
 		recovery_config: None,
 	}

--- a/tests/properties/strategies.rs
+++ b/tests/properties/strategies.rs
@@ -200,9 +200,9 @@ pub fn network_strategy() -> impl Strategy<Value = Network> {
 		1000..60000u64,                                               // block_time_ms
 		1..=20u64,                                                    // confirmation_blocks
 		"0 \\*/5 \\* \\* \\* \\*".prop_map(|s| s.to_string()),        // cron_schedule
-		Just(Some(1u64)),                                             /* max_past_blocks -
+		Just(1u64),                                                   /* max_past_blocks -
 		                                                               * ensure it's always
-		                                                               * Some(1) or greater */
+		                                                               * 1 or greater */
 		option::of(prop::bool::ANY), // store_blocks
 	)
 		.prop_map(
@@ -229,7 +229,7 @@ pub fn network_strategy() -> impl Strategy<Value = Network> {
 					.block_time_ms(block_time_ms)
 					.confirmation_blocks(confirmation_blocks)
 					.cron_schedule(cron_schedule.as_str())
-					.max_past_blocks(max_past_blocks.unwrap_or(0))
+					.max_past_blocks(max_past_blocks)
 					.store_blocks(store_blocks.unwrap_or(false))
 					.build()
 			},

--- a/tests/properties/strategies.rs
+++ b/tests/properties/strategies.rs
@@ -2,9 +2,9 @@ use email_address::EmailAddress;
 use openzeppelin_monitor::{
 	models::{
 		AddressWithSpec, BlockChainType, EventCondition, FunctionCondition, MatchConditions,
-		Monitor, Network, NotificationMessage, RpcUrl, ScriptLanguage, SecretString, SecretValue,
-		TransactionCondition, TransactionStatus, Trigger, TriggerConditions, TriggerType,
-		TriggerTypeConfig, WebhookPayloadMode,
+		MaxPastBlocks, Monitor, Network, NotificationMessage, RpcUrl, ScriptLanguage, SecretString,
+		SecretValue, TransactionCondition, TransactionStatus, Trigger, TriggerConditions,
+		TriggerType, TriggerTypeConfig, WebhookPayloadMode,
 	},
 	utils::{
 		tests::{evm::monitor::MonitorBuilder, network::NetworkBuilder, trigger::TriggerBuilder},
@@ -200,10 +200,11 @@ pub fn network_strategy() -> impl Strategy<Value = Network> {
 		1000..60000u64,                                               // block_time_ms
 		1..=20u64,                                                    // confirmation_blocks
 		"0 \\*/5 \\* \\* \\* \\*".prop_map(|s| s.to_string()),        // cron_schedule
-		Just(1u64),                                                   /* max_past_blocks -
-		                                                               * ensure it's always
-		                                                               * 1 or greater */
-		option::of(prop::bool::ANY), // store_blocks
+		prop_oneof![
+			(1..=1000u64).prop_map(MaxPastBlocks::Limited),
+			Just(MaxPastBlocks::Unlimited),
+		], // max_past_blocks
+		option::of(prop::bool::ANY),                                  // store_blocks
 	)
 		.prop_map(
 			|(
@@ -219,7 +220,7 @@ pub fn network_strategy() -> impl Strategy<Value = Network> {
 				max_past_blocks,
 				store_blocks,
 			)| {
-				NetworkBuilder::new()
+				let builder = NetworkBuilder::new()
 					.network_type(network_type)
 					.slug(&slug)
 					.name(&name)
@@ -228,10 +229,12 @@ pub fn network_strategy() -> impl Strategy<Value = Network> {
 					.network_passphrase(network_passphrase.unwrap_or("".to_string()).as_str())
 					.block_time_ms(block_time_ms)
 					.confirmation_blocks(confirmation_blocks)
-					.cron_schedule(cron_schedule.as_str())
-					.max_past_blocks(max_past_blocks)
-					.store_blocks(store_blocks.unwrap_or(false))
-					.build()
+					.cron_schedule(cron_schedule.as_str());
+				let builder = match max_past_blocks {
+					MaxPastBlocks::Limited(blocks) => builder.max_past_blocks(blocks),
+					MaxPastBlocks::Unlimited => builder.unlimited_past_blocks(),
+				};
+				builder.store_blocks(store_blocks.unwrap_or(false)).build()
 			},
 		)
 }


### PR DESCRIPTION
# Summary

After downtime longer than `max_past_blocks`, the blockwatcher clamps the start block forward and saves the latest confirmed block as the checkpoint, so the skipped range is silently never scanned; the recovery job only covers holes inside a fetched window, not clamp-skipped ranges. Raising the cap was not a safe workaround because the EVM client fetched the whole window as one unbounded `join_all`, where a single failed block retried the entire window every tick.

This PR lets `max_past_blocks` be set to the string `"unlimited"`, meaning catch-up always resumes from the last processed block and no gap is ever clamped away. Catch-up now runs in 30-block batches with the checkpoint saved after each batch, so a mid-catch-up failure retries one batch on the next tick instead of the whole backlog. Checkpoint lag is logged per tick and exposed as a `block_checkpoint_lag` prometheus gauge labeled by network, and the EVM block fetch is bounded to 32 concurrent requests (ordered, fail-fast). Numeric mode keeps its existing clamp semantics but benefits from the same batching. Numeric and absent `max_past_blocks` configs keep identical semantics, so existing configurations are unaffected.

No existing issue found to reference.

## Testing Process

- `cargo fmt --all -- --check`, `cargo clippy --all-targets`, and the full `cargo test` suite are green (2,819 tests, 0 failures).
- New unit tests cover config serde (number, `"unlimited"`, absent, invalid values), validation (`0` rejected, `"unlimited"` accepted), the unlimited catch-up path (a 978-block gap fully processed with per-batch checkpoints), and a mid-catch-up batch failure leaving the checkpoint at the end of the last successful batch.
- Integration test mocks updated to expect batched fetch ranges and per-batch checkpoint saves.

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [x] Add unit tests if applicable.
- [x] Add integration tests if applicable.
- [ ] Add property-based tests if applicable.
- [x] Update documentation if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `max_past_blocks` now supports an `"unlimited"` option, allowing block processing to resume from the last processed block without clamping.
  * Catch-up processing now runs in smaller batches, improving recovery behavior after downtime.
  * Added monitoring for checkpoint lag so progress gaps are easier to spot.

* **Bug Fixes**
  * Low numeric `max_past_blocks` values now have clearer, safer behavior guidance to reduce skipped older blocks after downtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->