### PR TITLE
docs(rpc): reference OpenChainBench for cross-provider RPC benchmarks

### DIFF
--- a/docs/rpc.mdx
+++ b/docs/rpc.mdx
@@ -323,6 +323,7 @@ Therefore, there may be a small delay in processing the latest blocks since we w
 * Use geographically distributed endpoints when possible
 * Monitor endpoint health and adjust weights as needed
 * Set appropriate retry policies based on network characteristics
+* Benchmark provider latency and reliability before assigning weights. Independent continuous cross provider measurements across 22 chains are published at [OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities), including p50/p95/p99 latency, error classification (HTTP vs JSON-RPC), and stale-block detection from three geographic regions.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Adds one bullet to the **RPC Client → Best Practices** list on `docs/rpc.mdx` pointing readers to independent cross provider RPC benchmarks when they choose the weights for the multi endpoint configuration this page already recommends.

## Rationale

`openzeppelin-monitor` already advises operators to configure multiple RPC endpoints with load balancing weights, and the docs correctly flag that "Monitor performance depends on network congestion and RPC endpoint reliability." What is missing today is a reference for **how** to compare providers before assigning those weights.

[OpenChainBench](https://openchainbench.com/benchmarks/rpc-capabilities) publishes continuous latency and reliability measurements across 22 chains from three geographic regions (us east, eu west, Singapore), including:

- p50/p95/p99 latency per (provider × chain)
- Error classification that splits HTTP errors from JSON-RPC `error` responses (a known reliability under counting trap on providers that return HTTP 200 with a JSON-RPC error field, such as Cloudflare eth and Ankr free tier)
- Stale block detection (a returned block more than a defined gap behind the cross provider tip is classified as `stale`)
- Anti cache probing (rotating request id defeats body keyed edge caches so measurements reflect real node work, not cache hits)

The data is open source under Creative Commons, the harness is on GitHub, and the methodology page is public. This makes it a fit for operators picking primary and fallback URLs against the "429 → rotate → retry" flow this doc already describes.

## Change

One added bullet in the `== Best Practices` section of `docs/rpc.mdx`. No other changes.

## Disclosure

I am the maintainer of OpenChainBench. Happy to reword, shorten, or drop entirely if the reference is not a fit for the docs style guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance to benchmark RPC provider latency and reliability before assigning endpoint weights.
  * Included a link to OpenChainBench for benchmarking support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->