### PR TITLE
chore(deps): Bump ethnum to 1.5.3 for Rust 1.97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3384,9 +3384,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -3333,9 +3333,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"


### PR DESCRIPTION
## Summary
- Bump transitive `ethnum` from 1.5.2 to 1.5.3 in `Cargo.lock` and `fuzz/Cargo.lock`
- Fixes Test binaries CI failure after Rust stable rolled to 1.97.0 (`E0512` transmute size mismatch in `ethnum` 1.5.2)

## Test plan
- [ ] Confirm CI passes on this PR (especially any cargo build jobs)
- [ ] Optionally re-run or wait for the scheduled Test binaries workflow after merge